### PR TITLE
Add TO-92 package family

### DIFF
--- a/diode.lbr
+++ b/diode.lbr
@@ -756,44 +756,6 @@ diameter 2 mm, horizontal, grid 7.62 mm</description>
 <rectangle x1="2.286" y1="-0.254" x2="2.921" y2="0.254" layer="51"/>
 <rectangle x1="-2.921" y1="-0.254" x2="-2.286" y2="0.254" layer="51"/>
 </package>
-<package name="TO220ACK">
-<description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
-2-lead molded, horizontal</description>
-<wire x1="-5.207" y1="-1.27" x2="5.207" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="14.605" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="-1.27" x2="5.207" y2="11.176" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="11.176" x2="4.318" y2="11.176" width="0.2032" layer="21"/>
-<wire x1="4.318" y1="11.176" x2="4.318" y2="12.7" width="0.2032" layer="21"/>
-<wire x1="4.318" y1="12.7" x2="5.207" y2="12.7" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="12.7" x2="5.207" y2="14.605" width="0.2032" layer="21"/>
-<wire x1="-5.207" y1="-1.27" x2="-5.207" y2="11.176" width="0.2032" layer="21"/>
-<wire x1="-5.207" y1="11.176" x2="-4.318" y2="11.176" width="0.2032" layer="21"/>
-<wire x1="-4.318" y1="11.176" x2="-4.318" y2="12.7" width="0.2032" layer="21"/>
-<wire x1="-4.318" y1="12.7" x2="-5.207" y2="12.7" width="0.2032" layer="21"/>
-<wire x1="-5.207" y1="12.7" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
-<wire x1="-4.572" y1="-0.635" x2="4.572" y2="-0.635" width="0.0508" layer="21"/>
-<wire x1="4.572" y1="7.62" x2="4.572" y2="-0.635" width="0.0508" layer="21"/>
-<wire x1="4.572" y1="7.62" x2="-4.572" y2="7.62" width="0.0508" layer="21"/>
-<wire x1="-4.572" y1="-0.635" x2="-4.572" y2="7.62" width="0.0508" layer="21"/>
-<wire x1="0.508" y1="1.27" x2="0.508" y2="0" width="0.2032" layer="21"/>
-<wire x1="0.508" y1="0" x2="-0.508" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="-0.508" y1="0.635" x2="0.508" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="-0.508" y1="1.27" x2="-0.508" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="-0.508" y1="0.635" x2="-0.508" y2="0" width="0.2032" layer="21"/>
-<circle x="0" y="11.176" radius="1.8034" width="0.2032" layer="21"/>
-<circle x="0" y="11.176" radius="2.921" width="0" layer="42"/>
-<circle x="0" y="11.176" radius="2.921" width="0" layer="43"/>
-<pad name="C" x="-2.54" y="-3.81" drill="1.1176" shape="long" rot="R90"/>
-<pad name="A" x="2.54" y="-3.81" drill="1.1176" shape="long" rot="R90"/>
-<text x="-6.0325" y="-1.27" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-4.1275" y="2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="-3.175" y1="-2.159" x2="-1.905" y2="-1.27" layer="51"/>
-<rectangle x1="1.905" y1="-2.159" x2="3.175" y2="-1.27" layer="51"/>
-<rectangle x1="-3.175" y1="-3.81" x2="-1.905" y2="-2.159" layer="51"/>
-<rectangle x1="1.905" y1="-3.81" x2="3.175" y2="-2.159" layer="51"/>
-<rectangle x1="-0.635" y1="-2.159" x2="0.635" y2="-1.27" layer="51"/>
-<hole x="0" y="11.176" drill="3.302"/>
-</package>
 <package name="DO218L">
 <description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
 2-lead molded, horizontal</description>
@@ -835,46 +797,6 @@ diameter 2 mm, horizontal, grid 7.62 mm</description>
 <rectangle x1="-6.096" y1="-10.16" x2="-4.826" y2="-8.128" layer="51"/>
 <rectangle x1="4.826" y1="-10.16" x2="6.096" y2="-8.128" layer="51"/>
 <hole x="0" y="10.16" drill="4.1148"/>
-</package>
-<package name="DO220L">
-<description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
-2-lead molded, horizontal</description>
-<wire x1="-5.207" y1="-1.27" x2="5.207" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="14.605" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="-1.27" x2="5.207" y2="11.176" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="11.176" x2="4.318" y2="11.176" width="0.2032" layer="21"/>
-<wire x1="4.318" y1="11.176" x2="4.318" y2="12.7" width="0.2032" layer="21"/>
-<wire x1="4.318" y1="12.7" x2="5.207" y2="12.7" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="12.7" x2="5.207" y2="14.605" width="0.2032" layer="21"/>
-<wire x1="-5.207" y1="-1.27" x2="-5.207" y2="11.176" width="0.2032" layer="21"/>
-<wire x1="-5.207" y1="11.176" x2="-4.318" y2="11.176" width="0.2032" layer="21"/>
-<wire x1="-4.318" y1="11.176" x2="-4.318" y2="12.7" width="0.2032" layer="21"/>
-<wire x1="-4.318" y1="12.7" x2="-5.207" y2="12.7" width="0.2032" layer="21"/>
-<wire x1="-5.207" y1="12.7" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
-<wire x1="-4.572" y1="-0.635" x2="4.572" y2="-0.635" width="0.0508" layer="21"/>
-<wire x1="4.572" y1="7.62" x2="4.572" y2="-0.635" width="0.0508" layer="21"/>
-<wire x1="4.572" y1="7.62" x2="-4.572" y2="7.62" width="0.0508" layer="21"/>
-<wire x1="-4.572" y1="-0.635" x2="-4.572" y2="7.62" width="0.0508" layer="21"/>
-<wire x1="0.508" y1="1.27" x2="0.508" y2="0" width="0.2032" layer="21"/>
-<wire x1="0.508" y1="0" x2="-0.508" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="-0.508" y1="0.635" x2="0.508" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="-0.508" y1="1.27" x2="-0.508" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="-0.508" y1="0.635" x2="-0.508" y2="0" width="0.2032" layer="21"/>
-<circle x="0" y="11.176" radius="1.8034" width="0.2032" layer="21"/>
-<circle x="0" y="11.176" radius="2.921" width="0" layer="42"/>
-<circle x="0" y="11.176" radius="2.921" width="0" layer="43"/>
-<pad name="C" x="-2.54" y="-6.35" drill="1.1176" shape="long" rot="R90"/>
-<pad name="A" x="2.54" y="-6.35" drill="1.1176" shape="long" rot="R90"/>
-<text x="-5.715" y="-1.5875" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-3.81" y="2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-4.445" y="7.874" size="1.016" layer="21" ratio="18">A17,5mm</text>
-<rectangle x1="-3.175" y1="-4.572" x2="-1.905" y2="-1.27" layer="51"/>
-<rectangle x1="1.905" y1="-4.572" x2="3.175" y2="-1.27" layer="51"/>
-<rectangle x1="2.159" y1="-6.35" x2="2.921" y2="-4.699" layer="51"/>
-<rectangle x1="2.159" y1="-4.699" x2="2.921" y2="-4.572" layer="51"/>
-<rectangle x1="-2.921" y1="-6.35" x2="-2.159" y2="-4.699" layer="51"/>
-<rectangle x1="-2.921" y1="-4.699" x2="-2.159" y2="-4.572" layer="51"/>
-<hole x="0" y="11.176" drill="3.302"/>
 </package>
 <package name="TO92H">
 <description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
@@ -1092,21 +1014,21 @@ diameter 5 mm, horizontal, grid 12.7 mm</description>
 <vertex x="0.4" y="-1.7"/>
 </polygon>
 </package>
-<package name="SOT54E">
-<description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
-3-lead plastic, vertical</description>
-<wire x1="-1.778" y1="-1.778" x2="1.778" y2="-1.778" width="0.2032" layer="21"/>
-<wire x1="1.7961" y1="-1.7961" x2="2.54" y2="0" width="0.2032" layer="21" curve="45.000645" cap="flat"/>
-<wire x1="0.9" y1="2.4" x2="2.54" y2="0" width="0.2032" layer="21" curve="-72.476417" cap="flat"/>
-<wire x1="-2.54" y1="0" x2="-1.7961" y2="-1.7961" width="0.2032" layer="21" curve="45.000645" cap="flat"/>
-<wire x1="-2.54" y1="0" x2="-0.9" y2="2.4" width="0.2032" layer="21" curve="-72.476417" cap="flat"/>
-<wire x1="0" y1="2.54" x2="0.9" y2="2.4" width="0.2032" layer="51" curve="-21.252291" cap="flat"/>
-<wire x1="-0.9" y1="2.4" x2="0" y2="2.54" width="0.2032" layer="51" curve="-20.224193" cap="flat"/>
-<pad name="A1" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="C" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="A2" x="1.27" y="0" drill="0.8128" shape="octagon"/>
+<package name="TO92-AB">
+<description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement. JEDEC TO-226G, variation AB.
+&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
+<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
+<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 </package>
 <package name="DO201T15">
 <description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
@@ -1534,39 +1456,39 @@ diameter 3 mm, horizontal, grid 10.16 mm</description>
 <rectangle x1="3.175" y1="-0.4064" x2="3.7338" y2="0.4064" layer="51"/>
 <rectangle x1="-3.7338" y1="-0.4064" x2="-3.175" y2="0.4064" layer="51"/>
 </package>
-<package name="TO220AC">
-<description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
-2-lead molded, horizontal</description>
-<wire x1="-5.207" y1="-1.27" x2="5.207" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="14.605" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="-1.27" x2="5.207" y2="11.176" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="11.176" x2="4.318" y2="11.176" width="0.2032" layer="21"/>
-<wire x1="4.318" y1="11.176" x2="4.318" y2="12.7" width="0.2032" layer="21"/>
-<wire x1="4.318" y1="12.7" x2="5.207" y2="12.7" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="12.7" x2="5.207" y2="14.605" width="0.2032" layer="21"/>
-<wire x1="-5.207" y1="-1.27" x2="-5.207" y2="11.176" width="0.2032" layer="21"/>
-<wire x1="-5.207" y1="11.176" x2="-4.318" y2="11.176" width="0.2032" layer="21"/>
-<wire x1="-4.318" y1="11.176" x2="-4.318" y2="12.7" width="0.2032" layer="21"/>
-<wire x1="-4.318" y1="12.7" x2="-5.207" y2="12.7" width="0.2032" layer="21"/>
-<wire x1="-5.207" y1="12.7" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
-<wire x1="-4.572" y1="-0.635" x2="4.572" y2="-0.635" width="0.0508" layer="21"/>
-<wire x1="4.572" y1="7.62" x2="4.572" y2="-0.635" width="0.0508" layer="21"/>
-<wire x1="4.572" y1="7.62" x2="-4.572" y2="7.62" width="0.0508" layer="21"/>
-<wire x1="-4.572" y1="-0.635" x2="-4.572" y2="7.62" width="0.0508" layer="21"/>
+<package name="TO220-AC-H">
+<description>&lt;b&gt;TO-220 AC (2.54mm lead pitch, 2 leads, exposed pad, horizontal, 17.5mm lead-to-hole)&lt;/b&gt;&lt;p&gt;
+Flange mounted header. 2.54mm lead pitch, 2 leads, exposed pad, horizontal, 17.5mm lead-to-hole. JEDEC TO-220K, variation AC.</description>
 <circle x="0" y="11.176" radius="1.8034" width="0.2032" layer="21"/>
 <circle x="0" y="11.176" radius="2.921" width="0" layer="42"/>
 <circle x="0" y="11.176" radius="2.921" width="0" layer="43"/>
-<pad name="C" x="-2.54" y="-6.35" drill="1.1176" shape="long" rot="R90"/>
-<pad name="A" x="2.54" y="-6.35" drill="1.1176" shape="long" rot="R90"/>
-<text x="-5.715" y="-1.27" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-4.1275" y="2.8575" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="2.159" y1="-4.445" x2="2.921" y2="-3.81" layer="21"/>
-<rectangle x1="-2.921" y1="-4.445" x2="-2.159" y2="-3.81" layer="21"/>
+<hole x="0" y="11.176" drill="3.302"/>
+<pad name="1" x="-2.54" y="-6.35" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="2.54" y="-6.35" drill="1.016" shape="long" rot="R90"/>
 <rectangle x1="-3.175" y1="-3.81" x2="-1.905" y2="-1.27" layer="21"/>
+<rectangle x1="-2.921" y1="-6.35" x2="-2.159" y2="-4.445" layer="51"/>
+<rectangle x1="-2.921" y1="-4.445" x2="-2.159" y2="-3.81" layer="21"/>
 <rectangle x1="1.905" y1="-3.81" x2="3.175" y2="-1.27" layer="21"/>
 <rectangle x1="2.159" y1="-6.35" x2="2.921" y2="-4.445" layer="51"/>
-<rectangle x1="-2.921" y1="-6.35" x2="-2.159" y2="-4.445" layer="51"/>
-<hole x="0" y="11.176" drill="3.302"/>
+<rectangle x1="2.159" y1="-4.445" x2="2.921" y2="-3.81" layer="21"/>
+<text x="-5.461" y="-1.27" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-3.937" y="2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.207" y1="-1.27" x2="5.207" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="-5.207" y1="-1.27" x2="-5.207" y2="11.176" width="0.2032" layer="21"/>
+<wire x1="-5.207" y1="11.176" x2="-4.318" y2="11.176" width="0.2032" layer="21"/>
+<wire x1="-5.207" y1="12.7" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
+<wire x1="-4.572" y1="-0.635" x2="4.572" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-4.572" y1="-0.635" x2="-4.572" y2="7.62" width="0.2032" layer="21"/>
+<wire x1="-4.318" y1="11.176" x2="-4.318" y2="12.7" width="0.2032" layer="21"/>
+<wire x1="-4.318" y1="12.7" x2="-5.207" y2="12.7" width="0.2032" layer="21"/>
+<wire x1="4.318" y1="11.176" x2="4.318" y2="12.7" width="0.2032" layer="21"/>
+<wire x1="4.318" y1="12.7" x2="5.207" y2="12.7" width="0.2032" layer="21"/>
+<wire x1="4.572" y1="7.62" x2="4.572" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="4.572" y1="7.62" x2="-4.572" y2="7.62" width="0.2032" layer="21"/>
+<wire x1="5.207" y1="-1.27" x2="5.207" y2="11.176" width="0.2032" layer="21"/>
+<wire x1="5.207" y1="11.176" x2="4.318" y2="11.176" width="0.2032" layer="21"/>
+<wire x1="5.207" y1="12.7" x2="5.207" y2="14.605" width="0.2032" layer="21"/>
+<wire x1="5.207" y1="14.605" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
 </package>
 <package name="TO3P">
 <description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
@@ -1704,46 +1626,6 @@ Also known as SOT78.</description>
 <wire x1="4.699" y1="-4.318" x2="4.953" y2="-4.064" width="0.2032" layer="21"/>
 <wire x1="4.699" y1="-4.318" x2="-4.699" y2="-4.318" width="0.2032" layer="21"/>
 <wire x1="5.08" y1="-1.143" x2="4.953" y2="-4.064" width="0.2032" layer="21"/>
-</package>
-<package name="DO220S">
-<description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
-2-lead molded, vertical</description>
-<wire x1="5.08" y1="-1.143" x2="4.953" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="4.699" y1="-4.318" x2="4.953" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="4.699" y1="-4.318" x2="-4.699" y2="-4.318" width="0.2032" layer="21"/>
-<wire x1="-4.953" y1="-4.064" x2="-4.699" y2="-4.318" width="0.2032" layer="21"/>
-<wire x1="-4.953" y1="-4.064" x2="-5.08" y2="-1.143" width="0.2032" layer="21"/>
-<circle x="-4.4958" y="-3.7084" radius="0.254" width="0" layer="21"/>
-<pad name="C" x="-2.54" y="-2.54" drill="1.016" shape="long" rot="R90"/>
-<pad name="A" x="2.54" y="-2.54" drill="1.016" shape="long" rot="R90"/>
-<text x="-4.7625" y="-6.0325" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-4.7625" y="-7.62" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="-5.334" y1="-0.762" x2="5.334" y2="0" layer="21"/>
-<rectangle x1="-5.334" y1="-1.27" x2="-3.429" y2="-0.762" layer="21"/>
-<rectangle x1="-3.429" y1="-1.27" x2="-1.651" y2="-0.762" layer="51"/>
-<rectangle x1="3.429" y1="-1.27" x2="5.334" y2="-0.762" layer="21"/>
-<rectangle x1="1.651" y1="-1.27" x2="3.429" y2="-0.762" layer="51"/>
-<rectangle x1="-1.651" y1="-1.27" x2="1.651" y2="-0.762" layer="21"/>
-</package>
-<package name="TO220ACS">
-<description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
-2-lead molded, vertical</description>
-<wire x1="5.08" y1="-1.143" x2="4.953" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="4.699" y1="-4.318" x2="4.953" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="4.699" y1="-4.318" x2="-4.699" y2="-4.318" width="0.2032" layer="21"/>
-<wire x1="-4.953" y1="-4.064" x2="-4.699" y2="-4.318" width="0.2032" layer="21"/>
-<wire x1="-4.953" y1="-4.064" x2="-5.08" y2="-1.143" width="0.2032" layer="21"/>
-<circle x="-4.4958" y="-3.7084" radius="0.254" width="0" layer="21"/>
-<pad name="C" x="-2.54" y="-2.54" drill="1.016" shape="long" rot="R90"/>
-<pad name="A" x="2.54" y="-2.54" drill="1.016" shape="long" rot="R90"/>
-<text x="-5.08" y="-6.0452" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-5.08" y="-7.62" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="-5.334" y1="-0.762" x2="5.334" y2="0" layer="21"/>
-<rectangle x1="-5.334" y1="-1.27" x2="-3.429" y2="-0.762" layer="21"/>
-<rectangle x1="-3.429" y1="-1.27" x2="-1.651" y2="-0.762" layer="51"/>
-<rectangle x1="3.429" y1="-1.27" x2="5.334" y2="-0.762" layer="21"/>
-<rectangle x1="1.651" y1="-1.27" x2="3.429" y2="-0.762" layer="51"/>
-<rectangle x1="-1.651" y1="-1.27" x2="1.651" y2="-0.762" layer="21"/>
 </package>
 <package name="DO218S">
 <description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
@@ -2766,22 +2648,6 @@ diameter 2.8 mm, horizontal, grid 10.10 mm</description>
 <text x="3.4925" y="0.9525" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.4925" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOT54A">
-<description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
-3-lead plastic, vertical</description>
-<wire x1="-1.778" y1="-1.778" x2="1.778" y2="-1.778" width="0.2032" layer="21"/>
-<wire x1="1.7961" y1="-1.7961" x2="2.54" y2="0" width="0.2032" layer="21" curve="45.000645" cap="flat"/>
-<wire x1="0.7649" y1="2.4221" x2="2.54" y2="0" width="0.2032" layer="21" curve="-72.473997" cap="flat"/>
-<wire x1="-2.54" y1="0" x2="-1.7961" y2="-1.7961" width="0.2032" layer="21" curve="45.000645" cap="flat"/>
-<wire x1="-2.54" y1="0" x2="-0.7649" y2="2.4221" width="0.2032" layer="21" curve="-72.473997" cap="flat"/>
-<wire x1="0" y1="2.54" x2="0.9206" y2="2.3673" width="0.2032" layer="51" curve="-21.250166" cap="flat"/>
-<wire x1="-0.8781" y1="2.3834" x2="0" y2="2.54" width="0.2032" layer="51" curve="-20.225015" cap="flat"/>
-<pad name="A1" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="C" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="A2" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="2.8575" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.8575" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-</package>
 <package name="SOT54B">
 <description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
 2-lead plastic, vertical</description>
@@ -3004,25 +2870,6 @@ diameter 2.3 mm, horizontal, grid 10.16 mm</description>
 <rectangle x1="-2.921" y1="-6.35" x2="-2.159" y2="-4.445" layer="51"/>
 <hole x="0" y="11.176" drill="3.302"/>
 </package>
-<package name="C221B1AS">
-<description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
-2-lead molded, vertical</description>
-<wire x1="5.207" y1="-1.143" x2="5.08" y2="-4.572" width="0.2032" layer="21"/>
-<wire x1="4.826" y1="-4.826" x2="5.08" y2="-4.572" width="0.2032" layer="21"/>
-<wire x1="4.826" y1="-4.826" x2="-4.826" y2="-4.826" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="-4.572" x2="-4.826" y2="-4.826" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="-4.572" x2="-5.207" y2="-1.143" width="0.2032" layer="21"/>
-<pad name="C" x="-2.54" y="-2.54" drill="1.016" shape="long" rot="R90"/>
-<pad name="A" x="2.54" y="-2.54" drill="1.016" shape="long" rot="R90"/>
-<text x="-5.08" y="-6.4262" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-5.08" y="-8.001" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="-5.334" y1="-1.397" x2="-3.429" y2="-0.889" layer="21"/>
-<rectangle x1="-3.429" y1="-1.397" x2="-1.651" y2="-0.889" layer="51"/>
-<rectangle x1="3.429" y1="-1.397" x2="5.334" y2="-0.889" layer="21"/>
-<rectangle x1="1.651" y1="-1.397" x2="3.429" y2="-0.889" layer="51"/>
-<rectangle x1="-1.651" y1="-1.397" x2="1.651" y2="-0.889" layer="21"/>
-<rectangle x1="-5.334" y1="-0.889" x2="5.334" y2="0" layer="21"/>
-</package>
 <package name="TO220CH">
 <description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
 3-lead molded, horizontal</description>
@@ -3237,33 +3084,6 @@ diameter 3 mm, horizontal, grid 12.7 mm</description>
 <rectangle x1="-2.54" y1="-1.524" x2="-1.778" y2="1.524" layer="21"/>
 <rectangle x1="-4.5" y1="-0.4064" x2="-3.175" y2="0.4064" layer="21"/>
 <rectangle x1="3.175" y1="-0.4064" x2="4.5" y2="0.4064" layer="21"/>
-</package>
-<package name="IW220ACS">
-<description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
-2-lead molded, vertical</description>
-<wire x1="4.699" y1="-4.318" x2="4.953" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="4.699" y1="-4.318" x2="-4.699" y2="-4.318" width="0.2032" layer="21"/>
-<wire x1="-4.953" y1="-4.064" x2="-4.699" y2="-4.318" width="0.2032" layer="21"/>
-<wire x1="5.334" y1="-0.127" x2="4.953" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-4.953" y1="-4.064" x2="-5.334" y2="-0.127" width="0.2032" layer="21"/>
-<circle x="-4.4958" y="-3.7084" radius="0.254" width="0" layer="21"/>
-<pad name="C" x="-2.54" y="-2.54" drill="1.1176" shape="long" rot="R90"/>
-<pad name="A" x="2.54" y="-2.54" drill="1.1176" shape="long" rot="R90"/>
-<text x="-4.7625" y="-6.0325" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-4.7625" y="-7.62" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="-5.334" y1="-0.762" x2="5.334" y2="0" layer="21"/>
-<rectangle x1="-5.334" y1="-1.27" x2="-3.429" y2="-0.762" layer="21"/>
-<rectangle x1="-3.429" y1="-1.27" x2="-1.651" y2="-0.762" layer="51"/>
-<rectangle x1="1.651" y1="-1.27" x2="3.429" y2="-0.762" layer="51"/>
-<rectangle x1="-1.651" y1="-1.27" x2="1.651" y2="-0.762" layer="21"/>
-<rectangle x1="3.937" y1="-2.794" x2="5.08" y2="-1.27" layer="21"/>
-<rectangle x1="3.429" y1="-1.27" x2="5.207" y2="-0.762" layer="21"/>
-<rectangle x1="5.08" y1="-1.905" x2="5.207" y2="-1.27" layer="21"/>
-<rectangle x1="1.143" y1="-2.794" x2="3.937" y2="-1.27" layer="51"/>
-<rectangle x1="-1.143" y1="-2.794" x2="1.143" y2="-1.27" layer="21"/>
-<rectangle x1="-3.937" y1="-2.794" x2="-1.143" y2="-1.27" layer="51"/>
-<rectangle x1="-5.08" y1="-2.794" x2="-3.937" y2="-1.27" layer="21"/>
-<rectangle x1="-5.207" y1="-1.905" x2="-5.08" y2="-1.27" layer="21"/>
 </package>
 <package name="F126-10A">
 <description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
@@ -11064,11 +10884,11 @@ variable-capacitance double diode, 9 V</description>
 <gate name="1" symbol="KDD" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOT54E">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="A1" pad="A1"/>
-<connect gate="1" pin="A2" pad="A2"/>
-<connect gate="1" pin="C" pad="C"/>
+<connect gate="1" pin="A1" pad="1"/>
+<connect gate="1" pin="A2" pad="3"/>
+<connect gate="1" pin="C" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -11672,10 +11492,10 @@ barrier rectifier, 7.5 A, 50 V</description>
 <gate name="1" symbol="D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO220AC">
+<device name="" package="TO220-AC-H">
 <connects>
-<connect gate="1" pin="A" pad="A"/>
-<connect gate="1" pin="C" pad="C"/>
+<connect gate="1" pin="A" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -11814,10 +11634,10 @@ ultra-fast recovery rectifier</description>
 <gate name="1" symbol="D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DO220S">
+<device name="" package="TO220-AC">
 <connects>
-<connect gate="1" pin="A" pad="A"/>
-<connect gate="1" pin="C" pad="C"/>
+<connect gate="1" pin="A" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -11832,10 +11652,10 @@ ultra fast rectifier, 200 V, 8 A</description>
 <gate name="1" symbol="D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DO220S">
+<device name="" package="TO220-AC">
 <connects>
-<connect gate="1" pin="A" pad="A"/>
-<connect gate="1" pin="C" pad="C"/>
+<connect gate="1" pin="A" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -12283,10 +12103,10 @@ hyperfast dual diode</description>
 <gate name="1" symbol="D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO220ACS">
+<device name="" package="TO220-AC">
 <connects>
-<connect gate="1" pin="A" pad="A"/>
-<connect gate="1" pin="C" pad="C"/>
+<connect gate="1" pin="A" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -12746,10 +12566,10 @@ silicon-mesa rectifier (Vishay Telefunken)</description>
 <gate name="1" symbol="D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DO220S">
+<device name="" package="TO220-AC">
 <connects>
-<connect gate="1" pin="A" pad="A"/>
-<connect gate="1" pin="C" pad="C"/>
+<connect gate="1" pin="A" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -13160,10 +12980,10 @@ high-efficiency fast recovery rectifier (ST)</description>
 <gate name="1" symbol="D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO220ACS">
+<device name="" package="TO220-AC">
 <connects>
-<connect gate="1" pin="A" pad="A"/>
-<connect gate="1" pin="C" pad="C"/>
+<connect gate="1" pin="A" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -13215,10 +13035,10 @@ ultra fast</description>
 <gate name="1" symbol="D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO220ACS">
+<device name="" package="TO220-AC">
 <connects>
-<connect gate="1" pin="A" pad="A"/>
-<connect gate="1" pin="C" pad="C"/>
+<connect gate="1" pin="A" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -14257,28 +14077,28 @@ super fast rectifier, 2 A</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DO220S" package="DO220S">
+<device name="DO220S" package="TO220-AC">
 <connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
+<connect gate="G$1" pin="A" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TO220H" package="TO220AC">
+<device name="TO220H" package="TO220-AC-H">
 <connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
+<connect gate="G$1" pin="A" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TO220V" package="TO220ACS">
+<device name="TO220V" package="TO220-AC">
 <connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
+<connect gate="G$1" pin="A" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -15254,11 +15074,11 @@ variable-capacitance diode (Infineon)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SOT54E" package="SOT54E">
+<device name="SOT54E" package="TO92-AB">
 <connects>
-<connect gate="-B1" pin="A1" pad="A1"/>
-<connect gate="-B1" pin="A2" pad="A2"/>
-<connect gate="-B1" pin="C" pad="C"/>
+<connect gate="-B1" pin="A1" pad="1"/>
+<connect gate="-B1" pin="A2" pad="3"/>
+<connect gate="-B1" pin="C" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -15722,19 +15542,19 @@ Small Signal Diode SOT-23</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-V" package="TO220ACS">
+<device name="-V" package="TO220-AC">
 <connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
+<connect gate="G$1" pin="A" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-H" package="TO220ACK">
+<device name="-H" package="TO220-AC">
 <connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
+<connect gate="G$1" pin="A" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -17619,19 +17439,19 @@ Semtech</description>
 <gate name="G$1" symbol="D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="ACS" package="TO220ACS">
+<device name="ACS" package="TO220-AC">
 <connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
+<connect gate="G$1" pin="A" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
 </technologies>
 </device>
-<device name="AC" package="TO220AC">
+<device name="AC" package="TO220-AC-H">
 <connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
+<connect gate="G$1" pin="A" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -17991,10 +17811,10 @@ SWITCHMODE Power Rectifier&lt;p&gt;
 <gate name="G$1" symbol="D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO220ACS">
+<device name="" package="TO220-AC">
 <connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
+<connect gate="G$1" pin="A" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/linear.lbr
+++ b/linear.lbr
@@ -76,17 +76,21 @@
 Operational amplifiers,  comparators, voltage regulators, ADCs, DACs, etc.&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="TO92">
-<description>&lt;b&gt;TO-92&lt;/b&gt;</description>
+<package name="TO92-AB">
+<description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement. JEDEC TO-226G, variation AB.
+&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
 <wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 <wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="1" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="3" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="2.413" y="1.651" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="2.921" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 </package>
 <package name="TO220-AB-H">
 <description>&lt;b&gt;TO-220 AB (2.54mm lead pitch, 3 leads, exposed pad, horizontal, 17.5mm lead-to-hole)&lt;/b&gt;&lt;p&gt;
@@ -9452,11 +9456,11 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <gate name="A1" symbol="78XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="Z" package="TO92">
+<device name="Z" package="TO92-AB">
 <connects>
 <connect gate="A1" pin="GND" pad="2"/>
-<connect gate="A1" pin="VI" pad="3"/>
-<connect gate="A1" pin="VO" pad="1"/>
+<connect gate="A1" pin="VI" pad="1"/>
+<connect gate="A1" pin="VO" pad="3"/>
 </connects>
 <technologies>
 <technology name="L05"/>
@@ -9499,11 +9503,11 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name="24"/>
 </technologies>
 </device>
-<device name="L" package="TO92">
+<device name="L" package="TO92-AB">
 <connects>
 <connect gate="A1" pin="GND" pad="2"/>
-<connect gate="A1" pin="VI" pad="3"/>
-<connect gate="A1" pin="VO" pad="1"/>
+<connect gate="A1" pin="VI" pad="1"/>
+<connect gate="A1" pin="VO" pad="3"/>
 </connects>
 <technologies>
 <technology name="05"/>
@@ -9539,11 +9543,11 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <gate name="A1" symbol="79XX" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="L" package="TO92">
+<device name="L" package="TO92-AB">
 <connects>
-<connect gate="A1" pin="GND" pad="1"/>
+<connect gate="A1" pin="GND" pad="3"/>
 <connect gate="A1" pin="VI" pad="2"/>
-<connect gate="A1" pin="VO" pad="3"/>
+<connect gate="A1" pin="VO" pad="1"/>
 </connects>
 <technologies>
 <technology name="05"/>
@@ -9587,11 +9591,11 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name="24"/>
 </technologies>
 </device>
-<device name="Z" package="TO92">
+<device name="Z" package="TO92-AB">
 <connects>
-<connect gate="A1" pin="GND" pad="1"/>
+<connect gate="A1" pin="GND" pad="3"/>
 <connect gate="A1" pin="VI" pad="2"/>
-<connect gate="A1" pin="VO" pad="3"/>
+<connect gate="A1" pin="VO" pad="1"/>
 </connects>
 <technologies>
 <technology name="L05"/>
@@ -9610,10 +9614,10 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <gate name="A1" symbol="317" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="LZ" package="TO92">
+<device name="LZ" package="TO92-AB">
 <connects>
-<connect gate="A1" pin="ADJ" pad="1"/>
-<connect gate="A1" pin="VI" pad="3"/>
+<connect gate="A1" pin="ADJ" pad="3"/>
+<connect gate="A1" pin="VI" pad="1"/>
 <connect gate="A1" pin="VO" pad="2"/>
 </connects>
 <technologies>
@@ -9638,10 +9642,10 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <gate name="A1" symbol="337" x="0" y="0"/>
 </gates>
 <devices>
-<device name="LZ" package="TO92">
+<device name="LZ" package="TO92-AB">
 <connects>
-<connect gate="A1" pin="ADJ" pad="1"/>
-<connect gate="A1" pin="VI" pad="3"/>
+<connect gate="A1" pin="ADJ" pad="3"/>
+<connect gate="A1" pin="VI" pad="1"/>
 <connect gate="A1" pin="VO" pad="2"/>
 </connects>
 <technologies>
@@ -9740,11 +9744,11 @@ current output</description>
 <gate name="A" symbol="AD590" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="A" pin="+" pad="1"/>
+<connect gate="A" pin="+" pad="3"/>
 <connect gate="A" pin="-" pad="2"/>
-<connect gate="A" pin="CAN" pad="3"/>
+<connect gate="A" pin="CAN" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -11341,11 +11345,11 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="78XX" x="22.86" y="0"/>
 </gates>
 <devices>
-<device name="LZ" package="TO92">
+<device name="LZ" package="TO92-AB">
 <connects>
 <connect gate="A" pin="GND" pad="2"/>
-<connect gate="A" pin="VI" pad="3"/>
-<connect gate="A" pin="VO" pad="1"/>
+<connect gate="A" pin="VI" pad="1"/>
+<connect gate="A" pin="VO" pad="3"/>
 </connects>
 <technologies>
 <technology name="05"/>
@@ -11379,11 +11383,11 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="79XX" x="22.86" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="A" pin="GND" pad="1"/>
+<connect gate="A" pin="GND" pad="3"/>
 <connect gate="A" pin="VI" pad="2"/>
-<connect gate="A" pin="VO" pad="3"/>
+<connect gate="A" pin="VO" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/maxim.lbr
+++ b/maxim.lbr
@@ -701,19 +701,23 @@ square</description>
 <rectangle x1="-1.3716" y1="1.0668" x2="-1.1684" y2="2.0828" layer="51"/>
 <rectangle x1="-2.2" y1="-1.9" x2="-1.7" y2="-1.4" layer="21"/>
 </package>
-<package name="TO92-">
-<description>&lt;b&gt;TO-92&lt;/b&gt;</description>
-<wire x1="-2.095" y1="-1.651" x2="2.095" y2="-1.651" width="0.2032" layer="21"/>
+<package name="TO92-AA">
+<description>&lt;b&gt;TO-92 (2.54mm lead pitch, 3 leads, vertical, linear pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 2.54mm lead pitch, 3 leads, vertical, linear pad arrangement. JEDEC TO-226G, variation AA.
+&lt;/p&gt;&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-2.54" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<pad name="2" x="0" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<pad name="3" x="2.54" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-2.4135" y1="-1.1159" x2="-2.095" y2="-1.631" width="0.2032" layer="21" curve="13.038528" cap="flat"/>
 <wire x1="-2.413" y1="1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="21" curve="-129.583345" cap="flat"/>
 <wire x1="-2.413" y1="1.1359" x2="-2.413" y2="-1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="-2.4135" y1="-1.1359" x2="-2.095" y2="-1.651" width="0.2032" layer="21" curve="13.038528" cap="flat"/>
+<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="2.095" y1="-1.631" x2="2.4247" y2="-1.0918" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
 <wire x1="2.413" y1="-1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="2.095" y1="-1.651" x2="2.4247" y2="-1.1118" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
-<pad name="3" x="2.54" y="0" drill="0.8128" shape="octagon"/>
-<pad name="1" x="-2.54" y="0" drill="0.8128" shape="octagon"/>
-<pad name="2" x="0" y="0" drill="0.8128" shape="octagon"/>
-<text x="-2.54" y="3.048" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-3.302" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="SSOP-065-530-20">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 20 leads)&lt;/b&gt;&lt;p&gt;
@@ -765,28 +769,6 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <wire x1="-3.75" y1="-2.6" x2="-3.75" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="-2.6" x2="3.8" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.6" x2="-3.75" y2="2.6" width="0.2032" layer="21"/>
-</package>
-<package name="SOT223-D">
-<description>&lt;b&gt;SMALL OUTLINE TRANSISTOR&lt;/b&gt;</description>
-<wire x1="3.277" y1="1.778" x2="3.277" y2="-1.778" width="0.2032" layer="21"/>
-<wire x1="3.277" y1="-1.778" x2="-3.277" y2="-1.778" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="-1.778" x2="-3.277" y2="1.778" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="1.778" x2="3.277" y2="1.778" width="0.2032" layer="21"/>
-<smd name="2" x="-2.311" y="-3.099" dx="1.219" dy="2.235" layer="1"/>
-<smd name="4" x="0" y="-3.099" dx="1.219" dy="2.235" layer="1"/>
-<smd name="3" x="2.311" y="-3.099" dx="1.219" dy="2.235" layer="1"/>
-<smd name="1" x="0" y="3.099" dx="3.6" dy="2.2" layer="1"/>
-<text x="-3.81" y="-1.5875" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="4.7625" y="-1.5875" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<rectangle x1="-1.6002" y1="1.8034" x2="1.6002" y2="3.6576" layer="51"/>
-<rectangle x1="-0.4318" y1="-3.6576" x2="0.4318" y2="-1.8034" layer="51"/>
-<rectangle x1="-2.7432" y1="-3.6576" x2="-1.8796" y2="-1.8034" layer="51"/>
-<rectangle x1="1.8796" y1="-3.6576" x2="2.7432" y2="-1.8034" layer="51"/>
-<rectangle x1="-1.6002" y1="1.8034" x2="1.6002" y2="3.6576" layer="51"/>
-<rectangle x1="-0.4318" y1="-3.6576" x2="0.4318" y2="-1.8034" layer="51"/>
-<rectangle x1="-2.7432" y1="-3.6576" x2="-1.8796" y2="-1.8034" layer="51"/>
-<rectangle x1="1.8796" y1="-3.6576" x2="2.7432" y2="-1.8034" layer="51"/>
-<rectangle x1="-1" y1="-1" x2="1" y2="1" layer="35"/>
 </package>
 <package name="SOT143">
 <description>&lt;b&gt;SMALL OUTLINE TRANSISTOR&lt;/b&gt;</description>
@@ -2941,6 +2923,73 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <wire x1="1.45" y1="-0.8" x2="-1.45" y2="-0.8" width="0.2032" layer="51"/>
 <wire x1="1.45" y1="-0.65" x2="1.45" y2="0.65" width="0.2032" layer="21"/>
 <wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
+</package>
+<package name="SSOP-065-530-28">
+<description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 28 leads)&lt;/b&gt;&lt;p&gt;
+Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JEDEC MO-150B. Variation AH.</description>
+<circle x="-4.185" y="-1.7988" radius="0.3175" width="0" layer="21"/>
+<rectangle x1="-4.4028" y1="-3.937" x2="-4.0472" y2="-2.6416" layer="51"/>
+<rectangle x1="-4.4027" y1="2.6416" x2="-4.0471" y2="3.937" layer="51"/>
+<rectangle x1="-3.7529" y1="-3.937" x2="-3.3973" y2="-2.6416" layer="51"/>
+<rectangle x1="-3.7528" y1="2.6416" x2="-3.3972" y2="3.937" layer="51"/>
+<rectangle x1="-3.1029" y1="-3.937" x2="-2.7473" y2="-2.6416" layer="51"/>
+<rectangle x1="-3.1028" y1="2.6416" x2="-2.7472" y2="3.937" layer="51"/>
+<rectangle x1="-2.4529" y1="-3.937" x2="-2.0973" y2="-2.6416" layer="51"/>
+<rectangle x1="-2.4529" y1="2.6416" x2="-2.0973" y2="3.937" layer="51"/>
+<rectangle x1="-1.8029" y1="-3.937" x2="-1.4473" y2="-2.6416" layer="51"/>
+<rectangle x1="-1.8029" y1="2.6416" x2="-1.4473" y2="3.937" layer="51"/>
+<rectangle x1="-1.1529" y1="-3.937" x2="-0.7973" y2="-2.6416" layer="51"/>
+<rectangle x1="-1.1529" y1="2.6416" x2="-0.7973" y2="3.937" layer="51"/>
+<rectangle x1="-0.5029" y1="-3.937" x2="-0.1473" y2="-2.6416" layer="51"/>
+<rectangle x1="-0.5029" y1="2.6416" x2="-0.1473" y2="3.937" layer="51"/>
+<rectangle x1="0.1471" y1="2.6416" x2="0.5027" y2="3.937" layer="51"/>
+<rectangle x1="0.1473" y1="-3.937" x2="0.5029" y2="-2.6416" layer="51"/>
+<rectangle x1="0.7971" y1="2.6416" x2="1.1527" y2="3.937" layer="51"/>
+<rectangle x1="0.7973" y1="-3.937" x2="1.1529" y2="-2.6416" layer="51"/>
+<rectangle x1="1.4471" y1="2.6416" x2="1.8027" y2="3.937" layer="51"/>
+<rectangle x1="1.4473" y1="-3.937" x2="1.8029" y2="-2.6416" layer="51"/>
+<rectangle x1="2.0971" y1="2.6416" x2="2.4527" y2="3.937" layer="51"/>
+<rectangle x1="2.0973" y1="-3.937" x2="2.4529" y2="-2.6416" layer="51"/>
+<rectangle x1="2.7471" y1="2.6416" x2="3.1027" y2="3.937" layer="51"/>
+<rectangle x1="2.7473" y1="-3.937" x2="3.1029" y2="-2.6416" layer="51"/>
+<rectangle x1="3.3971" y1="2.6416" x2="3.7527" y2="3.937" layer="51"/>
+<rectangle x1="3.3973" y1="-3.937" x2="3.7529" y2="-2.6416" layer="51"/>
+<rectangle x1="4.0471" y1="2.6416" x2="4.4027" y2="3.937" layer="51"/>
+<rectangle x1="4.0473" y1="-3.937" x2="4.4029" y2="-2.6416" layer="51"/>
+<smd name="1" x="-4.225" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="2" x="-3.575" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="3" x="-2.925" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="4" x="-2.275" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="5" x="-1.625" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="6" x="-0.975" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="7" x="-0.325" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="8" x="0.325" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="9" x="0.975" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="10" x="1.625" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="11" x="2.275" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="12" x="2.925" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="13" x="3.575" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="14" x="4.225" y="-3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="15" x="4.225" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="16" x="3.575" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="17" x="2.925" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="18" x="2.275" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="19" x="1.625" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="20" x="0.975" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="21" x="0.325" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="22" x="-0.325" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="23" x="-0.975" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="24" x="-1.625" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="25" x="-2.275" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="26" x="-2.925" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="27" x="-3.575" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<smd name="28" x="-4.225" y="3.625" dx="0.4" dy="1.5" layer="1"/>
+<text x="-5.76" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="6.395" y="-2.54" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-2.6" x2="5.1" y2="-2.6" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="-2.6" x2="-5.05" y2="2.6" width="0.2032" layer="21"/>
+<wire x1="5.1" y1="-2.6" x2="5.1" y2="2.6" width="0.2032" layer="21"/>
+<wire x1="5.1" y1="2.6" x2="-5.05" y2="2.6" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -26637,7 +26686,7 @@ DALLAS Semiconductor</description>
 <gate name="G$1" symbol="DS2405" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-">
+<device name="" package="TO92-AA">
 <connects>
 <connect gate="G$1" pin="DATA" pad="2"/>
 <connect gate="G$1" pin="GND" pad="1"/>
@@ -27632,11 +27681,11 @@ DALLAS Semiconductor</description>
 <gate name="G$1" symbol="DS2401" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT223-D">
+<device name="" package="SOT223">
 <connects>
-<connect gate="G$1" pin="DATA" pad="2"/>
-<connect gate="G$1" pin="GND" pad="1"/>
-<connect gate="G$1" pin="GND1" pad="4"/>
+<connect gate="G$1" pin="DATA" pad="1"/>
+<connect gate="G$1" pin="GND" pad="4"/>
+<connect gate="G$1" pin="GND1" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/microchip.lbr
+++ b/microchip.lbr
@@ -2062,20 +2062,21 @@ square, package type K</description>
 <vertex x="6.3619" y="0.3481"/>
 </polygon>
 </package>
-<package name="TO92">
-<description>&lt;b&gt;TO-92&lt;/b&gt;</description>
+<package name="TO92-AB">
+<description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement. JEDEC TO-226G, variation AB.
+&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
 <wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 <wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="1" x="1.27" y="0" drill="0.8128" diameter="1.4224" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.4224" shape="octagon"/>
-<pad name="3" x="-1.27" y="0" drill="0.8128" diameter="1.4224" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="1.143" y="0" size="1.27" layer="51" ratio="10">1</text>
-<text x="-0.635" y="0.635" size="1.27" layer="51" ratio="10">2</text>
-<text x="-2.159" y="0" size="1.27" layer="51" ratio="10">3</text>
+<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 </package>
 <package name="PLCC20S">
 <description>&lt;b&gt;PLASTIC LEADED CHIP CARRIER&lt;/b&gt;&lt;p&gt;
@@ -19800,10 +19801,10 @@ Source: http://www.microchip.com .. 21653b.pdf</description>
 <technology name="41"/>
 </technologies>
 </device>
-<device name="TO" package="TO92">
+<device name="TO" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="GND" pad="1"/>
-<connect gate="G$1" pin="VIN" pad="3"/>
+<connect gate="G$1" pin="GND" pad="3"/>
+<connect gate="G$1" pin="VIN" pad="1"/>
 <connect gate="G$1" pin="VO" pad="2"/>
 </connects>
 <technologies>

--- a/national-semi.lbr
+++ b/national-semi.lbr
@@ -691,17 +691,21 @@ NS Package Number SDE06A</description>
 <rectangle x1="0.375" y1="-3.5163" x2="1.125" y2="-1.6875" layer="51"/>
 <rectangle x1="1.875" y1="-3.5163" x2="2.625" y2="-1.6875" layer="51"/>
 </package>
-<package name="TO92">
-<description>&lt;b&gt;TO-92&lt;/b&gt;</description>
+<package name="TO92-AB">
+<description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement. JEDEC TO-226G, variation AB.
+&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
 <wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 <wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="1" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 </package>
 <package name="TO220-5KC">
 <description>&lt;b&gt;TO-220-5&lt;/b&gt;&lt;p&gt;
@@ -2241,11 +2245,11 @@ SIMPLE SWITCHERSynchronous 1MHz 0.75A</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="Z" package="TO92">
+<device name="Z" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="GND" pad="1"/>
+<connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="VOUT" pad="2"/>
-<connect gate="G$1" pin="VS" pad="3"/>
+<connect gate="G$1" pin="VS" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/ref-packages-transistor.lbr
+++ b/ref-packages-transistor.lbr
@@ -455,6 +455,40 @@ Also known as SOT186.</description>
 <wire x1="5.207" y1="12.7" x2="5.207" y2="14.605" width="0.2032" layer="21"/>
 <wire x1="5.207" y1="14.605" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
 </package>
+<package name="TO92-AA">
+<description>&lt;b&gt;TO-92 (2.54mm lead pitch, 3 leads, vertical, linear pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 2.54mm lead pitch, 3 leads, vertical, linear pad arrangement. JEDEC TO-226G, variation AA.
+&lt;/p&gt;&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-2.54" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<pad name="2" x="0" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<pad name="3" x="2.54" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-2.4135" y1="-1.1159" x2="-2.095" y2="-1.631" width="0.2032" layer="21" curve="13.038528" cap="flat"/>
+<wire x1="-2.413" y1="1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="21" curve="-129.583345" cap="flat"/>
+<wire x1="-2.413" y1="1.1359" x2="-2.413" y2="-1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
+<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="2.095" y1="-1.631" x2="2.4247" y2="-1.0918" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
+<wire x1="2.413" y1="-1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
+</package>
+<package name="TO92-AB">
+<description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement. JEDEC TO-226G, variation AB.
+&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
+<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
+<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
+</package>
 </packages>
 <symbols>
 </symbols>

--- a/ref-packages.lbr
+++ b/ref-packages.lbr
@@ -327,25 +327,6 @@ To use, open any library and&lt;p&gt;
 <rectangle x1="0.8529" y1="-2.4876" x2="1.0561" y2="-1.6494" layer="51"/>
 <rectangle x1="-0.4171" y1="-2.4876" x2="-0.2139" y2="-1.6494" layer="51"/>
 </package>
-<package name="SSOP5-0D95">
-<wire x1="-0.6222" y1="1.45" x2="0.6222" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="0.6222" y1="1.45" x2="0.6222" y2="-1.45" width="0.2032" layer="51"/>
-<wire x1="0.6222" y1="-1.45" x2="-0.6222" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-0.6222" y1="-1.45" x2="-0.6222" y2="1.45" width="0.2032" layer="51"/>
-<circle x="-0.2159" y="0.962" radius="0.2334" width="0" layer="21"/>
-<smd name="2" x="-1.143" y="0" dx="0.8" dy="0.5" layer="1"/>
-<smd name="1" x="-1.15" y="0.95" dx="0.8" dy="0.5" layer="1"/>
-<smd name="3" x="-1.15" y="-0.95" dx="0.8" dy="0.5" layer="1"/>
-<smd name="5" x="1.15" y="0.95" dx="0.8" dy="0.5" layer="1"/>
-<smd name="4" x="1.15" y="-0.95" dx="0.8" dy="0.5" layer="1"/>
-<text x="-1.27" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.27" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="-1.2487" y1="0.8494" x2="-0.6386" y2="1.0503" layer="51"/>
-<rectangle x1="-1.2487" y1="-0.0995" x2="-0.6386" y2="0.1014" layer="51"/>
-<rectangle x1="-1.2487" y1="-1.0494" x2="-0.6386" y2="-0.8485" layer="51"/>
-<rectangle x1="0.6309" y1="-1.0494" x2="1.241" y2="-0.8485" layer="51"/>
-<rectangle x1="0.6309" y1="0.8494" x2="1.241" y2="1.0503" layer="51"/>
-</package>
 <package name="FM8">
 <wire x1="-2.3622" y1="-1.4224" x2="2.3622" y2="-1.4224" width="0.2032" layer="51"/>
 <wire x1="2.4622" y1="-1.4224" x2="2.4622" y2="1.4224" width="0.2032" layer="21"/>

--- a/rohm-semi.lbr
+++ b/rohm-semi.lbr
@@ -78,26 +78,32 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2010, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SSOP5">
-<description>&lt;b&gt;SSOP5&lt;/b&gt;&lt;p&gt;
-0.95 mm pitch, body 2.9 x 1.6 mm</description>
-<wire x1="-0.8" y1="1.45" x2="0.8" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="0.8" y1="1.45" x2="0.8" y2="-1.45" width="0.2032" layer="51"/>
-<wire x1="0.8" y1="-1.45" x2="-0.8" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-0.8" y1="-1.45" x2="-0.8" y2="1.45" width="0.2032" layer="51"/>
-<circle x="-0.2159" y="0.962" radius="0.2334" width="0" layer="21"/>
-<smd name="2" x="-1.143" y="0" dx="0.8" dy="0.5" layer="1"/>
-<smd name="1" x="-1.15" y="0.95" dx="0.8" dy="0.5" layer="1"/>
-<smd name="3" x="-1.15" y="-0.95" dx="0.8" dy="0.5" layer="1"/>
-<smd name="5" x="1.15" y="0.95" dx="0.8" dy="0.5" layer="1"/>
-<smd name="4" x="1.15" y="-0.95" dx="0.8" dy="0.5" layer="1"/>
-<text x="-1.27" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.27" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="-1.3987" y1="0.8" x2="-0.7886" y2="1.1" layer="51"/>
-<rectangle x1="-1.3987" y1="-0.15" x2="-0.7886" y2="0.15" layer="51"/>
-<rectangle x1="-1.3987" y1="-1.1" x2="-0.7886" y2="-0.8" layer="51"/>
-<rectangle x1="0.8309" y1="-1.1" x2="1.441" y2="-0.8" layer="51"/>
-<rectangle x1="0.8309" y1="0.8" x2="1.441" y2="1.1" layer="51"/>
+<package name="SOT23-5">
+<description>&lt;b&gt;TSSOP (SSOT, 0.95mm pitch, 1.6mm body, 5 leads)&lt;/b&gt;&lt;p&gt;
+Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body width, 5 leads.
+&lt;p/&gt;
+1.1mm max height: JEDEC MO-193E, variation AB, TR-PDSO-G.
+&lt;p/&gt;
+1.45mm max height: JEDEC MO-178E, variation AB, R-PDSO-G.</description>
+<circle x="-1.1" y="-0.45" radius="0.1524" width="0" layer="21"/>
+<rectangle x1="-1.15" y1="-1.4" x2="-0.75" y2="-0.8" layer="51"/>
+<rectangle x1="-1.15" y1="0.8" x2="-0.75" y2="1.4" layer="51"/>
+<rectangle x1="-0.2" y1="-1.4" x2="0.2" y2="-0.8" layer="51"/>
+<rectangle x1="0.75" y1="-1.4" x2="1.15" y2="-0.8" layer="51"/>
+<rectangle x1="0.75" y1="0.8" x2="1.15" y2="1.4" layer="51"/>
+<smd name="1" x="-0.95" y="-1.2" dx="0.55" dy="0.8" layer="1"/>
+<smd name="2" x="0" y="-1.2" dx="0.55" dy="0.8" layer="1"/>
+<smd name="3" x="0.95" y="-1.2" dx="0.55" dy="0.8" layer="1"/>
+<smd name="4" x="0.95" y="1.2" dx="0.55" dy="0.8" layer="1"/>
+<smd name="5" x="-0.95" y="1.2" dx="0.55" dy="0.8" layer="1"/>
+<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-1.905" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-1.45" y1="-0.8" x2="-1.45" y2="0.8" width="0.2032" layer="51"/>
+<wire x1="-1.45" y1="-0.65" x2="-1.45" y2="0.65" width="0.2032" layer="21"/>
+<wire x1="-1.45" y1="0.8" x2="1.45" y2="0.8" width="0.2032" layer="51"/>
+<wire x1="1.45" y1="-0.8" x2="-1.45" y2="-0.8" width="0.2032" layer="51"/>
+<wire x1="1.45" y1="-0.65" x2="1.45" y2="0.65" width="0.2032" layer="21"/>
+<wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
 </package>
 <package name="HRP5">
 <description>HRP5</description>
@@ -168,7 +174,7 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <gate name="G$1" symbol="BD48XXG" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP5">
+<device name="" package="SOT23-5">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="VDD" pad="2"/>

--- a/transistor-fet.lbr
+++ b/transistor-fet.lbr
@@ -133,25 +133,6 @@ by R. Vogg  15.March.2002</description>
 <text x="-2.54" y="3.048" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2.54" y="-3.302" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="TO92L">
-<description>&lt;b&gt;&lt;/b&gt;</description>
-<wire x1="-1.1359" y1="2.413" x2="1.1359" y2="2.413" width="0.2032" layer="51" curve="-50.416655" cap="flat"/>
-<wire x1="-1.1359" y1="-2.413" x2="1.1359" y2="-2.413" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="-1.651" y1="2.0945" x2="-1.651" y2="-2.0945" width="0.2032" layer="21"/>
-<wire x1="-0.127" y1="-1.4041" x2="-0.127" y2="1.4041" width="0.2032" layer="21"/>
-<wire x1="-0.127" y1="-2.664" x2="-0.127" y2="-1.4041" width="0.2032" layer="51"/>
-<wire x1="-1.651" y1="-2.0945" x2="-1.1118" y2="-2.4242" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
-<wire x1="-0.127" y1="1.4041" x2="-0.127" y2="2.664" width="0.2032" layer="51"/>
-<wire x1="-1.651" y1="2.0945" x2="-1.1359" y2="2.413" width="0.2032" layer="21" curve="-13.038528" cap="flat"/>
-<wire x1="2.413" y1="-1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="1.1359" y1="-2.413" x2="2.413" y2="-1.1359" width="0.2032" layer="21" curve="39.583345" cap="flat"/>
-<wire x1="1.1359" y1="2.413" x2="2.413" y2="1.1359" width="0.2032" layer="21" curve="-39.583345" cap="flat"/>
-<pad name="1" x="0" y="-2.54" drill="0.8128" shape="long"/>
-<pad name="3" x="0" y="2.54" drill="0.8128" shape="long"/>
-<pad name="2" x="2.54" y="0" drill="0.8128" shape="long"/>
-<text x="-1.524" y="3.556" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.524" y="-4.953" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="TO3">
 <description>&lt;b&gt;TO 3&lt;/b&gt;</description>
 <wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>

--- a/transistor-fet.lbr
+++ b/transistor-fet.lbr
@@ -95,43 +95,23 @@ GDSB: gate, drain, source, bulk&lt;p&gt;
 &lt;p&gt;
 by R. Vogg  15.March.2002</description>
 <packages>
-<package name="TO92/">
-<description>&lt;b&gt;&lt;/b&gt;</description>
-<wire x1="-2.6485" y1="0.3136" x2="0.3136" y2="-2.6485" width="0.2032" layer="21"/>
-<wire x1="-1.1494" y1="2.4066" x2="1.1494" y2="2.4066" width="0.2032" layer="21" curve="-51.058586" cap="flat"/>
-<wire x1="-0.5566" y1="0.377" x2="0.377" y2="-0.5566" width="0.2032" layer="21"/>
-<wire x1="-2.4066" y1="1.1494" x2="-1.1494" y2="2.4066" width="0.2032" layer="51" curve="-38.941414" cap="flat"/>
-<wire x1="-2.6485" y1="0.3136" x2="-2.4066" y2="1.1494" width="0.2032" layer="21" curve="-18.776471" cap="flat"/>
-<wire x1="-1.9735" y1="1.7939" x2="-0.5566" y2="0.377" width="0.2032" layer="51"/>
-<wire x1="2.4066" y1="-1.1494" x2="2.4066" y2="1.1494" width="0.2032" layer="21" curve="51.058586" cap="flat"/>
-<wire x1="1.1494" y1="-2.4066" x2="2.4066" y2="-1.1494" width="0.2032" layer="51" curve="38.941414" cap="flat"/>
-<wire x1="0.377" y1="-0.5566" x2="1.7939" y2="-1.9735" width="0.2032" layer="51"/>
-<wire x1="0.3136" y1="-2.6485" x2="1.1494" y2="-2.4066" width="0.2032" layer="21" curve="18.776471" cap="flat"/>
-<wire x1="1.1494" y1="2.4066" x2="2.4066" y2="1.1494" width="0.2032" layer="51" curve="-38.941414" cap="flat"/>
-<pad name="3" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="1" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="3.048" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-4.318" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-">
-<description>&lt;b&gt;&lt;/b&gt;</description>
-<wire x1="-2.0945" y1="-1.651" x2="2.0945" y2="-1.651" width="0.2032" layer="21"/>
+<package name="TO92-AA">
+<description>&lt;b&gt;TO-92 (2.54mm lead pitch, 3 leads, vertical, linear pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 2.54mm lead pitch, 3 leads, vertical, linear pad arrangement. JEDEC TO-226G, variation AA.
+&lt;/p&gt;&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-2.54" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<pad name="2" x="0" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<pad name="3" x="2.54" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-2.4135" y1="-1.1159" x2="-2.095" y2="-1.631" width="0.2032" layer="21" curve="13.038528" cap="flat"/>
 <wire x1="-2.413" y1="1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="21" curve="-129.583345" cap="flat"/>
-<wire x1="1.1359" y1="-0.127" x2="-1.1359" y2="-0.127" width="0.2032" layer="51"/>
 <wire x1="-2.413" y1="1.1359" x2="-2.413" y2="-1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="-1.4041" y1="-0.127" x2="-2.664" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="-2.413" y1="-1.1359" x2="-2.0945" y2="-1.651" width="0.2032" layer="21" curve="13.038528" cap="flat"/>
-<wire x1="-1.1359" y1="-0.127" x2="-1.4041" y2="-0.127" width="0.2032" layer="21"/>
+<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="2.095" y1="-1.631" x2="2.4247" y2="-1.0918" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
 <wire x1="2.413" y1="-1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="2.664" y1="-0.127" x2="1.4041" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="1.4041" y1="-0.127" x2="1.1359" y2="-0.127" width="0.2032" layer="21"/>
-<wire x1="2.0945" y1="-1.651" x2="2.4242" y2="-1.1118" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
-<pad name="3" x="-2.54" y="0" drill="0.8128" shape="long" rot="R90"/>
-<pad name="1" x="2.54" y="0" drill="0.8128" shape="long" rot="R90"/>
-<pad name="2" x="0" y="0" drill="0.8128" shape="long" rot="R90"/>
-<text x="-2.54" y="3.048" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-3.302" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="TO3">
 <description>&lt;b&gt;TO 3&lt;/b&gt;</description>
@@ -789,29 +769,21 @@ Also known as SOT78.</description>
 <rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
 <rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
 </package>
-<package name="TO92">
-<description>&lt;b&gt;&lt;/b&gt;</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="1" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO-92">
-<description>&lt;b&gt;&lt;/b&gt;</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<package name="TO92-AB">
+<description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement. JEDEC TO-226G, variation AB.
+&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
 <pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
+<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
+<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 </package>
 <package name="TO262-H">
 <description>&lt;b&gt;Molded Package&lt;/b&gt;</description>
@@ -3805,11 +3777,11 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EN-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="3"/>
+<connect gate="G$1" pin="D" pad="1"/>
 <connect gate="G$1" pin="G" pad="2"/>
-<connect gate="G$1" pin="S" pad="1"/>
+<connect gate="G$1" pin="S" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3823,11 +3795,11 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EP-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="D" pad="2"/>
-<connect gate="G$1" pin="G" pad="1"/>
-<connect gate="G$1" pin="S" pad="3"/>
+<connect gate="G$1" pin="G" pad="3"/>
+<connect gate="G$1" pin="S" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3841,11 +3813,11 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EN-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="D" pad="2"/>
-<connect gate="G$1" pin="G" pad="1"/>
-<connect gate="G$1" pin="S" pad="3"/>
+<connect gate="G$1" pin="G" pad="3"/>
+<connect gate="G$1" pin="S" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3859,11 +3831,11 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EN-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="D" pad="2"/>
-<connect gate="G$1" pin="G" pad="1"/>
-<connect gate="G$1" pin="S" pad="3"/>
+<connect gate="G$1" pin="G" pad="3"/>
+<connect gate="G$1" pin="S" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3895,11 +3867,11 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EP-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="3"/>
+<connect gate="G$1" pin="D" pad="1"/>
 <connect gate="G$1" pin="G" pad="2"/>
-<connect gate="G$1" pin="S" pad="1"/>
+<connect gate="G$1" pin="S" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4027,11 +3999,11 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="JFET-N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="1"/>
+<connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
-<connect gate="G$1" pin="S" pad="3"/>
+<connect gate="G$1" pin="S" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4045,11 +4017,11 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="JFET-P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="1"/>
+<connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
-<connect gate="G$1" pin="S" pad="3"/>
+<connect gate="G$1" pin="S" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4081,10 +4053,10 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="JFET-N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="1"/>
-<connect gate="G$1" pin="G" pad="3"/>
+<connect gate="G$1" pin="D" pad="3"/>
+<connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="2"/>
 </connects>
 <technologies>
@@ -4099,10 +4071,10 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="JFET-N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="1"/>
-<connect gate="G$1" pin="G" pad="3"/>
+<connect gate="G$1" pin="D" pad="3"/>
+<connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="2"/>
 </connects>
 <technologies>
@@ -4117,10 +4089,10 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="JFET-N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="1"/>
-<connect gate="G$1" pin="G" pad="3"/>
+<connect gate="G$1" pin="D" pad="3"/>
+<connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="2"/>
 </connects>
 <technologies>
@@ -4135,10 +4107,10 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="JFET-N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="1"/>
-<connect gate="G$1" pin="G" pad="3"/>
+<connect gate="G$1" pin="D" pad="3"/>
+<connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="2"/>
 </connects>
 <technologies>
@@ -4153,10 +4125,10 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="JFET-P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="1"/>
-<connect gate="G$1" pin="G" pad="3"/>
+<connect gate="G$1" pin="D" pad="3"/>
+<connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="2"/>
 </connects>
 <technologies>
@@ -4318,7 +4290,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EP-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO-92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
@@ -4336,7 +4308,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EN-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO-92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
@@ -4354,7 +4326,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EP-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO-92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
@@ -4372,7 +4344,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EP-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO-92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
@@ -4444,7 +4416,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EN-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO-92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
@@ -4679,10 +4651,10 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="JFET-N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="3"/>
-<connect gate="G$1" pin="G" pad="1"/>
+<connect gate="G$1" pin="D" pad="1"/>
+<connect gate="G$1" pin="G" pad="3"/>
 <connect gate="G$1" pin="S" pad="2"/>
 </connects>
 <technologies>
@@ -4698,11 +4670,11 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="JFET-P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="3"/>
+<connect gate="G$1" pin="D" pad="1"/>
 <connect gate="G$1" pin="G" pad="2"/>
-<connect gate="G$1" pin="S" pad="1"/>
+<connect gate="G$1" pin="S" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4717,7 +4689,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="EMOS-N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N3" package="TO-92">
+<device name="N3" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
@@ -4745,10 +4717,10 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="JFET-P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="3"/>
-<connect gate="G$1" pin="G" pad="1"/>
+<connect gate="G$1" pin="D" pad="1"/>
+<connect gate="G$1" pin="G" pad="3"/>
 <connect gate="G$1" pin="S" pad="2"/>
 </connects>
 <technologies>
@@ -4763,10 +4735,10 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="JFET-N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="3"/>
-<connect gate="G$1" pin="G" pad="1"/>
+<connect gate="G$1" pin="D" pad="1"/>
+<connect gate="G$1" pin="G" pad="3"/>
 <connect gate="G$1" pin="S" pad="2"/>
 </connects>
 <technologies>
@@ -5022,7 +4994,7 @@ Vgs=12V</description>
 <gate name="G$1" symbol="MFNS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO-92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
@@ -5543,7 +5515,7 @@ Supertex Inc.</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N3" package="TO-92">
+<device name="N3" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
@@ -6833,11 +6805,11 @@ PowerTrench</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="KL" package="TO92">
+<device name="KL" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="1"/>
+<connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
-<connect gate="G$1" pin="S" pad="3"/>
+<connect gate="G$1" pin="S" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -6861,11 +6833,11 @@ PowerTrench</description>
 <gate name="G$1" symbol="JFET-N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="3"/>
+<connect gate="G$1" pin="D" pad="1"/>
 <connect gate="G$1" pin="G" pad="2"/>
-<connect gate="G$1" pin="S" pad="1"/>
+<connect gate="G$1" pin="S" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -6879,10 +6851,10 @@ PowerTrench</description>
 <gate name="G$1" symbol="JFET-N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="3"/>
-<connect gate="G$1" pin="G" pad="1"/>
+<connect gate="G$1" pin="D" pad="1"/>
+<connect gate="G$1" pin="G" pad="3"/>
 <connect gate="G$1" pin="S" pad="2"/>
 </connects>
 <technologies>
@@ -7653,10 +7625,10 @@ PowerTrench, 30V, 4.9A, 42mOhm</description>
 <gate name="G$1" symbol="JFET-N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="3"/>
-<connect gate="G$1" pin="G" pad="1"/>
+<connect gate="G$1" pin="D" pad="1"/>
+<connect gate="G$1" pin="G" pad="3"/>
 <connect gate="G$1" pin="S" pad="2"/>
 </connects>
 <technologies>
@@ -7953,10 +7925,10 @@ MOSFET P-CH 55V 18A DPAK</description>
 <gate name="G$1" symbol="JFET-N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="3"/>
-<connect gate="G$1" pin="G" pad="1"/>
+<connect gate="G$1" pin="D" pad="1"/>
+<connect gate="G$1" pin="G" pad="3"/>
 <connect gate="G$1" pin="S" pad="2"/>
 </connects>
 <technologies>

--- a/transistor-npn.lbr
+++ b/transistor-npn.lbr
@@ -298,17 +298,21 @@ grid 2.54 mm, vertical</description>
 <text x="0.635" y="-1.27" size="1.27" layer="51" ratio="10">2</text>
 <text x="0" y="0.635" size="1.27" layer="51" ratio="10">3</text>
 </package>
-<package name="TO92">
-<description>&lt;b&gt;TO-92&lt;/b&gt;</description>
+<package name="TO92-AB">
+<description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement. JEDEC TO-226G, variation AB.
+&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
 <wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 <wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="1" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 </package>
 <package name="TO218">
 <description>&lt;b&gt;TO-218&lt;/b&gt;&lt;p&gt;
@@ -781,19 +785,6 @@ grid 2.54 mm</description>
 <rectangle x1="-0.3175" y1="-7.9375" x2="0.3175" y2="-6.985" layer="21"/>
 <hole x="0" y="0" drill="3.048"/>
 </package>
-<package name="TO92-EBC">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
- grid 5.08 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="C" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="E" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="B" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="SOT89-ECB">
 <description>SOT-89 (Emitter Collector Base)</description>
 <wire x1="2.235" y1="-1.245" x2="-2.235" y2="-1.245" width="0.127" layer="51"/>
@@ -831,58 +822,6 @@ grid 2.54 mm</description>
 <wire x1="-2.286" y1="1.27" x2="-2.286" y2="-1.27" width="0.2032" layer="21"/>
 <wire x1="2.286" y1="1.27" x2="2.286" y2="-1.27" width="0.2032" layer="21"/>
 <wire x1="2.286" y1="1.27" x2="1.27" y2="1.27" width="0.2032" layer="21"/>
-</package>
-<package name="TO92-BCE">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="C" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="E" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="B" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-CBE">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="C" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="E" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="B" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-BEC">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="C" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="E" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="B" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-CEB">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="C" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="E" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="B" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="SOT89-BCE">
 <description>SOT-89 (Base Collector Emitter)</description>
@@ -1426,17 +1365,23 @@ CASE 340L, STYLE 3</description>
 <wire x1="-4" y1="-1.6" x2="-4" y2="1.7" width="0.2032" layer="21"/>
 <rectangle x1="-4" y1="1.1" x2="4" y2="1.7" layer="21"/>
 </package>
-<package name="TO92-3L">
-<description>&lt;b&gt;TO-92-3L&lt;/b&gt;</description>
+<package name="TO92-AA">
+<description>&lt;b&gt;TO-92 (2.54mm lead pitch, 3 leads, vertical, linear pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 2.54mm lead pitch, 3 leads, vertical, linear pad arrangement. JEDEC TO-226G, variation AA.
+&lt;/p&gt;&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-2.54" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<pad name="2" x="0" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<pad name="3" x="2.54" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-2.4135" y1="-1.1159" x2="-2.095" y2="-1.631" width="0.2032" layer="21" curve="13.038528" cap="flat"/>
+<wire x1="-2.413" y1="1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="21" curve="-129.583345" cap="flat"/>
+<wire x1="-2.413" y1="1.1359" x2="-2.413" y2="-1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
 <wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<pad name="2" x="0" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="1" x="-2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="3" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<text x="3.175" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<wire x1="-2.1" y1="-1.6" x2="-2.4" y2="-1.1" width="0.2032" layer="21" curve="-12.555039"/>
-<wire x1="-2.5" y1="1.1" x2="2.5" y2="1.1" width="0.2032" layer="21" curve="-123.974045"/>
-<wire x1="2.1" y1="-1.6" x2="2.4" y2="-1.1" width="0.2032" layer="21" curve="12.555039"/>
+<wire x1="2.095" y1="-1.631" x2="2.4247" y2="-1.0918" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
+<wire x1="2.413" y1="-1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
 </package>
 </packages>
 <symbols>
@@ -1824,11 +1769,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1860,10 +1805,10 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="1"/>
-<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="B" pad="3"/>
+<connect gate="G$1" pin="C" pad="1"/>
 <connect gate="G$1" pin="E" pad="2"/>
 </connects>
 <technologies>
@@ -1878,11 +1823,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="NPN-DAR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1914,11 +1859,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="1"/>
+<connect gate="G$1" pin="B" pad="3"/>
 <connect gate="G$1" pin="C" pad="2"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2023,11 +1968,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2041,11 +1986,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2062,11 +2007,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3613,11 +3558,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="NPN" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3631,11 +3576,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="NPN" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3759,11 +3704,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3777,11 +3722,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3795,11 +3740,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G1" pin="B" pad="2"/>
-<connect gate="G1" pin="C" pad="1"/>
-<connect gate="G1" pin="E" pad="3"/>
+<connect gate="G1" pin="C" pad="3"/>
+<connect gate="G1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4448,11 +4393,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4469,11 +4414,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4487,11 +4432,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4505,11 +4450,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4523,11 +4468,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4541,11 +4486,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name="A"/>
@@ -4560,11 +4505,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4580,11 +4525,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name="B"/>
@@ -4599,11 +4544,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name="B"/>
@@ -4618,11 +4563,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4636,11 +4581,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SMD" package="TO92-EBC">
+<device name="SMD" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -5236,11 +5181,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -5254,11 +5199,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -5291,11 +5236,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -5366,11 +5311,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -5403,11 +5348,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -5439,11 +5384,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="1"/>
+<connect gate="G$1" pin="B" pad="3"/>
 <connect gate="G$1" pin="C" pad="2"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -5457,11 +5402,11 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -5671,11 +5616,11 @@ complimentary to CMPTA56</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -5717,11 +5662,11 @@ complimentary to CMPTA56</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -5763,11 +5708,11 @@ complimentary to CMPTA56</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -6027,17 +5972,17 @@ BJT BIP NPN 1.5A 160V</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-BCE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="3"/>
+<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-3L" package="TO92-3L">
+<device name="-3L" package="TO92-AA">
 <connects>
 <connect gate="G$1" pin="B" pad="3"/>
 <connect gate="G$1" pin="C" pad="2"/>

--- a/transistor-pnp.lbr
+++ b/transistor-pnp.lbr
@@ -298,17 +298,21 @@ grid 2.54 mm, vertical</description>
 <text x="0.635" y="-1.27" size="1.27" layer="51" ratio="10">2</text>
 <text x="0" y="0.635" size="1.27" layer="51" ratio="10">3</text>
 </package>
-<package name="TO92">
-<description>&lt;b&gt;TO-92&lt;/b&gt;</description>
+<package name="TO92-AB">
+<description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement. JEDEC TO-226G, variation AB.
+&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
 <wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 <wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="1" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 </package>
 <package name="TO218">
 <description>&lt;b&gt;TO-218&lt;/b&gt;&lt;p&gt;
@@ -699,45 +703,6 @@ grid 2.3 mm, horizontal</description>
 <rectangle x1="-3.175" y1="-0.381" x2="-1.397" y2="0" layer="51"/>
 <rectangle x1="-0.889" y1="-0.381" x2="0.889" y2="0" layer="51"/>
 <rectangle x1="1.397" y1="-0.381" x2="3.175" y2="0" layer="51"/>
-</package>
-<package name="TO92-EBC">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="C" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="E" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="B" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-BCE">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="C" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="E" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="B" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-CBE">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="C" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="E" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="B" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="SC59-BEC">
 <description>&lt;b&gt;SC59&lt;/b&gt; (SOT23) Motorola</description>
@@ -1700,11 +1665,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1718,11 +1683,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1736,11 +1701,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1754,11 +1719,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP-DAR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1772,11 +1737,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2475,11 +2440,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2493,11 +2458,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2933,11 +2898,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2964,11 +2929,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2985,11 +2950,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3003,11 +2968,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3021,11 +2986,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3039,11 +3004,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3057,11 +3022,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3075,11 +3040,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3094,11 +3059,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3115,11 +3080,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name="A"/>
@@ -3135,11 +3100,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name="A"/>
@@ -3155,11 +3120,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3174,11 +3139,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-EBC">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3491,11 +3456,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-BCE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="3"/>
+<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3509,11 +3474,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-BCE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="3"/>
+<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3527,11 +3492,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-BCE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="3"/>
+<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3545,11 +3510,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-BCE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="3"/>
+<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3563,11 +3528,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-BCE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="3"/>
+<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3581,11 +3546,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-BCE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="3"/>
+<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3599,11 +3564,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-CBE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3617,11 +3582,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-CBE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3635,11 +3600,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-CBE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name="A"/>
@@ -3653,11 +3618,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-CBE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3671,11 +3636,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-CBE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3689,11 +3654,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-CBE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3851,11 +3816,11 @@ CASE 340L, STYLE 3</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4039,11 +4004,11 @@ complimentary to CMPTA06</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-CBE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4255,11 +4220,11 @@ Silicon planar high voltage transistor, Zetex</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-CBE">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/transistor-small-signal.lbr
+++ b/transistor-small-signal.lbr
@@ -78,19 +78,6 @@ www.semiconductors.com;&lt;br&gt;
 www.irf.com&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="TO92C">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="E" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="C" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="B" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="TO72B">
 <description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
 grid 2.54 mm</description>
@@ -210,22 +197,23 @@ grid 2.54 mm</description>
 <rectangle x1="-0.889" y1="-2.794" x2="0.889" y2="-2.286" layer="51"/>
 <rectangle x1="1.651" y1="-2.794" x2="3.429" y2="-2.286" layer="51"/>
 </package>
-<package name="SOT54AA">
-<description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<wire x1="-1.1105" y1="2.1423" x2="1.1105" y2="2.1423" width="0.2032" layer="51" curve="-54.801566" cap="flat"/>
-<wire x1="-2.1254" y1="1.1425" x2="-2.1254" y2="-1.1425" width="0.2032" layer="51" curve="56.520138" cap="flat"/>
-<wire x1="-2.1251" y1="-1.1425" x2="-1.631" y2="-1.778" width="0.2032" layer="21" curve="19.203018" cap="flat"/>
-<wire x1="-2.1254" y1="1.1425" x2="-1.1105" y2="2.1423" width="0.2032" layer="21" curve="-34.339012" cap="flat"/>
-<wire x1="2.1254" y1="-1.1425" x2="2.1254" y2="1.1425" width="0.2032" layer="51" curve="56.520138" cap="flat"/>
-<wire x1="1.631" y1="-1.778" x2="2.1251" y2="-1.1425" width="0.2032" layer="21" curve="19.203018" cap="flat"/>
-<wire x1="1.1105" y1="2.1423" x2="2.1254" y2="1.1425" width="0.2032" layer="21" curve="-34.339012" cap="flat"/>
-<pad name="C" x="-2.54" y="0" drill="0.8128" shape="octagon"/>
-<pad name="B" x="0" y="2.54" drill="0.8128" shape="octagon"/>
-<pad name="E" x="2.54" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.27" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<package name="TO92-AA">
+<description>&lt;b&gt;TO-92 (2.54mm lead pitch, 3 leads, vertical, linear pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 2.54mm lead pitch, 3 leads, vertical, linear pad arrangement. JEDEC TO-226G, variation AA.
+&lt;/p&gt;&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-2.54" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<pad name="2" x="0" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<pad name="3" x="2.54" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-2.4135" y1="-1.1159" x2="-2.095" y2="-1.631" width="0.2032" layer="21" curve="13.038528" cap="flat"/>
+<wire x1="-2.413" y1="1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="21" curve="-129.583345" cap="flat"/>
+<wire x1="-2.413" y1="1.1359" x2="-2.413" y2="-1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
+<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="2.095" y1="-1.631" x2="2.4247" y2="-1.0918" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
+<wire x1="2.413" y1="-1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
 </package>
 <package name="TO72I">
 <description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
@@ -315,71 +303,6 @@ grid 2.54 mm</description>
 <rectangle x1="-0.635" y1="2.794" x2="0.635" y2="3.048" layer="21"/>
 <rectangle x1="-0.508" y1="2.413" x2="0.508" y2="2.794" layer="21"/>
 <hole x="0" y="0" drill="5.08"/>
-</package>
-<package name="BC337">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9692" y1="2.2098" x2="0.9692" y2="2.2098" width="0.2032" layer="51" curve="-47.363718" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="-0.9689" y2="2.2098" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="0.9689" y1="2.2098" x2="1.631" y2="-1.778" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<pad name="C" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="B" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="E" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="BC877">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9692" y1="2.2098" x2="0.9692" y2="2.2098" width="0.2032" layer="51" curve="-47.363718" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="-0.9689" y2="2.2098" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="0.9689" y1="2.2098" x2="1.631" y2="-1.778" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<pad name="E" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="C" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="B" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="SOT54B">
-<description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9692" y1="2.2098" x2="0.9692" y2="2.2098" width="0.2032" layer="51" curve="-47.363718" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="-0.9689" y2="2.2098" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="0.9689" y1="2.2098" x2="1.631" y2="-1.778" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<pad name="C" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="E" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="B" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-</package>
-<package name="SOT54D">
-<description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9692" y1="2.2098" x2="0.9692" y2="2.2098" width="0.2032" layer="51" curve="-47.363718" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="-0.9689" y2="2.2098" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="0.9689" y1="2.2098" x2="1.631" y2="-1.778" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<pad name="E" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="C" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="B" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-</package>
-<package name="SOT54C">
-<description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9692" y1="2.2098" x2="0.9692" y2="2.2098" width="0.2032" layer="51" curve="-47.363718" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="-0.9689" y2="2.2098" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="0.9689" y1="2.2098" x2="1.631" y2="-1.778" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<pad name="G" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="S" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="D" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 </package>
 <package name="TO72A">
 <description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
@@ -817,84 +740,6 @@ grid 2.54 mm</description>
 <text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="TO92D">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="E" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="B" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="C" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92B">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="B" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="E" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="C" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92E">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 3.54 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="B1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="E" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="B2" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92F">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="S" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="D" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92G">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="D" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="S" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92R">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="G" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="S" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="D" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="TO72G">
 <description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
 grid 2.54 mm</description>
@@ -1062,65 +907,21 @@ grid 2.54 mm</description>
 <text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="TO92">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
+<package name="TO92-AB">
+<description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement. JEDEC TO-226G, variation AB.
+&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
 <wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 <wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="1" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="SOT54A">
-<description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9692" y1="2.2098" x2="0.9692" y2="2.2098" width="0.2032" layer="51" curve="-47.363718" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="-0.9689" y2="2.2098" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="0.9689" y1="2.2098" x2="1.631" y2="-1.778" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<pad name="C" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="B" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="E" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.27" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-</package>
-<package name="SOT54BB">
-<description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
-grid 4 mm</description>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<wire x1="-1.1105" y1="2.1423" x2="1.1105" y2="2.1423" width="0.2032" layer="51" curve="-54.801566" cap="flat"/>
-<wire x1="-2.1254" y1="1.1425" x2="-2.1254" y2="-1.1425" width="0.2032" layer="51" curve="56.520138" cap="flat"/>
-<wire x1="-2.1251" y1="-1.1425" x2="-1.631" y2="-1.778" width="0.2032" layer="21" curve="19.203018" cap="flat"/>
-<wire x1="-2.1254" y1="1.1425" x2="-1.1105" y2="2.1423" width="0.2032" layer="21" curve="-34.339012" cap="flat"/>
-<wire x1="2.1254" y1="-1.1425" x2="2.1254" y2="1.1425" width="0.2032" layer="51" curve="56.520138" cap="flat"/>
-<wire x1="1.631" y1="-1.778" x2="2.1251" y2="-1.1425" width="0.2032" layer="21" curve="19.203018" cap="flat"/>
-<wire x1="1.1105" y1="2.1423" x2="2.1254" y2="1.1425" width="0.2032" layer="21" curve="-34.339012" cap="flat"/>
-<pad name="C" x="-2" y="0" drill="0.8128" shape="octagon"/>
-<pad name="E" x="0" y="2" drill="0.8128" shape="octagon"/>
-<pad name="B" x="2" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.27" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-</package>
-<package name="SOT54CA">
-<description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<wire x1="-1.1105" y1="2.1423" x2="1.1105" y2="2.1423" width="0.2032" layer="51" curve="-54.801566" cap="flat"/>
-<wire x1="-2.1254" y1="1.1425" x2="-2.1254" y2="-1.1425" width="0.2032" layer="51" curve="56.520138" cap="flat"/>
-<wire x1="-2.1251" y1="-1.1425" x2="-1.631" y2="-1.778" width="0.2032" layer="21" curve="19.203018" cap="flat"/>
-<wire x1="-2.1254" y1="1.1425" x2="-1.1105" y2="2.1423" width="0.2032" layer="21" curve="-34.339012" cap="flat"/>
-<wire x1="2.1254" y1="-1.1425" x2="2.1254" y2="1.1425" width="0.2032" layer="51" curve="56.520138" cap="flat"/>
-<wire x1="1.631" y1="-1.778" x2="2.1251" y2="-1.1425" width="0.2032" layer="21" curve="19.203018" cap="flat"/>
-<wire x1="1.1105" y1="2.1423" x2="2.1254" y2="1.1425" width="0.2032" layer="21" curve="-34.339012" cap="flat"/>
-<pad name="G" x="-2.54" y="0" drill="0.8128" shape="octagon"/>
-<pad name="S" x="0" y="2.54" drill="0.8128" shape="octagon"/>
-<pad name="D" x="2.54" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.27" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 </package>
 <package name="SOT54DA">
 <description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
@@ -1180,57 +981,6 @@ grid 4 mm</description>
 <text x="1.6002" y="0.6604" size="1.016" layer="21" ratio="18">S</text>
 <text x="1.6002" y="-1.8796" size="1.016" layer="21" ratio="18">G</text>
 </package>
-<package name="SOT54AB">
-<description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
-grid 4 mm</description>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<wire x1="-1.2252" y1="2.0788" x2="1.2252" y2="2.0788" width="0.2032" layer="51" curve="-61.028365" cap="flat"/>
-<wire x1="-2.0638" y1="1.2504" x2="-2.0638" y2="-1.2504" width="0.2032" layer="51" curve="62.421053" cap="flat"/>
-<wire x1="-2.0638" y1="-1.2504" x2="-1.6313" y2="-1.7781" width="0.2032" layer="21" curve="16.254995" cap="flat"/>
-<wire x1="-2.0638" y1="1.2504" x2="-1.2252" y2="2.0788" width="0.2032" layer="21" curve="-28.276487" cap="flat"/>
-<wire x1="2.0638" y1="-1.2504" x2="2.0638" y2="1.2504" width="0.2032" layer="51" curve="62.421053" cap="flat"/>
-<wire x1="1.631" y1="-1.778" x2="2.0634" y2="-1.2504" width="0.2032" layer="21" curve="16.252389" cap="flat"/>
-<wire x1="1.2252" y1="2.0788" x2="2.0638" y2="1.2504" width="0.2032" layer="21" curve="-28.276487" cap="flat"/>
-<pad name="C" x="-2" y="0" drill="0.8128" shape="octagon"/>
-<pad name="B" x="0" y="2" drill="0.8128" shape="octagon"/>
-<pad name="E" x="2" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.27" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-</package>
-<package name="SOT54BA">
-<description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<wire x1="-1.2252" y1="2.0788" x2="1.2252" y2="2.0788" width="0.2032" layer="51" curve="-61.028365" cap="flat"/>
-<wire x1="-2.0638" y1="1.2504" x2="-2.0638" y2="-1.2504" width="0.2032" layer="51" curve="62.421053" cap="flat"/>
-<wire x1="-2.0638" y1="-1.2504" x2="-1.6313" y2="-1.7781" width="0.2032" layer="21" curve="16.254995" cap="flat"/>
-<wire x1="-2.0638" y1="1.2504" x2="-1.2252" y2="2.0788" width="0.2032" layer="21" curve="-28.276487" cap="flat"/>
-<wire x1="2.0638" y1="-1.2504" x2="2.0638" y2="1.2504" width="0.2032" layer="51" curve="62.421053" cap="flat"/>
-<wire x1="1.631" y1="-1.778" x2="2.0634" y2="-1.2504" width="0.2032" layer="21" curve="16.252389" cap="flat"/>
-<wire x1="1.2252" y1="2.0788" x2="2.0638" y2="1.2504" width="0.2032" layer="21" curve="-28.276487" cap="flat"/>
-<pad name="C" x="-2.54" y="0" drill="0.8128" shape="octagon"/>
-<pad name="E" x="0" y="2.54" drill="0.8128" shape="octagon"/>
-<pad name="B" x="2.54" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.27" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-</package>
-<package name="SOT54CB">
-<description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
-grid 4 mm</description>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<wire x1="-1.2252" y1="2.0788" x2="1.2252" y2="2.0788" width="0.2032" layer="51" curve="-61.028365" cap="flat"/>
-<wire x1="-2.0638" y1="1.2504" x2="-2.0638" y2="-1.2504" width="0.2032" layer="51" curve="62.421053" cap="flat"/>
-<wire x1="-2.0638" y1="-1.2504" x2="-1.6313" y2="-1.7781" width="0.2032" layer="21" curve="16.254995" cap="flat"/>
-<wire x1="-2.0638" y1="1.2504" x2="-1.2252" y2="2.0788" width="0.2032" layer="21" curve="-28.276487" cap="flat"/>
-<wire x1="2.0638" y1="-1.2504" x2="2.0638" y2="1.2504" width="0.2032" layer="51" curve="62.421053" cap="flat"/>
-<wire x1="1.631" y1="-1.778" x2="2.0634" y2="-1.2504" width="0.2032" layer="21" curve="16.252389" cap="flat"/>
-<wire x1="1.2252" y1="2.0788" x2="2.0638" y2="1.2504" width="0.2032" layer="21" curve="-28.276487" cap="flat"/>
-<pad name="G" x="-2" y="0" drill="0.8128" shape="octagon"/>
-<pad name="S" x="0" y="2" drill="0.8128" shape="octagon"/>
-<pad name="D" x="2" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.27" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-</package>
 <package name="SOT54DB">
 <description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
 grid 4 mm</description>
@@ -1247,45 +997,6 @@ grid 4 mm</description>
 <pad name="B" x="2.159" y="0" drill="0.8128" shape="octagon"/>
 <text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-</package>
-<package name="TO92I">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="S" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="D" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="SOT54E">
-<description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9692" y1="2.2098" x2="0.9692" y2="2.2098" width="0.2032" layer="51" curve="-47.363718" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="-0.9689" y2="2.2098" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="0.9689" y1="2.2098" x2="1.631" y2="-1.778" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<pad name="D" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="G" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="S" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-</package>
-<package name="TO92K">
-<description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="D" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="S" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="TO18-">
 <description>&lt;b&gt;TO-18&lt;/b&gt;&lt;p&gt;
@@ -1672,56 +1383,6 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <wire x1="-3.25" y1="1.75" x2="3.25" y2="1.75" width="0.2032" layer="21"/>
 <wire x1="3.25" y1="-1.75" x2="-3.25" y2="-1.75" width="0.2032" layer="21"/>
 <wire x1="3.25" y1="1.75" x2="3.25" y2="-1.75" width="0.2032" layer="21"/>
-</package>
-<package name="SOT323W_INFINEON">
-<description>&lt;b&gt;Small Outline Transistor&lt;/b&gt; Wave soldering&lt;p&gt;
-INFINEON, www.infineon.com/cmc_upload/0/000/010/257/eh_db_5b.pdf</description>
-<wire x1="0" y1="-0.7" x2="0" y2="0.6" width="0.127" layer="48"/>
-<wire x1="0" y1="0.6" x2="-0.2" y2="0.2" width="0.127" layer="48"/>
-<wire x1="-0.2" y1="0.2" x2="0.2" y2="0.2" width="0.127" layer="48"/>
-<wire x1="0.2" y1="0.2" x2="0" y2="0.6" width="0.127" layer="48"/>
-<wire x1="0" y1="-0.7" x2="0.2" y2="-0.3" width="0.127" layer="48"/>
-<wire x1="0.2" y1="-0.3" x2="-0.2" y2="-0.3" width="0.127" layer="48"/>
-<wire x1="-0.2" y1="-0.3" x2="0" y2="-0.7" width="0.127" layer="48"/>
-<wire x1="-0.5" y1="0.45" x2="-0.9" y2="0.45" width="0.2032" layer="21"/>
-<wire x1="-0.9" y1="0.45" x2="-0.9" y2="-0.2" width="0.2032" layer="21"/>
-<wire x1="0.5" y1="0.45" x2="0.9" y2="0.45" width="0.2032" layer="21"/>
-<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.2" width="0.2032" layer="21"/>
-<wire x1="-0.9" y1="-0.25" x2="-0.9" y2="-0.45" width="0.2032" layer="51"/>
-<wire x1="-0.9" y1="-0.45" x2="0.9" y2="-0.45" width="0.2032" layer="51"/>
-<wire x1="0.9" y1="-0.45" x2="0.9" y2="-0.25" width="0.2032" layer="51"/>
-<wire x1="-0.5" y1="0.45" x2="0.5" y2="0.45" width="0.2032" layer="51"/>
-<smd name="1" x="-0.65" y="-0.8" dx="1" dy="0.8" layer="1" rot="R90"/>
-<smd name="2" x="0" y="0.8" dx="1" dy="0.8" layer="1" rot="R90"/>
-<smd name="3" x="0.65" y="-0.8" dx="1" dy="0.8" layer="1" rot="R90"/>
-<text x="0.635" y="0.9525" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-0.9525" y="-2.2225" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="0.4" y="0.4" size="0.254" layer="48">direction of pcb</text>
-<text x="0.4" y="-0.05" size="0.254" layer="48">transportation for</text>
-<text x="0.4" y="-0.5" size="0.254" layer="48">wavesoldering</text>
-<rectangle x1="-0.95" y1="-0.95" x2="-0.35" y2="-0.65" layer="51" rot="R90"/>
-<rectangle x1="0.35" y1="-0.95" x2="0.95" y2="-0.65" layer="51" rot="R90"/>
-<rectangle x1="-0.3" y1="0.65" x2="0.3" y2="0.95" layer="51" rot="R90"/>
-</package>
-<package name="SOT323R_INFINEON">
-<description>&lt;b&gt;Small Outline Transistor&lt;/b&gt; Reflow soldering&lt;p&gt;
-INFINEON, www.infineon.com/cmc_upload/0/000/010/257/eh_db_5b.pdf</description>
-<wire x1="-0.5" y1="0.45" x2="-0.9" y2="0.45" width="0.2032" layer="21"/>
-<wire x1="-0.9" y1="0.45" x2="-0.9" y2="-0.2" width="0.2032" layer="21"/>
-<wire x1="0.5" y1="0.45" x2="0.9" y2="0.45" width="0.2032" layer="21"/>
-<wire x1="0.9" y1="0.45" x2="0.9" y2="-0.2" width="0.2032" layer="21"/>
-<wire x1="-0.9" y1="-0.25" x2="-0.9" y2="-0.45" width="0.2032" layer="51"/>
-<wire x1="-0.9" y1="-0.45" x2="0.9" y2="-0.45" width="0.2032" layer="51"/>
-<wire x1="0.9" y1="-0.45" x2="0.9" y2="-0.25" width="0.2032" layer="51"/>
-<wire x1="-0.5" y1="0.45" x2="0.5" y2="0.45" width="0.2032" layer="51"/>
-<smd name="1" x="-0.65" y="-0.8" dx="0.6" dy="0.8" layer="1"/>
-<smd name="2" x="0" y="0.8" dx="0.6" dy="0.8" layer="1"/>
-<smd name="3" x="0.65" y="-0.8" dx="0.6" dy="0.8" layer="1"/>
-<text x="0.9525" y="0.9525" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-0.9525" y="-2.2225" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="-0.95" y1="-0.95" x2="-0.35" y2="-0.65" layer="51" rot="R90"/>
-<rectangle x1="0.35" y1="-0.95" x2="0.95" y2="-0.65" layer="51" rot="R90"/>
-<rectangle x1="-0.3" y1="0.65" x2="0.3" y2="0.95" layer="51" rot="R90"/>
 </package>
 <package name="SCT595_INFINEON">
 <description>&lt;b&gt;Small Outline Transistor; 5 leads&lt;/b&gt; Reflow soldering&lt;p&gt;
@@ -2663,11 +2324,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54A">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
+<connect gate="1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2699,11 +2360,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="JFETN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92F">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G" pad="G"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="D" pad="3"/>
+<connect gate="1" pin="G" pad="2"/>
+<connect gate="1" pin="S" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2717,11 +2378,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="JFETP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92F">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G" pad="G"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="D" pad="3"/>
+<connect gate="1" pin="G" pad="2"/>
+<connect gate="1" pin="S" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2754,11 +2415,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92D">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2790,11 +2451,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92D">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2808,11 +2469,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54A">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
+<connect gate="1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2826,11 +2487,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92D">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2973,11 +2634,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="JFETN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92R">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G" pad="G"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="D" pad="3"/>
+<connect gate="1" pin="G" pad="1"/>
+<connect gate="1" pin="S" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3027,11 +2688,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92D">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3063,11 +2724,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="JFETN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92G">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G" pad="G"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="D" pad="1"/>
+<connect gate="1" pin="G" pad="3"/>
+<connect gate="1" pin="S" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3099,11 +2760,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="JFETN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92R">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G" pad="G"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="D" pad="3"/>
+<connect gate="1" pin="G" pad="1"/>
+<connect gate="1" pin="S" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3135,11 +2796,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="JFETN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54C">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G" pad="G"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="D" pad="3"/>
+<connect gate="1" pin="G" pad="1"/>
+<connect gate="1" pin="S" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3153,11 +2814,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="UJTN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92E">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B1" pad="B1"/>
-<connect gate="1" pin="B2" pad="B2"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B1" pad="1"/>
+<connect gate="1" pin="B2" pad="3"/>
+<connect gate="1" pin="E" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3207,11 +2868,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92C">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="3"/>
+<connect gate="1" pin="C" pad="2"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3261,11 +2922,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54A">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
+<connect gate="1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3279,11 +2940,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54A">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
+<connect gate="1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3297,11 +2958,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="P-DAR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54A">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
+<connect gate="1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3315,11 +2976,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="N-DAR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54A">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
+<connect gate="1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3333,11 +2994,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92D">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3351,11 +3012,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92D">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3406,11 +3067,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54A">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
+<connect gate="1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3424,11 +3085,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54A">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
+<connect gate="1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3442,11 +3103,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54D">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="3"/>
+<connect gate="1" pin="C" pad="2"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3460,11 +3121,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54D">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="3"/>
+<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3478,11 +3139,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54D">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="3"/>
+<connect gate="1" pin="C" pad="2"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3496,11 +3157,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54D">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="3"/>
+<connect gate="1" pin="C" pad="2"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3551,11 +3212,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="IGFNA" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54E">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G" pad="G"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="D" pad="1"/>
+<connect gate="1" pin="G" pad="2"/>
+<connect gate="1" pin="S" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3569,11 +3230,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="IGFPA" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54E">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G" pad="G"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="D" pad="1"/>
+<connect gate="1" pin="G" pad="2"/>
+<connect gate="1" pin="S" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3738,21 +3399,21 @@ Small Signal SM Transistor</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-R" package="SOT323R_INFINEON">
+<device name="-R" package="SC70-3">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
-<connect gate="G$1" pin="C" pad="2"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-W" package="SOT323W_INFINEON">
+<device name="-W" package="SC70-3">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
-<connect gate="G$1" pin="C" pad="2"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3767,21 +3428,21 @@ Small Signal SM Transistor</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-R" package="SOT323R_INFINEON">
+<device name="-R" package="SC70-3">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
-<connect gate="G$1" pin="C" pad="2"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-W" package="SOT323W_INFINEON">
+<device name="-W" package="SC70-3">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
-<connect gate="G$1" pin="C" pad="2"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/transistor.lbr
+++ b/transistor.lbr
@@ -78,37 +78,6 @@
 <description>&lt;b&gt;NPN Transistors&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="TO92/">
-<description>&lt;b&gt;TO-92&lt;/b&gt; Diagonal grid 2.54 mm&lt;p&gt;</description>
-<wire x1="-2.649" y1="0.314" x2="0.314" y2="-2.649" width="0.2032" layer="21"/>
-<wire x1="-1.1494" y1="2.4066" x2="1.1494" y2="2.4066" width="0.2032" layer="21" curve="-51.058586" cap="flat"/>
-<wire x1="-0.557" y1="0.377" x2="0.377" y2="-0.557" width="0.2032" layer="21"/>
-<wire x1="-2.4066" y1="1.1494" x2="-1.1494" y2="2.4066" width="0.2032" layer="51" curve="-38.941414" cap="flat"/>
-<wire x1="-2.649" y1="0.314" x2="-2.4071" y2="1.1498" width="0.2032" layer="21" curve="-18.776471" cap="flat"/>
-<wire x1="-1.974" y1="1.794" x2="-0.557" y2="0.377" width="0.2032" layer="51"/>
-<wire x1="2.4066" y1="-1.1494" x2="2.4066" y2="1.1494" width="0.2032" layer="21" curve="51.058586" cap="flat"/>
-<wire x1="1.1494" y1="-2.4066" x2="2.4066" y2="-1.1494" width="0.2032" layer="51" curve="38.941414" cap="flat"/>
-<wire x1="0.377" y1="-0.557" x2="1.794" y2="-1.974" width="0.2032" layer="51"/>
-<wire x1="0.314" y1="-2.649" x2="1.1498" y2="-2.4071" width="0.2032" layer="21" curve="18.776471" cap="flat"/>
-<wire x1="1.1494" y1="2.4066" x2="2.4066" y2="1.1494" width="0.2032" layer="51" curve="-38.941414" cap="flat"/>
-<pad name="3" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="1" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="3.048" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-4.318" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-EBC">
-<description>&lt;b&gt;TO-92&lt;/b&gt; Pads In Line</description>
-<pad name="C" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="E" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="B" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="TO3">
 <description>&lt;b&gt;TO-3&lt;/b&gt;</description>
 <wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
@@ -276,17 +245,21 @@ grid 2.54 mm, vertical</description>
 <text x="0.635" y="-1.27" size="1.27" layer="51" ratio="10">2</text>
 <text x="0" y="0.635" size="1.27" layer="51" ratio="10">3</text>
 </package>
-<package name="TO92">
-<description>&lt;b&gt;TO-92&lt;/b&gt; Pads Triangle</description>
-<pad name="1" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<package name="TO92-AB">
+<description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement. JEDEC TO-226G, variation AB.
+&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
 <wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 <wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 </package>
 <package name="TO218">
 <description>&lt;b&gt;TO-218&lt;/b&gt;&lt;p&gt;
@@ -767,18 +740,6 @@ grid 2.54 mm, vertical</description>
 <rectangle x1="-0.3175" y1="-7.9375" x2="0.3175" y2="-6.985" layer="21"/>
 <hole x="0" y="0" drill="3.048"/>
 </package>
-<package name="TO92-E1">
-<description>&lt;b&gt;TO-92&lt;/b&gt; Pads Triangle Reverse</description>
-<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="SOT89-ECB">
 <description>SOT98 Emitter Collector Basis</description>
 <wire x1="2.235" y1="-1.245" x2="-2.235" y2="-1.245" width="0.2032" layer="51"/>
@@ -897,81 +858,23 @@ grid 2.54 mm, vertical</description>
 <text x="-9.5" y="-5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-1" y="-5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="TO92-BCE">
-<description>&lt;b&gt;TO-92&lt;/b&gt; Pads In Line</description>
-<wire x1="-2.095" y1="-1.651" x2="2.095" y2="-1.651" width="0.2032" layer="21"/>
+<package name="TO92-AA">
+<description>&lt;b&gt;TO-92 (2.54mm lead pitch, 3 leads, vertical, linear pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 2.54mm lead pitch, 3 leads, vertical, linear pad arrangement. JEDEC TO-226G, variation AA.
+&lt;/p&gt;&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-2.54" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<pad name="2" x="0" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<pad name="3" x="2.54" y="0.02" drill="0.8128" shape="long" rot="R90"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-2.4135" y1="-1.1159" x2="-2.095" y2="-1.631" width="0.2032" layer="21" curve="13.038528" cap="flat"/>
 <wire x1="-2.413" y1="1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="21" curve="-129.583345" cap="flat"/>
-<wire x1="1.136" y1="-0.127" x2="-1.136" y2="-0.127" width="0.2032" layer="51"/>
 <wire x1="-2.413" y1="1.1359" x2="-2.413" y2="-1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="-1.404" y1="-0.127" x2="-2.664" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="-2.4135" y1="-1.1359" x2="-2.095" y2="-1.651" width="0.2032" layer="21" curve="13.038528" cap="flat"/>
-<wire x1="-1.136" y1="-0.127" x2="-1.404" y2="-0.127" width="0.2032" layer="21"/>
+<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="2.095" y1="-1.631" x2="2.4247" y2="-1.0918" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
 <wire x1="2.413" y1="-1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="2.664" y1="-0.127" x2="1.404" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="1.404" y1="-0.127" x2="1.136" y2="-0.127" width="0.2032" layer="21"/>
-<wire x1="2.095" y1="-1.651" x2="2.4247" y2="-1.1118" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
-<pad name="C" x="0" y="0" drill="0.8128" shape="long" rot="R90"/>
-<pad name="E" x="-2.54" y="0" drill="0.8128" shape="long" rot="R90"/>
-<pad name="B" x="2.54" y="0" drill="0.8128" shape="long" rot="R90"/>
-<text x="-2.54" y="3.048" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-3.302" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-CBE">
-<description>&lt;b&gt;TO-92&lt;/b&gt; Pads In Line</description>
-<wire x1="-2.095" y1="-1.651" x2="2.095" y2="-1.651" width="0.2032" layer="21"/>
-<wire x1="-2.413" y1="1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="21" curve="-129.583345" cap="flat"/>
-<wire x1="1.136" y1="-0.127" x2="-1.136" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="-2.413" y1="1.1359" x2="-2.413" y2="-1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="-1.404" y1="-0.127" x2="-2.664" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="-2.4135" y1="-1.1359" x2="-2.095" y2="-1.651" width="0.2032" layer="21" curve="13.038528" cap="flat"/>
-<wire x1="-1.136" y1="-0.127" x2="-1.404" y2="-0.127" width="0.2032" layer="21"/>
-<wire x1="2.413" y1="-1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="2.664" y1="-0.127" x2="1.404" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="1.404" y1="-0.127" x2="1.136" y2="-0.127" width="0.2032" layer="21"/>
-<wire x1="2.095" y1="-1.651" x2="2.4247" y2="-1.1118" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
-<pad name="C" x="2.54" y="0" drill="0.8128" shape="long" rot="R90"/>
-<pad name="E" x="-2.54" y="0" drill="0.8128" shape="long" rot="R90"/>
-<pad name="B" x="0" y="0" drill="0.8128" shape="long" rot="R90"/>
-<text x="-2.54" y="3.048" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-3.302" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-BEC">
-<description>&lt;b&gt;TO-92&lt;/b&gt; Pads In Line</description>
-<wire x1="-2.095" y1="-1.651" x2="2.095" y2="-1.651" width="0.2032" layer="21"/>
-<wire x1="-2.413" y1="1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="21" curve="-129.583345" cap="flat"/>
-<wire x1="1.136" y1="-0.127" x2="-1.136" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="-2.413" y1="1.1359" x2="-2.413" y2="-1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="-1.404" y1="-0.127" x2="-2.664" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="-2.4135" y1="-1.1359" x2="-2.095" y2="-1.651" width="0.2032" layer="21" curve="13.038528" cap="flat"/>
-<wire x1="-1.136" y1="-0.127" x2="-1.404" y2="-0.127" width="0.2032" layer="21"/>
-<wire x1="2.413" y1="-1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="2.664" y1="-0.127" x2="1.404" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="1.404" y1="-0.127" x2="1.136" y2="-0.127" width="0.2032" layer="21"/>
-<wire x1="2.095" y1="-1.651" x2="2.4247" y2="-1.1118" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
-<pad name="C" x="2.54" y="0" drill="0.8128" shape="long" rot="R90"/>
-<pad name="E" x="0" y="0" drill="0.8128" shape="long" rot="R90"/>
-<pad name="B" x="-2.54" y="0" drill="0.8128" shape="long" rot="R90"/>
-<text x="-2.54" y="3.048" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-3.302" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-CEB">
-<description>&lt;b&gt;TO-92&lt;/b&gt; Pads In Line</description>
-<wire x1="-2.095" y1="-1.651" x2="2.095" y2="-1.651" width="0.2032" layer="21"/>
-<wire x1="-2.413" y1="1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="21" curve="-129.583345" cap="flat"/>
-<wire x1="1.136" y1="-0.127" x2="-1.136" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="-2.413" y1="1.1359" x2="-2.413" y2="-1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="-1.404" y1="-0.127" x2="-2.664" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="-2.4135" y1="-1.1359" x2="-2.095" y2="-1.651" width="0.2032" layer="21" curve="13.038528" cap="flat"/>
-<wire x1="-1.136" y1="-0.127" x2="-1.404" y2="-0.127" width="0.2032" layer="21"/>
-<wire x1="2.413" y1="-1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="2.664" y1="-0.127" x2="1.404" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="1.404" y1="-0.127" x2="1.136" y2="-0.127" width="0.2032" layer="21"/>
-<wire x1="2.095" y1="-1.651" x2="2.4247" y2="-1.1118" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
-<pad name="C" x="2.54" y="0" drill="0.8128" shape="long" rot="R90"/>
-<pad name="E" x="0" y="0" drill="0.8128" shape="long" rot="R90"/>
-<pad name="B" x="-2.54" y="0" drill="0.8128" shape="long" rot="R90"/>
-<text x="-2.54" y="3.048" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-3.302" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="SOT89-BCE">
 <description>SOT98 Basis Collector Emitter</description>
@@ -1854,11 +1757,11 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1890,10 +1793,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="1"/>
-<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="B" pad="3"/>
+<connect gate="G$1" pin="C" pad="1"/>
 <connect gate="G$1" pin="E" pad="2"/>
 </connects>
 <technologies>
@@ -1908,11 +1811,11 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <gate name="G$1" symbol="NPN-DAR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1944,11 +1847,11 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="1"/>
+<connect gate="G$1" pin="B" pad="3"/>
 <connect gate="G$1" pin="C" pad="2"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2052,11 +1955,11 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2070,11 +1973,11 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2088,11 +1991,11 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3614,11 +3517,11 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <gate name="G$1" symbol="NPN" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3632,11 +3535,11 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <gate name="G$1" symbol="NPN" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3704,11 +3607,11 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3722,11 +3625,11 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3758,11 +3661,11 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <gate name="G1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G1" pin="B" pad="2"/>
-<connect gate="G1" pin="C" pad="1"/>
-<connect gate="G1" pin="E" pad="3"/>
+<connect gate="G1" pin="C" pad="3"/>
+<connect gate="G1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4195,21 +4098,21 @@ common emitter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TO92" package="TO92">
+<device name="TO92" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TO92-EBC" package="TO92-EBC">
+<device name="TO92-EBC" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name="BC337"/>
@@ -4240,7 +4143,7 @@ common emitter</description>
 <technology name="BCX59"/>
 </technologies>
 </device>
-<device name="TO92-E1" package="TO92-E1">
+<device name="TO92-E1" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
 <connect gate="G$1" pin="C" pad="1"/>
@@ -4367,11 +4270,11 @@ common emitter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TO92-BCE" package="TO92-BCE">
+<device name="TO92-BCE" package="TO92-AA">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="3"/>
+<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name="BC368"/>
@@ -4382,11 +4285,11 @@ common emitter</description>
 <technology name="BF422"/>
 </technologies>
 </device>
-<device name="TO92-CBE" package="TO92-CBE">
+<device name="TO92-CBE" package="TO92-AA">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name="2N4124"/>
@@ -4417,11 +4320,11 @@ common emitter</description>
 <technology name="MPSW42"/>
 </technologies>
 </device>
-<device name="TO92-BEC" package="TO92-BEC">
+<device name="TO92-BEC" package="TO92-AA">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="1"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="2"/>
 </connects>
 <technologies>
 <technology name="BF199"/>
@@ -4430,11 +4333,11 @@ common emitter</description>
 <technology name="BF959"/>
 </technologies>
 </device>
-<device name="TO92-CEB" package="TO92-CEB">
+<device name="TO92-CEB" package="TO92-AA">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="1"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="2"/>
 </connects>
 <technologies>
 <technology name="BF374"/>
@@ -4678,21 +4581,21 @@ common emitter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TO92" package="TO92">
+<device name="TO92" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TO92-EBC" package="TO92-EBC">
+<device name="TO92-EBC" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name="BC327"/>
@@ -4723,7 +4626,7 @@ common emitter</description>
 <technology name="BCX79"/>
 </technologies>
 </device>
-<device name="TO92-E1" package="TO92-E1">
+<device name="TO92-E1" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
 <connect gate="G$1" pin="C" pad="1"/>
@@ -4733,11 +4636,11 @@ common emitter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TO92/" package="TO92/">
+<device name="TO92/" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
+<connect gate="G$1" pin="C" pad="1"/>
+<connect gate="G$1" pin="E" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4825,11 +4728,11 @@ common emitter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TO92-BCE" package="TO92-BCE">
+<device name="TO92-BCE" package="TO92-AA">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="3"/>
+<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name="BC369"/>
@@ -4841,11 +4744,11 @@ common emitter</description>
 <technology name="MPSA56"/>
 </technologies>
 </device>
-<device name="TO92-CBE" package="TO92-CBE">
+<device name="TO92-CBE" package="TO92-AA">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name="2N4126"/>
@@ -4855,21 +4758,21 @@ common emitter</description>
 <technology name="MPSW92"/>
 </technologies>
 </device>
-<device name="TO92-BEC" package="TO92-BEC">
+<device name="TO92-BEC" package="TO92-AA">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="1"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TO92-CEB" package="TO92-CEB">
+<device name="TO92-CEB" package="TO92-AA">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="1"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/transistor.lbr
+++ b/transistor.lbr
@@ -109,25 +109,6 @@
 <text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="TO92L">
-<description>&lt;b&gt;TO-92&lt;/b&gt; Grid 5.08</description>
-<wire x1="-2.413" y1="-1.1359" x2="-2.413" y2="1.1359" width="0.2032" layer="51" curve="-50.416655" cap="flat"/>
-<wire x1="2.413" y1="-1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="-2.095" y1="-1.651" x2="2.095" y2="-1.651" width="0.2032" layer="21"/>
-<wire x1="1.404" y1="-0.127" x2="-1.404" y2="-0.127" width="0.2032" layer="21"/>
-<wire x1="2.664" y1="-0.127" x2="1.404" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="2.095" y1="-1.651" x2="2.4247" y2="-1.1118" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
-<wire x1="-1.404" y1="-0.127" x2="-2.664" y2="-0.127" width="0.2032" layer="51"/>
-<wire x1="-2.095" y1="-1.651" x2="-2.4135" y2="-1.1359" width="0.2032" layer="21" curve="-13.037954" cap="flat"/>
-<wire x1="1.1359" y1="2.413" x2="-1.1359" y2="2.413" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
-<wire x1="2.413" y1="1.1359" x2="1.1359" y2="2.413" width="0.2032" layer="21" curve="39.581288" cap="flat"/>
-<wire x1="-2.413" y1="1.1359" x2="-1.1359" y2="2.413" width="0.2032" layer="21" curve="-39.585403" cap="flat"/>
-<pad name="1" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="3" x="-2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<pad name="2" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon" rot="R90"/>
-<text x="-1.524" y="3.556" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.524" y="-3.683" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="TO3">
 <description>&lt;b&gt;TO-3&lt;/b&gt;</description>
 <wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
@@ -4269,16 +4250,6 @@ common emitter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TO92L" package="TO92L">
-<connects>
-<connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
 <device name="TOP3" package="TOP3">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
@@ -4763,16 +4734,6 @@ common emitter</description>
 </technologies>
 </device>
 <device name="TO92/" package="TO92/">
-<connects>
-<connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="TO92L" package="TO92L">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
 <connect gate="G$1" pin="C" pad="3"/>

--- a/triac.lbr
+++ b/triac.lbr
@@ -157,27 +157,6 @@ Also known as SOT78.</description>
 <wire x1="4.699" y1="-4.318" x2="-4.699" y2="-4.318" width="0.2032" layer="21"/>
 <wire x1="5.08" y1="-1.143" x2="4.953" y2="-4.064" width="0.2032" layer="21"/>
 </package>
-<package name="TIC106S">
-<wire x1="4.826" y1="-4.318" x2="5.08" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="4.826" y1="-4.318" x2="-4.826" y2="-4.318" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="-4.064" x2="-4.826" y2="-4.318" width="0.2032" layer="21"/>
-<wire x1="5.08" y1="-1.143" x2="5.08" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="-4.064" x2="-5.08" y2="-1.143" width="0.2032" layer="21"/>
-<circle x="-4.6228" y="-3.7084" radius="0.254" width="0" layer="21"/>
-<pad name="C" x="-2.54" y="-2.54" drill="1.016" shape="long" rot="R90"/>
-<pad name="A" x="0" y="-2.54" drill="1.016" shape="long" rot="R90"/>
-<pad name="G" x="2.54" y="-2.54" drill="1.016" shape="long" rot="R90"/>
-<text x="-5.08" y="-6.0452" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-5.08" y="-7.62" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="-5.334" y1="-0.635" x2="5.334" y2="0" layer="21"/>
-<rectangle x1="-5.334" y1="-1.27" x2="-3.429" y2="-0.635" layer="21"/>
-<rectangle x1="-1.651" y1="-1.27" x2="-0.889" y2="-0.635" layer="21"/>
-<rectangle x1="0.889" y1="-1.27" x2="1.651" y2="-0.635" layer="21"/>
-<rectangle x1="3.429" y1="-1.27" x2="5.334" y2="-0.635" layer="21"/>
-<rectangle x1="-3.429" y1="-1.27" x2="-1.651" y2="-0.635" layer="51"/>
-<rectangle x1="-0.889" y1="-1.27" x2="0.889" y2="-0.635" layer="51"/>
-<rectangle x1="1.651" y1="-1.27" x2="3.429" y2="-0.635" layer="51"/>
-</package>
 <package name="GT32">
 <wire x1="2.032" y1="-1.27" x2="-2.032" y2="-1.27" width="0.2032" layer="21"/>
 <wire x1="2.032" y1="-1.27" x2="2.032" y2="1.27" width="0.2032" layer="21"/>
@@ -319,60 +298,21 @@ Also known as SOT78.</description>
 <rectangle x1="-1.905" y1="-2.032" x2="1.905" y2="-1.016" layer="51"/>
 <rectangle x1="3.556" y1="-2.032" x2="7.239" y2="-1.016" layer="51"/>
 </package>
-<package name="TO92-1">
+<package name="TO92-AB">
+<description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement. JEDEC TO-226G, variation AB.
+&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
 <wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 <wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="B1" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="E" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="B2" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-2">
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
 <wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="C" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="G" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="A" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-3">
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="A1" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="G" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="A2" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-4">
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="A" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="G" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="C" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="SOT54">
-<wire x1="-0.9692" y1="2.2098" x2="0.9692" y2="2.2098" width="0.2032" layer="51" curve="-47.363718" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="-0.9689" y2="2.2098" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="0.9689" y1="2.2098" x2="1.631" y2="-1.778" width="0.2032" layer="21" curve="-113.782137" cap="flat"/>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<pad name="A" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="G" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="C" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 </package>
 <package name="SOT93L">
 <wire x1="-7.493" y1="-6.35" x2="7.493" y2="-6.35" width="0.2032" layer="21"/>
@@ -517,28 +457,6 @@ Also known as SOT78.</description>
 <rectangle x1="4.953" y1="-5.588" x2="6.223" y2="-3.81" layer="21"/>
 <rectangle x1="4.953" y1="-7.62" x2="6.223" y2="-5.588" layer="51"/>
 <hole x="0" y="12.7" drill="4.1148"/>
-</package>
-<package name="TO92-5">
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="G" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="A" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="C" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92-6">
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="G" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="A2" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="A1" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="TO220CSH">
 <wire x1="4.699" y1="-4.318" x2="4.953" y2="-4.064" width="0.2032" layer="21"/>
@@ -1104,11 +1022,11 @@ Also known as SOT78.</description>
 <gate name="1" symbol="THYR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TIC106S">
+<device name="" package="TO220-AB">
 <connects>
-<connect gate="1" pin="A" pad="A"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="G" pad="G"/>
+<connect gate="1" pin="A" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
+<connect gate="1" pin="G" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1156,11 +1074,11 @@ Also known as SOT78.</description>
 <gate name="1" symbol="THYR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOT54">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="A" pad="A"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="G" pad="G"/>
+<connect gate="1" pin="A" pad="1"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="G" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1228,11 +1146,11 @@ Also known as SOT78.</description>
 <gate name="1" symbol="THYR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-4">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="A" pad="A"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="G" pad="G"/>
+<connect gate="1" pin="A" pad="1"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="G" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1246,11 +1164,11 @@ Also known as SOT78.</description>
 <gate name="1" symbol="THYR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-2">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="A" pad="A"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="G" pad="G"/>
+<connect gate="1" pin="A" pad="3"/>
+<connect gate="1" pin="C" pad="1"/>
+<connect gate="1" pin="G" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1318,11 +1236,11 @@ Also known as SOT78.</description>
 <gate name="1" symbol="THYR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-5">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="A" pad="A"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="G" pad="G"/>
+<connect gate="1" pin="A" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="G" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1372,11 +1290,11 @@ Also known as SOT78.</description>
 <gate name="1" symbol="TRIAC" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-6">
+<device name="" package="TO92-AB">
 <connects>
-<connect gate="1" pin="A1" pad="A1"/>
-<connect gate="1" pin="A2" pad="A2"/>
-<connect gate="1" pin="G" pad="G"/>
+<connect gate="1" pin="A1" pad="3"/>
+<connect gate="1" pin="A2" pad="2"/>
+<connect gate="1" pin="G" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/v-reg.lbr
+++ b/v-reg.lbr
@@ -76,17 +76,21 @@
 <description>&lt;b&gt;Voltage Regulators&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="TO92">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
+<package name="TO92-AB">
+<description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
+Header family flat index. 1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement. JEDEC TO-226G, variation AB.
+&lt;p&gt;
+Also known as SOT54. Formerly standardized as JEDEC TO-92.
+&lt;/p&gt;</description>
 <pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
+<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
+<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 </package>
 <package name="TO220-AB">
 <description>&lt;b&gt;TO-220 AB (2.54mm lead pitch, 3 leads, exposed pad, vertical)&lt;/b&gt;&lt;p&gt;
@@ -149,40 +153,6 @@ Also known as SOT78.</description>
 <wire x1="5.207" y1="11.176" x2="4.318" y2="11.176" width="0.2032" layer="21"/>
 <wire x1="5.207" y1="12.7" x2="5.207" y2="14.605" width="0.2032" layer="21"/>
 <wire x1="5.207" y1="14.605" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
-</package>
-<package name="78LXX">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="-2.0946" y1="-1.651" x2="-0.7863" y2="2.5485" width="0.1778" layer="21" curve="-111.098957" cap="flat"/>
-<wire x1="0.7868" y1="2.5484" x2="2.095" y2="-1.651" width="0.1778" layer="21" curve="-111.09954" cap="flat"/>
-<wire x1="-2.095" y1="-1.651" x2="2.095" y2="-1.651" width="0.2032" layer="21"/>
-<wire x1="-2.655" y1="-0.254" x2="-2.254" y2="-0.254" width="0.2032" layer="21"/>
-<wire x1="2.254" y1="-0.254" x2="2.655" y2="-0.254" width="0.2032" layer="21"/>
-<wire x1="-0.7863" y1="2.5485" x2="0.7863" y2="2.5485" width="0.2032" layer="51" curve="-34.293591" cap="flat"/>
-<pad name="1" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="3" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="-0.635" y="0.889" size="1.27" layer="51" ratio="10">G</text>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.778" y="-0.635" size="1.27" layer="51" ratio="10">O</text>
-<text x="0.635" y="-0.635" size="1.27" layer="51" ratio="10">I</text>
-</package>
-<package name="79LXX">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="-2.0946" y1="-1.651" x2="-0.7863" y2="2.5485" width="0.1778" layer="21" curve="-111.098957" cap="flat"/>
-<wire x1="0.7868" y1="2.5484" x2="2.095" y2="-1.651" width="0.1778" layer="21" curve="-111.09954" cap="flat"/>
-<wire x1="-2.095" y1="-1.651" x2="2.095" y2="-1.651" width="0.2032" layer="21"/>
-<wire x1="-2.655" y1="-0.254" x2="-2.254" y2="-0.254" width="0.2032" layer="21"/>
-<wire x1="2.254" y1="-0.254" x2="2.655" y2="-0.254" width="0.2032" layer="21"/>
-<wire x1="-0.7863" y1="2.5485" x2="0.7863" y2="2.5485" width="0.2032" layer="51" curve="-34.293591" cap="flat"/>
-<pad name="1" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="3" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.778" y="-0.635" size="1.27" layer="51" ratio="10">G</text>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="0.635" y="-0.635" size="1.27" layer="51" ratio="10">O</text>
-<text x="-0.635" y="0.889" size="1.27" layer="51" ratio="10">I</text>
 </package>
 <package name="TO3-78">
 <description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
@@ -478,40 +448,6 @@ Also known as SOT78.</description>
 <rectangle x1="-2.921" y1="-5.08" x2="-2.159" y2="-3.429" layer="51"/>
 <hole x="0" y="17.78" drill="3.048"/>
 </package>
-<package name="317L">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="-2.0946" y1="-1.651" x2="-0.7863" y2="2.5485" width="0.1778" layer="21" curve="-111.098957" cap="flat"/>
-<wire x1="0.7868" y1="2.5484" x2="2.095" y2="-1.651" width="0.1778" layer="21" curve="-111.09954" cap="flat"/>
-<wire x1="-2.095" y1="-1.651" x2="2.095" y2="-1.651" width="0.2032" layer="21"/>
-<wire x1="-2.655" y1="-0.254" x2="-2.254" y2="-0.254" width="0.2032" layer="21"/>
-<wire x1="2.254" y1="-0.254" x2="2.655" y2="-0.254" width="0.2032" layer="21"/>
-<wire x1="-0.7863" y1="2.5485" x2="0.7863" y2="2.5485" width="0.2032" layer="51" curve="-34.293591" cap="flat"/>
-<pad name="1" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="3" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="-0.635" y="0.889" size="1.27" layer="51" ratio="10">O</text>
-<text x="0.635" y="-0.635" size="1.27" layer="51" ratio="10">I</text>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.905" y="-0.635" size="1.27" layer="51" ratio="10">A</text>
-</package>
-<package name="337L">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="-2.0946" y1="-1.651" x2="-0.7863" y2="2.5485" width="0.1778" layer="21" curve="-111.098957" cap="flat"/>
-<wire x1="0.7868" y1="2.5484" x2="2.095" y2="-1.651" width="0.1778" layer="21" curve="-111.09954" cap="flat"/>
-<wire x1="-2.095" y1="-1.651" x2="2.095" y2="-1.651" width="0.2032" layer="21"/>
-<wire x1="-2.655" y1="-0.254" x2="-2.254" y2="-0.254" width="0.2032" layer="21"/>
-<wire x1="2.254" y1="-0.254" x2="2.655" y2="-0.254" width="0.2032" layer="21"/>
-<wire x1="-0.7863" y1="2.5485" x2="0.7863" y2="2.5485" width="0.2032" layer="51" curve="-34.293591" cap="flat"/>
-<pad name="1" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="3" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="-0.635" y="0.889" size="1.27" layer="51" ratio="10">O</text>
-<text x="0.635" y="-0.635" size="1.27" layer="51" ratio="10">I</text>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.905" y="-0.635" size="1.27" layer="51" ratio="10">A</text>
-</package>
 <package name="79MXXL">
 <description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
 <wire x1="-5.207" y1="-1.27" x2="-5.207" y2="7.3406" width="0.2032" layer="21"/>
@@ -673,51 +609,6 @@ L200.pdf from www.st.com</description>
 <rectangle x1="-3.937" y1="-8.509" x2="-2.921" y2="-7.366" layer="51"/>
 <rectangle x1="-0.508" y1="-7.366" x2="0.508" y2="-4.826" layer="21"/>
 <rectangle x1="-3.937" y1="-7.366" x2="-2.921" y2="-4.826" layer="21"/>
-</package>
-<package name="TO92A">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="0.635" y="-0.635" size="1.27" layer="51" ratio="10">I</text>
-<text x="-0.635" y="0.635" size="1.27" layer="51" ratio="10">-</text>
-<text x="-1.905" y="-0.635" size="1.27" layer="51" ratio="10">O</text>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO92B">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="0.635" y="-0.635" size="1.27" layer="51" ratio="10">I</text>
-<text x="-0.635" y="0.635" size="1.27" layer="51" ratio="10">O</text>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.905" y="-0.635" size="1.27" layer="51" ratio="10">A</text>
-</package>
-<package name="TO92-CLP">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
-<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
-<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
-<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-0.3175" y="0.635" size="0.8128" layer="51">A</text>
-<text x="-1.5875" y="-1.27" size="0.8128" layer="51">R</text>
-<text x="0.9525" y="-1.27" size="0.8128" layer="51">C</text>
 </package>
 <package name="TO3-K02">
 <description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
@@ -2892,7 +2783,7 @@ horizontal, no mount hole.</description>
 <gate name="1" symbol="78XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="LP" package="78LXX">
+<device name="LP" package="TO92-AB">
 <connects>
 <connect gate="1" pin="GND" pad="2"/>
 <connect gate="1" pin="IN" pad="3"/>
@@ -2920,7 +2811,7 @@ horizontal, no mount hole.</description>
 <gate name="A" symbol="79XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="79LXX">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="A" pin="GND" pad="1"/>
 <connect gate="A" pin="IN" pad="2"/>
@@ -2974,7 +2865,7 @@ horizontal, no mount hole.</description>
 <gate name="A" symbol="78ADJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="317L">
+<device name="P" package="TO92-AB">
 <connects>
 <connect gate="A" pin="ADJ" pad="1"/>
 <connect gate="A" pin="IN" pad="3"/>
@@ -3002,7 +2893,7 @@ horizontal, no mount hole.</description>
 <gate name="A" symbol="79ADJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="337L">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="A" pin="ADJ" pad="1"/>
 <connect gate="A" pin="IN" pad="3"/>
@@ -3309,7 +3200,7 @@ horizontal, no mount hole.</description>
 <gate name="G$1" symbol="TL431LP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92-CLP">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="A" pad="2"/>
 <connect gate="G$1" pin="C" pad="3"/>
@@ -3593,11 +3484,11 @@ horizontal, no mount hole.</description>
 <gate name="G$1" symbol="78XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO92">
+<device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
-<connect gate="G$1" pin="IN" pad="3"/>
-<connect gate="G$1" pin="OUT" pad="1"/>
+<connect gate="G$1" pin="IN" pad="1"/>
+<connect gate="G$1" pin="OUT" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3676,7 +3567,7 @@ horizontal, no mount hole.</description>
 <gate name="A" symbol="ZMR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="C" package="TO92A">
+<device name="C" package="TO92-AB">
 <connects>
 <connect gate="A" pin="GND" pad="2"/>
 <connect gate="A" pin="IN" pad="3"/>
@@ -4263,11 +4154,11 @@ DPAK, fixed voltage</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="Z" package="TO92">
+<device name="Z" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
-<connect gate="G$1" pin="IN" pad="3"/>
-<connect gate="G$1" pin="OUT" pad="1"/>
+<connect gate="G$1" pin="IN" pad="1"/>
+<connect gate="G$1" pin="OUT" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4461,9 +4352,9 @@ PRECISION MICROPOWER SHUNT</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="LP" package="TO92">
+<device name="LP" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="A" pad="3"/>
+<connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="C" pad="2"/>
 </connects>
 <technologies>
@@ -5841,11 +5732,11 @@ Fixed 150mA Low-Noise</description>
 <technology name="AC"/>
 </technologies>
 </device>
-<device name="Z" package="TO92">
+<device name="Z" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="GND" pad="1"/>
+<connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="IN" pad="2"/>
-<connect gate="G$1" pin="OUT" pad="3"/>
+<connect gate="G$1" pin="OUT" pad="1"/>
 </connects>
 <technologies>
 <technology name="AB"/>


### PR DESCRIPTION
 - Added TO-92 package family to ref-packages-transistor.lbr: TO92-AA, TO92-AB.
 - Synchronized packages with the new contents of ref-packages-transistor.lbr. Manual verification has been done in all cases. It looks like most of the libraries used wrong TO-92 pin numbering (pins 1 and 3 swapped). I've verified this observation with JEDEC TO-92, TO-226 (newer replacement standard), multiple part datasheets and vendor-specific "standard" outline drawings.

The names of the newly added packages:
TO92-AA
TO92-AB