### PR TITLE
Update transistor reference packages

### DIFF
--- a/diode.lbr
+++ b/diode.lbr
@@ -4766,33 +4766,12 @@ diameter 2 mm, horizontal, grid 10.16 mm</description>
 <vertex x="0.635" y="-0.508"/>
 </polygon>
 </package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270" thermals="no"/>
-<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -4801,6 +4780,28 @@ diameter 2 mm, horizontal, grid 10.16 mm</description>
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
 <package name="POWER-DI5">
 <wire x1="-2.7" y1="2" x2="2.7" y2="2" width="0.2032" layer="21"/>
@@ -5926,24 +5927,12 @@ diameter 5.3 mm, 9.5 length, CASE 267?05</description>
 <vertex x="0.7" y="-0.9"/>
 </polygon>
 </package>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1" thermals="no"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="3.175" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -5952,6 +5941,18 @@ diameter 5.3 mm, 9.5 length, CASE 267?05</description>
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
 <package name="SOT563">
 <description>SOT-563&lt;p&gt;
@@ -6043,42 +6044,6 @@ diameter 2 mm, horizontal, grid 7.62 mm</description>
 <vertex x="-0.6" y="0"/>
 <vertex x="0.6" y="0.7"/>
 <vertex x="0.6" y="-0.7"/>
-</polygon>
-</package>
-<package name="TO263-2">
-<description>&lt;b&gt;TO-263 Package&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270" thermals="no"/>
-<smd name="1" x="-2.54" y="-7.755" dx="1.905" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-7.755" dx="1.905" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-4.1275" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-4.1275" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="-4.1275" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.5" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.5" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.5" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-8.5" x2="-1.905" y2="-5.5" layer="51"/>
-<rectangle x1="1.905" y1="-8.5" x2="3.175" y2="-5.5" layer="51"/>
-<polygon width="0.2032" layer="51">
-<vertex x="-5.3975" y="4.445"/>
-<vertex x="-5.3975" y="5.08"/>
-<vertex x="-4.445" y="5.715"/>
-<vertex x="4.445" y="5.715"/>
-<vertex x="5.3975" y="5.08"/>
-<vertex x="5.3975" y="4.445"/>
 </polygon>
 </package>
 <package name="DSN2-152AC">
@@ -15831,7 +15796,7 @@ ON Semiconductor, 100V, 1Vf, SOD-123 &lt;/b&gt;</description>
 <gate name="G$1" symbol="SCHOTTKY-2A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -15962,11 +15927,11 @@ Schottky barrier diode, 10 A (Diodes Inc.)</description>
 <gate name="G$1" symbol="SCHOTTKY-2K" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="D2PAK">
+<device name="" package="TO263-AB">
 <connects>
 <connect gate="G$1" pin="A" pad="3"/>
 <connect gate="G$1" pin="K1" pad="1"/>
-<connect gate="G$1" pin="K2" pad="2"/>
+<connect gate="G$1" pin="K2" pad="4"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -16074,11 +16039,11 @@ SCR Diode Array for ESD and Transient Overvoltage Protection</description>
 <gate name="G$1" symbol="D2A1C" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="D2PAK">
+<device name="" package="TO263-AB">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="3"/>
-<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="C" pad="4"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -16487,11 +16452,11 @@ GPP SMD 400V 1A SMB&lt;p&gt;</description>
 <gate name="G$1" symbol="D2A1C" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="D2PAK">
+<device name="" package="TO263-AB">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="3"/>
-<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="C" pad="4"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -16861,7 +16826,7 @@ Diodes Inc.</description>
 <gate name="G$1" symbol="SCHOTTKY-2A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -17287,7 +17252,7 @@ Semtech</description>
 <gate name="G$1" symbol="SD2A1C" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -17417,7 +17382,7 @@ Semtech</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="AB" package="TO263-2">
+<device name="AB" package="TO263-AB">
 <connects>
 <connect gate="G$1" pin="A" pad="3"/>
 <connect gate="G$1" pin="C" pad="4"/>
@@ -17701,10 +17666,10 @@ SWITCHMODE Power Rectifier&lt;p&gt;
 <gate name="G$1" symbol="SCHOTTKY" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="D2PAK">
+<device name="" package="TO263-AB">
 <connects>
 <connect gate="G$1" pin="A" pad="3"/>
-<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="C" pad="4"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -17823,10 +17788,10 @@ Bi-Directional ESD Protection</description>
 <gate name="G$1" symbol="SCHOTTKY" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="D2PAK">
+<device name="" package="TO263-AB">
 <connects>
 <connect gate="G$1" pin="A" pad="3"/>
-<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="C" pad="4"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/diode.lbr
+++ b/diode.lbr
@@ -2839,37 +2839,6 @@ diameter 2.3 mm, horizontal, grid 10.16 mm</description>
 <rectangle x1="-7.239" y1="-2.032" x2="-3.556" y2="-1.143" layer="51"/>
 <rectangle x1="-1.905" y1="-2.032" x2="1.905" y2="-1.143" layer="51"/>
 </package>
-<package name="C221B1A">
-<description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
-2-lead molded, horizontal</description>
-<wire x1="-5.207" y1="-1.27" x2="5.207" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="14.478" x2="-5.207" y2="14.478" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="8.001" x2="-5.207" y2="8.001" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="8.001" x2="5.207" y2="14.478" width="0.2032" layer="21"/>
-<wire x1="-5.207" y1="8.001" x2="-5.207" y2="14.478" width="0.2032" layer="21"/>
-<wire x1="5.207" y1="-1.27" x2="5.207" y2="8.001" width="0.2032" layer="21"/>
-<wire x1="-5.207" y1="-1.27" x2="-5.207" y2="8.001" width="0.2032" layer="21"/>
-<wire x1="4.953" y1="6.731" x2="4.953" y2="-1.016" width="0.0508" layer="21"/>
-<wire x1="4.953" y1="6.731" x2="-4.953" y2="6.731" width="0.0508" layer="21"/>
-<wire x1="4.953" y1="-1.016" x2="-4.953" y2="-1.016" width="0.0508" layer="21"/>
-<wire x1="-4.953" y1="6.731" x2="-4.953" y2="-1.016" width="0.0508" layer="21"/>
-<wire x1="-2.794" y1="-4.191" x2="-3.175" y2="-3.81" width="0.508" layer="21"/>
-<wire x1="3.175" y1="-3.81" x2="2.794" y2="-4.191" width="0.508" layer="21"/>
-<circle x="0" y="11.176" radius="1.8034" width="0.1524" layer="21"/>
-<circle x="0" y="11.176" radius="2.921" width="0" layer="42"/>
-<circle x="0" y="11.176" radius="2.921" width="0" layer="43"/>
-<pad name="C" x="-2.54" y="-6.35" drill="1.1176" shape="long" rot="R90"/>
-<pad name="A" x="2.54" y="-6.35" drill="1.1176" shape="long" rot="R90"/>
-<text x="-2.54" y="4.191" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.81" y="1.651" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="2.159" y1="-4.445" x2="2.921" y2="-3.81" layer="21"/>
-<rectangle x1="-2.921" y1="-4.445" x2="-2.159" y2="-3.81" layer="21"/>
-<rectangle x1="-3.429" y1="-3.81" x2="-2.159" y2="-1.27" layer="21"/>
-<rectangle x1="2.159" y1="-3.81" x2="3.429" y2="-1.27" layer="21"/>
-<rectangle x1="2.159" y1="-6.35" x2="2.921" y2="-4.445" layer="51"/>
-<rectangle x1="-2.921" y1="-6.35" x2="-2.159" y2="-4.445" layer="51"/>
-<hole x="0" y="11.176" drill="3.302"/>
-</package>
 <package name="TO220CH">
 <description>&lt;B&gt;DIODE&lt;/B&gt;&lt;p&gt;
 3-lead molded, horizontal</description>
@@ -12745,10 +12714,10 @@ dual rectifier, 6 A, 200 V, common cathode</description>
 <gate name="1" symbol="D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="C221B1A">
+<device name="" package="TO220-AC-H">
 <connects>
-<connect gate="1" pin="A" pad="A"/>
-<connect gate="1" pin="C" pad="C"/>
+<connect gate="1" pin="A" pad="2"/>
+<connect gate="1" pin="C" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -14141,15 +14110,6 @@ super fast rectifier, 2 A</description>
 </technologies>
 </device>
 <device name="C2673" package="C2673">
-<connects>
-<connect gate="G$1" pin="A" pad="A"/>
-<connect gate="G$1" pin="C" pad="C"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="C221B1A" package="C221B1A">
 <connects>
 <connect gate="G$1" pin="A" pad="A"/>
 <connect gate="G$1" pin="C" pad="C"/>

--- a/heatsink-aavid.lbr
+++ b/heatsink-aavid.lbr
@@ -996,24 +996,12 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <text x="-6.858" y="6.096" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2.032" y="-2.667" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1" thermals="no"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="3.175" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -1022,6 +1010,18 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
 <package name="573300">
 <description>SMD HEATSINK - D2PAK (TO-263)</description>

--- a/linear.lbr
+++ b/linear.lbr
@@ -133,29 +133,41 @@ Also known as SOT78.</description>
 <wire x1="5.207" y1="14.605" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
 </package>
 <package name="TO18">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="-2.7432" y1="0.4572" x2="-3.556" y2="0.4572" width="0.2032" layer="21"/>
-<wire x1="-3.556" y1="0.4572" x2="-3.556" y2="-0.4826" width="0.2032" layer="21"/>
-<wire x1="-3.556" y1="-0.4826" x2="-2.7178" y2="-0.4826" width="0.2032" layer="21"/>
-<circle x="0" y="-0.0254" radius="2.7686" width="0.2032" layer="21"/>
-<pad name="1" x="-1.27" y="-1.27" drill="0.8128" shape="octagon"/>
-<pad name="2" x="1.27" y="-1.27" drill="0.8128" shape="octagon"/>
-<pad name="3" x="1.27" y="1.27" drill="0.8128" shape="octagon"/>
-<text x="2.667" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="2.667" y="-2.413" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<description>&lt;b&gt;TO-18 (2.54mm lead pitch, 3 leads)&lt;/b&gt;&lt;p&gt;
+Header family package. 2.54mm lead pitch, 3 leads, metal can.
+&lt;p/&gt;&lt;p&gt;
+JEDEC TO-18.
+&lt;/p&gt;</description>
+<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
+<pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="-0.508" x2="-2.8765" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="0.508" x2="-2.8765" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="51" curve="-135.281008" cap="flat"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
 </package>
 <package name="TO39">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-39&lt;/b&gt;&lt;p&gt;
+JEDEC TO-39
+&lt;p/&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="3.8608" width="0.2032" layer="21"/>
-<pad name="1" x="0" y="-2.54" drill="0.8128" shape="octagon"/>
-<pad name="2" x="2.54" y="0" drill="0.8128" shape="octagon"/>
-<pad name="3" x="0" y="2.54" drill="0.8128" shape="octagon"/>
-<text x="-2.794" y="4.826" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.302" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
+<pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
 <package name="SIP11">
 <description>&lt;b&gt;TO-220&lt;/b&gt;&lt;p&gt;
@@ -417,52 +429,23 @@ Also known as SOT78.</description>
 <text x="-6.604" y="-1.016" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="TO78">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="-4.572" y1="0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-5.334" y1="-0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-5.334" y1="-0.508" x2="-4.572" y2="-0.508" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-78 (6 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-78.
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
 <circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
-<pad name="4" x="1.905" y="1.905" drill="0.8128" diameter="1.524"/>
+<pad name="1" x="-1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
 <pad name="2" x="0" y="-2.54" drill="0.8128" diameter="1.524"/>
+<pad name="3" x="1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
+<pad name="4" x="1.905" y="1.905" drill="0.8128" diameter="1.524"/>
 <pad name="5" x="0" y="2.54" drill="0.8128" diameter="1.524"/>
 <pad name="6" x="-1.905" y="1.905" drill="0.8128" diameter="1.524"/>
-<pad name="3" x="1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
-<pad name="1" x="-1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <rectangle x1="-5.334" y1="-0.508" x2="-4.572" y2="0.508" layer="21"/>
-</package>
-<package name="H03A">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;&lt;p&gt;
-National Semiconductor</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="3.8608" width="0.2032" layer="21"/>
-<pad name="1" x="0" y="-2.54" drill="0.8128" shape="octagon"/>
-<pad name="2" x="2.54" y="0" drill="0.8128" shape="octagon"/>
-<pad name="3" x="0" y="2.54" drill="0.8128" shape="octagon"/>
-<text x="-2.794" y="4.826" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.794" y="-5.969" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-3.175" y="0.635" size="0.8128" layer="250">MOT 79-05</text>
-<text x="-3.175" y="-1.27" size="0.8128" layer="250">NS H03A</text>
-</package>
-<package name="H03B">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;&lt;p&gt;
-National Semiconductor</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="3.8608" width="0.2032" layer="21"/>
-<pad name="1" x="0" y="-2.54" drill="0.8128" shape="octagon"/>
-<pad name="2" x="2.54" y="0" drill="0.8128" shape="octagon"/>
-<pad name="3" x="0" y="2.54" drill="0.8128" shape="octagon"/>
+<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-5.969" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-3.175" y="0.635" size="0.8128" layer="250">NS H03B</text>
+<wire x1="-5.334" y1="-0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-5.334" y1="-0.508" x2="-4.572" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-4.572" y1="0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
 </package>
 <package name="H08C">
 <description>&lt;b&gt;TO-99&lt;/b&gt;&lt;p&gt;
@@ -526,84 +509,31 @@ National Semiconductor</description>
 <text x="-1.397" y="-0.508" size="0.254" layer="250">HA04E</text>
 </package>
 <package name="TO3">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="21"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="21"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-1.778" y="-5.461" drill="1.1938" shape="octagon"/>
-<pad name="B" x="-1.778" y="5.461" drill="1.1938" shape="octagon"/>
-<pad name="C" x="15.113" y="0" drill="4.1148"/>
-<pad name="C/" x="-15.113" y="0" drill="4.1148"/>
-<text x="9.398" y="9.906" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-6.096" y="-1.016" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.397" y="-8.509" size="0.254" layer="250">MOTOROLA 1-03</text>
-</package>
-<package name="K02A">
-<description>&lt;b&gt;TO-3&lt;/b&gt;&lt;p&gt;
-National Semiconductor</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="21"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="21"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="2" x="-1.778" y="-5.461" drill="1.1938" shape="long"/>
-<pad name="1" x="-1.778" y="5.461" drill="1.1938" shape="long"/>
-<pad name="3" x="15.113" y="0" drill="4.1148"/>
-<pad name="3/" x="-15.113" y="0" drill="4.1148"/>
-<text x="8.636" y="10.668" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-6.096" y="-0.889" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-0.254" y="-8.509" size="0.254" layer="250">NS K02A</text>
-</package>
-<package name="K02B">
-<description>&lt;b&gt;TO-3&lt;/b&gt;&lt;p&gt;
-National Semiconductor</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="21"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="21"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="2" x="-1.778" y="-5.461" drill="1.1938" shape="long"/>
-<pad name="1" x="-1.778" y="5.461" drill="1.1938" shape="long"/>
-<pad name="3" x="15.113" y="0" drill="4.1148"/>
-<pad name="3/" x="-15.113" y="0" drill="4.1148"/>
-<text x="9.398" y="10.16" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-5.842" y="-0.889" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.397" y="-7.493" size="0.254" layer="250">NS K02B</text>
+<description>&lt;b&gt;TO-3 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-3.
+&lt;/p&gt;</description>
+<circle x="-15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="9.3726" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
+<circle x="15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<pad name="1" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="2" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="3" x="15.113" y="0" drill="4.1148" diameter="6.477"/>
+<pad name="4" x="-15.113" y="0" drill="4.1148" diameter="6.477"/>
+<text x="2.54" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="5.08" y="-3.81" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.2032" layer="21" curve="-60.173068" cap="flat"/>
+<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.2032" layer="21" curve="59.404169" cap="flat"/>
+<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.2032" layer="21" curve="-30.113639" cap="flat"/>
+<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.2032" layer="21"/>
+<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.2032" layer="21" curve="28.0726" cap="flat"/>
+<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.2032" layer="21"/>
+<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.2032" layer="21" curve="30.113639" cap="flat"/>
+<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.2032" layer="21" curve="-28.0726" cap="flat"/>
+<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.2032" layer="21"/>
+<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.2032" layer="21"/>
+<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="57.148737" cap="flat"/>
+<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="-57.148737" cap="flat"/>
 </package>
 <package name="K04A">
 <description>&lt;b&gt;TO-3&lt;/b&gt;&lt;p&gt;
@@ -666,33 +596,6 @@ National Semiconductor</description>
 <text x="9.652" y="9.906" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-8.128" y="-0.762" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-0.635" y="-8.509" size="0.254" layer="250">NS K08A</text>
-</package>
-<package name="KC02A">
-<description>&lt;b&gt;TO-3&lt;/b&gt;&lt;p&gt;
-National Semiconductor</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="21"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="21"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="2" x="-1.778" y="-5.461" drill="1.1938" shape="octagon"/>
-<pad name="1" x="-1.778" y="5.461" drill="1.1938" shape="octagon"/>
-<pad name="3" x="15.113" y="0" drill="4.1148"/>
-<pad name="3/" x="-15.113" y="0" drill="4.1148"/>
-<text x="9.906" y="9.652" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-6.604" y="-0.889" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-0.635" y="-8.509" size="0.254" layer="250">NS KC02A</text>
 </package>
 <package name="KA15A">
 <description>&lt;b&gt;TO-3&lt;/b&gt;&lt;p&gt;

--- a/linear.lbr
+++ b/linear.lbr
@@ -985,179 +985,32 @@ Small outline package. Lead pitch 1.27mm, body width 300mil/7.60mm, 16 leads. No
 <rectangle x1="-0.4" y1="-6.6" x2="0.4" y2="-4.5" layer="21"/>
 <rectangle x1="3" y1="-6.6" x2="3.8" y2="-4.5" layer="21"/>
 </package>
-<package name="DPACK_1">
-<description>&lt;b&gt;DPAK&lt;/b&gt;&lt;p&gt;Style 1 (Motorola)</description>
-<wire x1="3.2766" y1="3.8354" x2="3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="3.277" y1="-2.159" x2="-3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="-2.159" x2="-3.2766" y2="3.8354" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="3.835" x2="3.2774" y2="3.8346" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="3.937" x2="-2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="4.6482" x2="-2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="-2.1082" y1="5.1054" x2="2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="2.1082" y1="5.1054" x2="2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="4.6482" x2="2.5654" y2="3.937" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="3.937" x2="-2.5654" y2="3.937" width="0.2032" layer="51"/>
-<smd name="C" x="0" y="2.5" dx="5.4" dy="6.2" layer="1"/>
-<smd name="B" x="-2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<smd name="E" x="2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<text x="-3.81" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-2.54" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<rectangle x1="-2.7178" y1="-5.1562" x2="-1.8542" y2="-2.2606" layer="51"/>
-<rectangle x1="1.8542" y1="-5.1562" x2="2.7178" y2="-2.2606" layer="51"/>
-<rectangle x1="-0.4318" y1="-3.0226" x2="0.4318" y2="-2.2606" layer="21"/>
-<polygon width="0.1998" layer="51">
-<vertex x="-2.5654" y="3.937"/>
-<vertex x="-2.5654" y="4.6482"/>
-<vertex x="-2.1082" y="5.1054"/>
-<vertex x="2.1082" y="5.1054"/>
-<vertex x="2.5654" y="4.6482"/>
-<vertex x="2.5654" y="3.937"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
+<polygon width="0.2032" layer="51">
+<vertex x="-2.5" y="3.2"/>
+<vertex x="-2.5" y="3.95"/>
+<vertex x="-1.65" y="4.5"/>
+<vertex x="1.65" y="4.5"/>
+<vertex x="2.5" y="3.95"/>
+<vertex x="2.5" y="3.2"/>
 </polygon>
-</package>
-<package name="DPACK_2">
-<description>&lt;b&gt;DPAK&lt;/b&gt;&lt;p&gt;Style 2 (Motorola)</description>
-<wire x1="3.2766" y1="3.8354" x2="3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="3.277" y1="-2.159" x2="-3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="-2.159" x2="-3.2766" y2="3.8354" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="3.835" x2="3.2774" y2="3.8346" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="3.937" x2="-2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="4.6482" x2="-2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="-2.1082" y1="5.1054" x2="2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="2.1082" y1="5.1054" x2="2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="4.6482" x2="2.5654" y2="3.937" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="3.937" x2="-2.5654" y2="3.937" width="0.2032" layer="51"/>
-<smd name="D" x="0" y="2.5" dx="5.4" dy="6.2" layer="1"/>
-<smd name="G" x="-2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<smd name="S" x="2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<text x="-3.81" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-2.54" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<rectangle x1="-2.7178" y1="-5.1562" x2="-1.8542" y2="-2.2606" layer="51"/>
-<rectangle x1="1.8542" y1="-5.1562" x2="2.7178" y2="-2.2606" layer="51"/>
-<rectangle x1="-0.4318" y1="-3.0226" x2="0.4318" y2="-2.2606" layer="21"/>
-<polygon width="0.1998" layer="51">
-<vertex x="-2.5654" y="3.937"/>
-<vertex x="-2.5654" y="4.6482"/>
-<vertex x="-2.1082" y="5.1054"/>
-<vertex x="2.1082" y="5.1054"/>
-<vertex x="2.5654" y="4.6482"/>
-<vertex x="2.5654" y="3.937"/>
-</polygon>
-</package>
-<package name="DPACK_3">
-<description>&lt;b&gt;DPAK&lt;/b&gt;&lt;p&gt;Style 3 (Motorola)</description>
-<wire x1="3.2766" y1="3.8354" x2="3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="3.277" y1="-2.159" x2="-3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="-2.159" x2="-3.2766" y2="3.8354" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="3.835" x2="3.2774" y2="3.8346" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="3.937" x2="-2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="4.6482" x2="-2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="-2.1082" y1="5.1054" x2="2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="2.1082" y1="5.1054" x2="2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="4.6482" x2="2.5654" y2="3.937" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="3.937" x2="-2.5654" y2="3.937" width="0.2032" layer="51"/>
-<smd name="C" x="0" y="2.5" dx="5.4" dy="6.2" layer="1"/>
-<smd name="A1" x="-2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<smd name="A2" x="2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<text x="-3.81" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-2.54" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<rectangle x1="-2.7178" y1="-5.1562" x2="-1.8542" y2="-2.2606" layer="51"/>
-<rectangle x1="1.8542" y1="-5.1562" x2="2.7178" y2="-2.2606" layer="51"/>
-<rectangle x1="-0.4318" y1="-3.0226" x2="0.4318" y2="-2.2606" layer="21"/>
-<polygon width="0.1998" layer="51">
-<vertex x="-2.5654" y="3.937"/>
-<vertex x="-2.5654" y="4.6482"/>
-<vertex x="-2.1082" y="5.1054"/>
-<vertex x="2.1082" y="5.1054"/>
-<vertex x="2.5654" y="4.6482"/>
-<vertex x="2.5654" y="3.937"/>
-</polygon>
-</package>
-<package name="DPACK_4">
-<description>&lt;b&gt;DPAK&lt;/b&gt;&lt;p&gt;Style 4 (Motorola)</description>
-<wire x1="3.2766" y1="3.8354" x2="3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="3.277" y1="-2.159" x2="-3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="-2.159" x2="-3.2766" y2="3.8354" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="3.835" x2="3.2774" y2="3.8346" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="3.937" x2="-2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="4.6482" x2="-2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="-2.1082" y1="5.1054" x2="2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="2.1082" y1="5.1054" x2="2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="4.6482" x2="2.5654" y2="3.937" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="3.937" x2="-2.5654" y2="3.937" width="0.2032" layer="51"/>
-<smd name="A" x="0" y="2.5" dx="5.4" dy="6.2" layer="1"/>
-<smd name="C" x="-2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<smd name="G" x="2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<text x="-3.81" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-2.54" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<rectangle x1="-2.7178" y1="-5.1562" x2="-1.8542" y2="-2.2606" layer="51"/>
-<rectangle x1="1.8542" y1="-5.1562" x2="2.7178" y2="-2.2606" layer="51"/>
-<rectangle x1="-0.4318" y1="-3.0226" x2="0.4318" y2="-2.2606" layer="21"/>
-<polygon width="0.1998" layer="51">
-<vertex x="-2.5654" y="3.937"/>
-<vertex x="-2.5654" y="4.6482"/>
-<vertex x="-2.1082" y="5.1054"/>
-<vertex x="2.1082" y="5.1054"/>
-<vertex x="2.5654" y="4.6482"/>
-<vertex x="2.5654" y="3.937"/>
-</polygon>
-</package>
-<package name="DPACK_5">
-<description>&lt;b&gt;DPAK&lt;/b&gt;&lt;p&gt;Style 5 (Motorola)</description>
-<wire x1="3.2766" y1="3.8354" x2="3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="3.277" y1="-2.159" x2="-3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="-2.159" x2="-3.2766" y2="3.8354" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="3.835" x2="3.2774" y2="3.8346" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="3.937" x2="-2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="4.6482" x2="-2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="-2.1082" y1="5.1054" x2="2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="2.1082" y1="5.1054" x2="2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="4.6482" x2="2.5654" y2="3.937" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="3.937" x2="-2.5654" y2="3.937" width="0.2032" layer="51"/>
-<smd name="A" x="0" y="2.5" dx="5.4" dy="6.2" layer="1"/>
-<smd name="G" x="-2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<smd name="C" x="2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<text x="-3.81" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-2.54" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<rectangle x1="-2.7178" y1="-5.1562" x2="-1.8542" y2="-2.2606" layer="51"/>
-<rectangle x1="1.8542" y1="-5.1562" x2="2.7178" y2="-2.2606" layer="51"/>
-<rectangle x1="-0.4318" y1="-3.0226" x2="0.4318" y2="-2.2606" layer="21"/>
-<polygon width="0.1998" layer="51">
-<vertex x="-2.5654" y="3.937"/>
-<vertex x="-2.5654" y="4.6482"/>
-<vertex x="-2.1082" y="5.1054"/>
-<vertex x="2.1082" y="5.1054"/>
-<vertex x="2.5654" y="4.6482"/>
-<vertex x="2.5654" y="3.937"/>
-</polygon>
-</package>
-<package name="DPACK_6">
-<description>&lt;b&gt;DPAK&lt;/b&gt;&lt;p&gt;Style 6 (Motorola)</description>
-<wire x1="3.2766" y1="3.8354" x2="3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="3.277" y1="-2.159" x2="-3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="-2.159" x2="-3.2766" y2="3.8354" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="3.835" x2="3.2774" y2="3.8346" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="3.937" x2="-2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="4.6482" x2="-2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="-2.1082" y1="5.1054" x2="2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="2.1082" y1="5.1054" x2="2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="4.6482" x2="2.5654" y2="3.937" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="3.937" x2="-2.5654" y2="3.937" width="0.2032" layer="51"/>
-<smd name="MT2" x="0" y="2.5" dx="5.4" dy="6.2" layer="1"/>
-<smd name="MT1" x="-2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<smd name="G" x="2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<text x="-3.81" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-2.54" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<rectangle x1="-2.7178" y1="-5.1562" x2="-1.8542" y2="-2.2606" layer="51"/>
-<rectangle x1="1.8542" y1="-5.1562" x2="2.7178" y2="-2.2606" layer="51"/>
-<rectangle x1="-0.4318" y1="-3.0226" x2="0.4318" y2="-2.2606" layer="21"/>
-<polygon width="0.1998" layer="51">
-<vertex x="-2.5654" y="3.937"/>
-<vertex x="-2.5654" y="4.6482"/>
-<vertex x="-2.1082" y="5.1054"/>
-<vertex x="2.1082" y="5.1054"/>
-<vertex x="2.5654" y="4.6482"/>
-<vertex x="2.5654" y="3.937"/>
-</polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
 <package name="MULTIWAT-SIL17">
 <description>&lt;b&gt;DBS17P&lt;/b&gt; plastic DIL-bent-SIL power package&lt;p&gt;

--- a/linear.lbr
+++ b/linear.lbr
@@ -9459,8 +9459,8 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <device name="Z" package="TO92-AB">
 <connects>
 <connect gate="A1" pin="GND" pad="2"/>
-<connect gate="A1" pin="VI" pad="1"/>
-<connect gate="A1" pin="VO" pad="3"/>
+<connect gate="A1" pin="VI" pad="3"/>
+<connect gate="A1" pin="VO" pad="1"/>
 </connects>
 <technologies>
 <technology name="L05"/>
@@ -9506,8 +9506,8 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <device name="L" package="TO92-AB">
 <connects>
 <connect gate="A1" pin="GND" pad="2"/>
-<connect gate="A1" pin="VI" pad="1"/>
-<connect gate="A1" pin="VO" pad="3"/>
+<connect gate="A1" pin="VI" pad="3"/>
+<connect gate="A1" pin="VO" pad="1"/>
 </connects>
 <technologies>
 <technology name="05"/>
@@ -9545,9 +9545,9 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <devices>
 <device name="L" package="TO92-AB">
 <connects>
-<connect gate="A1" pin="GND" pad="3"/>
+<connect gate="A1" pin="GND" pad="1"/>
 <connect gate="A1" pin="VI" pad="2"/>
-<connect gate="A1" pin="VO" pad="1"/>
+<connect gate="A1" pin="VO" pad="3"/>
 </connects>
 <technologies>
 <technology name="05"/>
@@ -9593,9 +9593,9 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 </device>
 <device name="Z" package="TO92-AB">
 <connects>
-<connect gate="A1" pin="GND" pad="3"/>
+<connect gate="A1" pin="GND" pad="1"/>
 <connect gate="A1" pin="VI" pad="2"/>
-<connect gate="A1" pin="VO" pad="1"/>
+<connect gate="A1" pin="VO" pad="3"/>
 </connects>
 <technologies>
 <technology name="L05"/>
@@ -9616,8 +9616,8 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <devices>
 <device name="LZ" package="TO92-AB">
 <connects>
-<connect gate="A1" pin="ADJ" pad="3"/>
-<connect gate="A1" pin="VI" pad="1"/>
+<connect gate="A1" pin="ADJ" pad="1"/>
+<connect gate="A1" pin="VI" pad="3"/>
 <connect gate="A1" pin="VO" pad="2"/>
 </connects>
 <technologies>
@@ -9644,8 +9644,8 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <devices>
 <device name="LZ" package="TO92-AB">
 <connects>
-<connect gate="A1" pin="ADJ" pad="3"/>
-<connect gate="A1" pin="VI" pad="1"/>
+<connect gate="A1" pin="ADJ" pad="1"/>
+<connect gate="A1" pin="VI" pad="3"/>
 <connect gate="A1" pin="VO" pad="2"/>
 </connects>
 <technologies>
@@ -9746,9 +9746,9 @@ current output</description>
 <devices>
 <device name="" package="TO92-AB">
 <connects>
-<connect gate="A" pin="+" pad="3"/>
+<connect gate="A" pin="+" pad="1"/>
 <connect gate="A" pin="-" pad="2"/>
-<connect gate="A" pin="CAN" pad="1"/>
+<connect gate="A" pin="CAN" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -11348,8 +11348,8 @@ latched 4/8-channel analog multiplexer</description>
 <device name="LZ" package="TO92-AB">
 <connects>
 <connect gate="A" pin="GND" pad="2"/>
-<connect gate="A" pin="VI" pad="1"/>
-<connect gate="A" pin="VO" pad="3"/>
+<connect gate="A" pin="VI" pad="3"/>
+<connect gate="A" pin="VO" pad="1"/>
 </connects>
 <technologies>
 <technology name="05"/>
@@ -11385,9 +11385,9 @@ latched 4/8-channel analog multiplexer</description>
 <devices>
 <device name="" package="TO92-AB">
 <connects>
-<connect gate="A" pin="GND" pad="3"/>
+<connect gate="A" pin="GND" pad="1"/>
 <connect gate="A" pin="VI" pad="2"/>
-<connect gate="A" pin="VO" pad="1"/>
+<connect gate="A" pin="VO" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/micrel.lbr
+++ b/micrel.lbr
@@ -1207,34 +1207,44 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <rectangle x1="-0.45" y1="1.5" x2="-0.2" y2="2.5" layer="51"/>
 <rectangle x1="-1.1" y1="1.5" x2="-0.85" y2="2.5" layer="51"/>
 </package>
-<package name="TO263">
-<description>&lt;b&gt;TO-263 Package&lt;/b&gt;</description>
-<wire x1="-5.5" y1="-4.365" x2="-5.5" y2="4.635" width="0.2032" layer="21"/>
-<wire x1="5.5" y1="-4.365" x2="5.5" y2="4.635" width="0.2032" layer="21"/>
-<wire x1="5.5" y1="-4.365" x2="-5.5" y2="-4.365" width="0.2032" layer="21"/>
-<wire x1="-5.5" y1="4.635" x2="5.5" y2="4.635" width="0.2032" layer="51"/>
-<wire x1="-5.5" y1="4.635" x2="-4.4" y2="5.735" width="0.2032" layer="51"/>
-<wire x1="-4.4" y1="5.735" x2="4.4" y2="5.735" width="0.2032" layer="51"/>
-<wire x1="4.4" y1="5.735" x2="5.5" y2="4.635" width="0.2032" layer="51"/>
-<wire x1="-5.5" y1="3.935" x2="5.5" y2="3.935" width="0.2032" layer="51"/>
-<wire x1="-5.5" y1="-3.965" x2="5.5" y2="-3.965" width="0.2032" layer="51"/>
-<circle x="-3" y="-2.965" radius="0.4123" width="0" layer="51"/>
-<smd name="4" x="0" y="2.635" dx="10.25" dy="9" layer="1" rot="R180" thermals="no"/>
-<smd name="1" x="-2.54" y="-8.255" dx="3.81" dy="1.524" layer="1" rot="R90"/>
-<smd name="2" x="0" y="-8.255" dx="3.81" dy="1.524" layer="1" rot="R90"/>
-<smd name="3" x="2.54" y="-8.255" dx="3.81" dy="1.524" layer="1" rot="R90"/>
-<text x="-6.35" y="-4.445" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="7.3025" y="-4.445" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<text x="-3.2" y="-2.165" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.3" y="-2.165" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.4" y="-2.165" size="1.016" layer="51" ratio="10">2</text>
-<text x="-0.55" y="2.385" size="1.016" layer="51" ratio="10">4</text>
-<rectangle x1="-3.04" y1="-5.865" x2="-2" y2="-4.37" layer="21"/>
-<rectangle x1="-0.5" y1="-5.865" x2="0.5" y2="-4.37" layer="21"/>
-<rectangle x1="2.04" y1="-5.865" x2="3" y2="-4.37" layer="21"/>
-<rectangle x1="-3.04" y1="-8.64" x2="-2" y2="-5.865" layer="51"/>
-<rectangle x1="-0.5" y1="-8.64" x2="0.5" y2="-5.865" layer="51"/>
-<rectangle x1="2.04" y1="-8.64" x2="3" y2="-5.865" layer="51"/>
+<package name="TO263-AA">
+<description>&lt;b&gt;TO-263 AA (3 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 3 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AA, R-PSFM.
+&lt;/p&gt;</description>
+<polygon width="0.2032" layer="51">
+<vertex x="-5.3975" y="4.445"/>
+<vertex x="-5.3975" y="5.08"/>
+<vertex x="-4.445" y="5.715"/>
+<vertex x="4.445" y="5.715"/>
+<vertex x="5.3975" y="5.08"/>
+<vertex x="5.3975" y="4.445"/>
+</polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-7.62" x2="0.635" y2="-5.715" layer="51"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="2" x="0" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
 <package name="SOT23">
 <description>&lt;b&gt;SOT23 (0.95mm pitch, 1.3mm body, 3 leads)&lt;/b&gt;&lt;p&gt;
@@ -3831,7 +3841,7 @@ Adjustable 150mA Low-Noise</description>
 <gate name="G$1" symbol="MIC2940A-XXBU/WU" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="TO263">
+<device name="" package="TO263-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="GND1" pad="4"/>

--- a/national-semi.lbr
+++ b/national-semi.lbr
@@ -520,35 +520,12 @@ NS Package Number SDC08A</description>
 <rectangle x1="-1.25" y1="-1" x2="1.25" y2="1" layer="31"/>
 <rectangle x1="-2.6" y1="-2" x2="-2.15" y2="-1.55" layer="21"/>
 </package>
-<package name="TO263-3">
-<description>&lt;b&gt;TO-263 Package&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270" thermals="no"/>
-<smd name="1" x="-2.54" y="-7.755" dx="1.905" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-7.755" dx="1.905" dy="3.81" layer="1" rot="R180"/>
-<smd name="2" x="0" y="-7.755" dx="1.905" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-4.1275" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-4.1275" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="-4.1275" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.5" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.5" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.5" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-8.5" x2="-1.905" y2="-5.5" layer="51"/>
-<rectangle x1="1.905" y1="-8.5" x2="3.175" y2="-5.5" layer="51"/>
-<rectangle x1="-0.635" y1="-8.5" x2="0.635" y2="-5.5" layer="51"/>
+<package name="TO263-AA">
+<description>&lt;b&gt;TO-263 AA (3 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 3 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AA, R-PSFM.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -557,42 +534,67 @@ NS Package Number SDC08A</description>
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
-</package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-7.62" x2="0.635" y2="-5.715" layer="51"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="2" x="0" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
 <wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
 <wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
 <wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
 <wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
 <wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
 <wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270" thermals="no"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+</package>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
+<polygon width="0.2032" layer="51">
+<vertex x="-5.3975" y="4.445"/>
+<vertex x="-5.3975" y="5.08"/>
+<vertex x="-4.445" y="5.715"/>
+<vertex x="4.445" y="5.715"/>
+<vertex x="5.3975" y="5.08"/>
+<vertex x="5.3975" y="4.445"/>
+</polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
 <smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
 <smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
 <text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
-<polygon width="0.2032" layer="51">
-<vertex x="-5.3975" y="4.445"/>
-<vertex x="-5.3975" y="5.08"/>
-<vertex x="-4.445" y="5.715"/>
-<vertex x="4.445" y="5.715"/>
-<vertex x="5.3975" y="5.08"/>
-<vertex x="5.3975" y="4.445"/>
-</polygon>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
 <package name="SOT223">
 <description>&lt;b&gt;SOT223 (2.3mm pitch, 3.5mm body, 4 leads)&lt;/b&gt;&lt;p/&gt;
@@ -1871,7 +1873,7 @@ with Precision Enable</description>
 <gate name="G$1" symbol="LM2937" x="0" y="0"/>
 </gates>
 <devices>
-<device name="ES" package="TO263-3">
+<device name="ES" package="TO263-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="GND@4" pad="4"/>
@@ -1936,7 +1938,7 @@ with Precision Enable</description>
 <gate name="G$1" symbol="LP2954IS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO263-3">
+<device name="" package="TO263-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="GND@4" pad="4"/>

--- a/on-semi.lbr
+++ b/on-semi.lbr
@@ -103,33 +103,12 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <wire x1="1.45" y1="-0.65" x2="1.45" y2="0.65" width="0.2032" layer="21"/>
 <wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
 </package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270" thermals="no"/>
-<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -138,25 +117,35 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1" thermals="no"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="-3.81" y="-2.8575" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -165,6 +154,18 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
 <package name="DPAK-5">
 <description>&lt;b&gt;SMD DPAK 5&lt;/b&gt;&lt;p&gt;

--- a/opto-honeywell.lbr
+++ b/opto-honeywell.lbr
@@ -86,18 +86,27 @@
 <text x="-2.54" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2.54" y="-5.08" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="TO-18">
-<description>&lt;b&gt;OPTO SENSOR DEVICE&lt;/b&gt;</description>
-<wire x1="-2.7432" y1="0.4572" x2="-3.556" y2="0.4572" width="0.2032" layer="21"/>
-<wire x1="-3.556" y1="0.4572" x2="-3.556" y2="-0.4826" width="0.2032" layer="21"/>
-<wire x1="-3.556" y1="-0.4826" x2="-2.7178" y2="-0.4826" width="0.2032" layer="21"/>
-<circle x="0" y="-0.0254" radius="2.7686" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="2.54" width="0.1016" layer="51"/>
-<pad name="1" x="-1.27" y="-1.27" drill="0.8128" shape="octagon"/>
-<pad name="2" x="1.27" y="-1.27" drill="0.8128" shape="octagon"/>
-<pad name="3" x="1.27" y="1.27" drill="0.8128" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<package name="TO18">
+<description>&lt;b&gt;TO-18 (2.54mm lead pitch, 3 leads)&lt;/b&gt;&lt;p&gt;
+Header family package. 2.54mm lead pitch, 3 leads, metal can.
+&lt;p/&gt;&lt;p&gt;
+JEDEC TO-18.
+&lt;/p&gt;</description>
+<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
+<pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="-0.508" x2="-2.8765" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="0.508" x2="-2.8765" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="51" curve="-135.281008" cap="flat"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
 </package>
 <package name="HFE-3XX">
 <description>&lt;b&gt;OPTO SENSOR DEVICE&lt;/b&gt;</description>
@@ -4563,7 +4572,7 @@
 <gate name="NC1" symbol="NC" x="7.62" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TO-18">
+<device name="" package="TO18">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="C" pad="2"/>
@@ -4582,7 +4591,7 @@
 <gate name="NC3" symbol="NC" x="7.62" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TO-18">
+<device name="" package="TO18">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="C" pad="2"/>
@@ -4618,7 +4627,7 @@
 <gate name="G$1" symbol="LED-SH" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO-18">
+<device name="" package="TO18">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="C" pad="2"/>

--- a/ref-packages-transistor.lbr
+++ b/ref-packages-transistor.lbr
@@ -504,6 +504,45 @@ JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
 <wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
 <wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
+<package name="TO263-AA">
+<description>&lt;b&gt;TO-263 AA (3 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 3 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AA, R-PSFM.
+&lt;/p&gt;</description>
+<polygon width="0.2032" layer="51">
+<vertex x="-5.3975" y="4.445"/>
+<vertex x="-5.3975" y="5.08"/>
+<vertex x="-4.445" y="5.715"/>
+<vertex x="4.445" y="5.715"/>
+<vertex x="5.3975" y="5.08"/>
+<vertex x="5.3975" y="4.445"/>
+</polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-7.62" x2="0.635" y2="-5.715" layer="51"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="2" x="0" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+</package>
 <package name="TO263-AB">
 <description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
 Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.

--- a/ref-packages-transistor.lbr
+++ b/ref-packages-transistor.lbr
@@ -609,6 +609,25 @@ JEDEC TO-72.
 <wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
 <wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
 </package>
+<package name="TO78">
+<description>&lt;b&gt;TO-78 (6 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-78.
+&lt;/p&gt;</description>
+<circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
+<circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
+<pad name="1" x="-1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
+<pad name="2" x="0" y="-2.54" drill="0.8128" diameter="1.524"/>
+<pad name="3" x="1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
+<pad name="4" x="1.905" y="1.905" drill="0.8128" diameter="1.524"/>
+<pad name="5" x="0" y="2.54" drill="0.8128" diameter="1.524"/>
+<pad name="6" x="-1.905" y="1.905" drill="0.8128" diameter="1.524"/>
+<rectangle x1="-5.334" y1="-0.508" x2="-4.572" y2="0.508" layer="21"/>
+<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-5.334" y1="-0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-5.334" y1="-0.508" x2="-4.572" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-4.572" y1="0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
+</package>
 <package name="TO92-AA">
 <description>&lt;b&gt;TO-92 (2.54mm lead pitch, 3 leads, vertical, linear pad arrangement)&lt;/b&gt;&lt;p&gt;
 Header family flat index. 2.54mm lead pitch, 3 leads, vertical, linear pad arrangement. JEDEC TO-226G, variation AA.

--- a/ref-packages-transistor.lbr
+++ b/ref-packages-transistor.lbr
@@ -504,6 +504,43 @@ JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
 <wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
 <wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
+<polygon width="0.2032" layer="51">
+<vertex x="-5.3975" y="4.445"/>
+<vertex x="-5.3975" y="5.08"/>
+<vertex x="-4.445" y="5.715"/>
+<vertex x="4.445" y="5.715"/>
+<vertex x="5.3975" y="5.08"/>
+<vertex x="5.3975" y="4.445"/>
+</polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+</package>
 <package name="TO3">
 <description>&lt;b&gt;TO-3 (2 leads)&lt;/b&gt;&lt;p&gt;
 JEDEC TO-3.

--- a/ref-packages-transistor.lbr
+++ b/ref-packages-transistor.lbr
@@ -278,6 +278,28 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <wire x1="1.45" y1="-0.65" x2="1.45" y2="0.65" width="0.2032" layer="21"/>
 <wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
 </package>
+<package name="TO18">
+<description>&lt;b&gt;TO-18 (2.54mm lead pitch, 3 leads)&lt;/b&gt;&lt;p&gt;
+Header family package. 2.54mm lead pitch, 3 leads, metal can.
+&lt;p/&gt;&lt;p&gt;
+JEDEC TO-18.
+&lt;/p&gt;</description>
+<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
+<pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="-0.508" x2="-2.8765" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="0.508" x2="-2.8765" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="51" curve="-135.281008" cap="flat"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+</package>
 <package name="TO220-AB">
 <description>&lt;b&gt;TO-220 AB (2.54mm lead pitch, 3 leads, exposed pad, vertical)&lt;/b&gt;&lt;p&gt;
 Flange mounted header. 2.54mm lead pitch, 3 leads, exposed pad, vertical. JEDEC TO-220K, variation AB.

--- a/ref-packages-transistor.lbr
+++ b/ref-packages-transistor.lbr
@@ -548,6 +548,21 @@ JEDEC TO-39
 <wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
 <wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
+<package name="TO5">
+<description>&lt;b&gt;TO-5 (3 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-5
+&lt;/p&gt;</description>
+<circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
+<circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
+<pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
+</package>
 <package name="TO92-AA">
 <description>&lt;b&gt;TO-92 (2.54mm lead pitch, 3 leads, vertical, linear pad arrangement)&lt;/b&gt;&lt;p&gt;
 Header family flat index. 2.54mm lead pitch, 3 leads, vertical, linear pad arrangement. JEDEC TO-226G, variation AA.

--- a/ref-packages-transistor.lbr
+++ b/ref-packages-transistor.lbr
@@ -533,6 +533,21 @@ Non-standard, based on JEDEC TO-3.
 <wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="57.148737" cap="flat"/>
 <wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="-57.148737" cap="flat"/>
 </package>
+<package name="TO39">
+<description>&lt;b&gt;TO-39&lt;/b&gt;&lt;p&gt;
+JEDEC TO-39
+&lt;p/&gt;</description>
+<circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
+<circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
+<pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
+</package>
 <package name="TO92-AA">
 <description>&lt;b&gt;TO-92 (2.54mm lead pitch, 3 leads, vertical, linear pad arrangement)&lt;/b&gt;&lt;p&gt;
 Header family flat index. 2.54mm lead pitch, 3 leads, vertical, linear pad arrangement. JEDEC TO-226G, variation AA.

--- a/ref-packages-transistor.lbr
+++ b/ref-packages-transistor.lbr
@@ -477,6 +477,33 @@ Also known as SOT186.</description>
 <wire x1="5.207" y1="12.7" x2="5.207" y2="14.605" width="0.2032" layer="21"/>
 <wire x1="5.207" y1="14.605" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
 </package>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
+<polygon width="0.2032" layer="51">
+<vertex x="-2.5" y="3.2"/>
+<vertex x="-2.5" y="3.95"/>
+<vertex x="-1.65" y="4.5"/>
+<vertex x="1.65" y="4.5"/>
+<vertex x="2.5" y="3.95"/>
+<vertex x="2.5" y="3.2"/>
+</polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+</package>
 <package name="TO3">
 <description>&lt;b&gt;TO-3 (2 leads)&lt;/b&gt;&lt;p&gt;
 JEDEC TO-3.

--- a/ref-packages-transistor.lbr
+++ b/ref-packages-transistor.lbr
@@ -563,6 +563,29 @@ JEDEC TO-5
 <wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
 <wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
+<package name="TO66">
+<description>&lt;b&gt;TO-66 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-66.
+&lt;/p&gt;</description>
+<circle x="-12.192" y="0" radius="1.905" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="7.874" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="6.35" width="0.2032" layer="51"/>
+<circle x="12.192" y="0" radius="1.905" width="0.2032" layer="51"/>
+<pad name="1" x="-2.54" y="-2.54" drill="1.1176" diameter="2.54" shape="long"/>
+<pad name="2" x="-2.54" y="2.54" drill="1.1176" diameter="2.54" shape="long"/>
+<pad name="3" x="12.192" y="0" drill="3.302" diameter="6.35"/>
+<pad name="4" x="-12.192" y="0" drill="3.302" diameter="6.35"/>
+<text x="1.27" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="3.175" y="-3.175" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-13.711" y1="3.3666" x2="-13.711" y2="-3.367" width="0.2032" layer="21" curve="132.167583" cap="flat"/>
+<wire x1="-3.501" y1="-7.895" x2="3.5012" y2="-7.895" width="0.2032" layer="21" curve="47.833229" cap="flat"/>
+<wire x1="-3.501" y1="-7.895" x2="-13.711" y2="-3.367" width="0.2032" layer="21"/>
+<wire x1="-3.501" y1="7.895" x2="3.5012" y2="7.895" width="0.2032" layer="21" curve="-47.833229" cap="flat"/>
+<wire x1="-3.501" y1="7.895" x2="-13.711" y2="3.367" width="0.2032" layer="21"/>
+<wire x1="3.501" y1="-7.895" x2="13.711" y2="-3.367" width="0.2032" layer="21"/>
+<wire x1="3.501" y1="7.895" x2="13.711" y2="3.367" width="0.2032" layer="21"/>
+<wire x1="13.711" y1="-3.367" x2="13.711" y2="3.3666" width="0.2032" layer="21" curve="132.167583" cap="flat"/>
+</package>
 <package name="TO92-AA">
 <description>&lt;b&gt;TO-92 (2.54mm lead pitch, 3 leads, vertical, linear pad arrangement)&lt;/b&gt;&lt;p&gt;
 Header family flat index. 2.54mm lead pitch, 3 leads, vertical, linear pad arrangement. JEDEC TO-226G, variation AA.

--- a/ref-packages-transistor.lbr
+++ b/ref-packages-transistor.lbr
@@ -586,6 +586,29 @@ JEDEC TO-66.
 <wire x1="3.501" y1="7.895" x2="13.711" y2="3.367" width="0.2032" layer="21"/>
 <wire x1="13.711" y1="-3.367" x2="13.711" y2="3.3666" width="0.2032" layer="21" curve="132.167583" cap="flat"/>
 </package>
+<package name="TO72">
+<description>&lt;b&gt;TO-72 (4 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-72.
+&lt;/p&gt;</description>
+<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
+<pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="4" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="51" curve="-45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+</package>
 <package name="TO92-AA">
 <description>&lt;b&gt;TO-92 (2.54mm lead pitch, 3 leads, vertical, linear pad arrangement)&lt;/b&gt;&lt;p&gt;
 Header family flat index. 2.54mm lead pitch, 3 leads, vertical, linear pad arrangement. JEDEC TO-226G, variation AA.

--- a/ref-packages-transistor.lbr
+++ b/ref-packages-transistor.lbr
@@ -504,6 +504,35 @@ JEDEC TO-3.
 <wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="57.148737" cap="flat"/>
 <wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="-57.148737" cap="flat"/>
 </package>
+<package name="TO3-4">
+<description>&lt;b&gt;TO-3 (4 leads)&lt;/b&gt;&lt;p&gt;
+Non-standard, based on JEDEC TO-3.
+&lt;/p&gt;</description>
+<circle x="-15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="9.3726" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
+<circle x="15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<pad name="1" x="-2.159" y="-5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
+<pad name="2" x="4.9022" y="-3.5306" drill="1.1938" diameter="3.81" shape="octagon"/>
+<pad name="3" x="4.9022" y="3.5306" drill="1.1938" diameter="3.81" shape="octagon"/>
+<pad name="4" x="-2.159" y="5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
+<pad name="5" x="15.113" y="0" drill="4.1148" diameter="6.477"/>
+<pad name="6" x="-15.113" y="0" drill="4.1148" diameter="6.477"/>
+<text x="-3.81" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-3.81" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.2032" layer="21" curve="-60.173068" cap="flat"/>
+<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.2032" layer="21" curve="59.404169" cap="flat"/>
+<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.2032" layer="21" curve="-30.113639" cap="flat"/>
+<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.2032" layer="21"/>
+<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.2032" layer="21" curve="28.0726" cap="flat"/>
+<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.2032" layer="21"/>
+<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.2032" layer="21" curve="30.113639" cap="flat"/>
+<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.2032" layer="21" curve="-28.0726" cap="flat"/>
+<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.2032" layer="21"/>
+<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.2032" layer="21"/>
+<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="57.148737" cap="flat"/>
+<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="-57.148737" cap="flat"/>
+</package>
 <package name="TO92-AA">
 <description>&lt;b&gt;TO-92 (2.54mm lead pitch, 3 leads, vertical, linear pad arrangement)&lt;/b&gt;&lt;p&gt;
 Header family flat index. 2.54mm lead pitch, 3 leads, vertical, linear pad arrangement. JEDEC TO-226G, variation AA.

--- a/ref-packages-transistor.lbr
+++ b/ref-packages-transistor.lbr
@@ -477,6 +477,33 @@ Also known as SOT186.</description>
 <wire x1="5.207" y1="12.7" x2="5.207" y2="14.605" width="0.2032" layer="21"/>
 <wire x1="5.207" y1="14.605" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
 </package>
+<package name="TO3">
+<description>&lt;b&gt;TO-3 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-3.
+&lt;/p&gt;</description>
+<circle x="-15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="9.3726" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
+<circle x="15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<pad name="1" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="2" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="3" x="15.113" y="0" drill="4.1148" diameter="6.477"/>
+<pad name="4" x="-15.113" y="0" drill="4.1148" diameter="6.477"/>
+<text x="2.54" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="5.08" y="-3.81" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.2032" layer="21" curve="-60.173068" cap="flat"/>
+<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.2032" layer="21" curve="59.404169" cap="flat"/>
+<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.2032" layer="21" curve="-30.113639" cap="flat"/>
+<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.2032" layer="21"/>
+<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.2032" layer="21" curve="28.0726" cap="flat"/>
+<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.2032" layer="21"/>
+<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.2032" layer="21" curve="30.113639" cap="flat"/>
+<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.2032" layer="21" curve="-28.0726" cap="flat"/>
+<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.2032" layer="21"/>
+<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.2032" layer="21"/>
+<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="57.148737" cap="flat"/>
+<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="-57.148737" cap="flat"/>
+</package>
 <package name="TO92-AA">
 <description>&lt;b&gt;TO-92 (2.54mm lead pitch, 3 leads, vertical, linear pad arrangement)&lt;/b&gt;&lt;p&gt;
 Header family flat index. 2.54mm lead pitch, 3 leads, vertical, linear pad arrangement. JEDEC TO-226G, variation AA.

--- a/ref-packages.lbr
+++ b/ref-packages.lbr
@@ -79,24 +79,12 @@ To use, open any library and&lt;p&gt;
 2) when prompted, select the script 'update-smd-ic.scr'.&lt;p&gt;
 &lt;author&gt;Created by Bob Starr, rtzaudio@mindspring.com&lt;/author&gt;</description>
 <packages>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="3.175" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -105,34 +93,25 @@ To use, open any library and&lt;p&gt;
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
-<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -141,6 +120,28 @@ To use, open any library and&lt;p&gt;
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
 <package name="TO263-3">
 <description>&lt;b&gt;TO-263 Package&lt;/b&gt;</description>

--- a/resistor-power.lbr
+++ b/resistor-power.lbr
@@ -1902,24 +1902,12 @@ Metal-Mite 25W</description>
 <hole x="9.13" y="9.92" drill="3.2"/>
 <hole x="-9.13" y="-9.92" drill="3.2"/>
 </package>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="3.175" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -1928,6 +1916,18 @@ Metal-Mite 25W</description>
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
 <package name="ASP10">
 <description>ASP10 10W High Power&lt;p&gt;
@@ -2050,33 +2050,12 @@ two lead horizontal mount</description>
 <rectangle x1="-2.921" y1="-6.35" x2="-2.159" y2="-4.445" layer="51"/>
 <hole x="0" y="11.176" drill="3.302"/>
 </package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
-<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -2085,6 +2064,28 @@ two lead horizontal mount</description>
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
 <package name="TUM10">
 <description>&lt;b&gt;CEMENT POWER RESISTOR&lt;/b&gt; - 10W&lt;p&gt;
@@ -2948,7 +2949,7 @@ body 18 x 10 mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TDH35" package="DPAK">
+<device name="TDH35" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="3"/>
@@ -3082,7 +3083,7 @@ Source: www.token.com.tw .. power-resistor-rmg100pdf</description>
 <gate name="G$1" symbol="R" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="D2PAK">
+<device name="" package="TO263-AB">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="3"/>

--- a/smd-special.lbr
+++ b/smd-special.lbr
@@ -2640,33 +2640,12 @@
 <text x="-16.51" y="18.161" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-7.62" y="18.288" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
-<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -2675,25 +2654,35 @@
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="3.175" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -2702,6 +2691,18 @@
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
 <package name="SMB">
 <description>&lt;B&gt;DIODE&lt;/B&gt;</description>

--- a/transistor-fet.lbr
+++ b/transistor-fet.lbr
@@ -114,145 +114,54 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <wire x1="2.413" y1="-1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
 </package>
 <package name="TO3">
-<description>&lt;b&gt;TO 3&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
+<description>&lt;b&gt;TO-3 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-3.
+&lt;/p&gt;</description>
+<circle x="-15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="9.3726" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
+<circle x="15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
 <pad name="1" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
 <pad name="2" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
 <pad name="3" x="15.113" y="0" drill="4.1148" diameter="6.477"/>
 <pad name="4" x="-15.113" y="0" drill="4.1148" diameter="6.477"/>
 <text x="2.54" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.08" y="-3.81" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<text x="15.24" y="-4.953" size="1.27" layer="51" ratio="10" rot="R90">3</text>
-<text x="-5.08" y="-3.683" size="1.27" layer="51" ratio="10" rot="R90">1</text>
-<text x="-5.08" y="3.302" size="1.27" layer="51" ratio="10" rot="R90">2</text>
-<text x="-13.97" y="-4.953" size="1.27" layer="51" ratio="10" rot="R90">4</text>
-</package>
-<package name="TO3A">
-<description>&lt;b&gt;&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="1" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
-<pad name="2" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
-<pad name="3" x="15.113" y="0" drill="3.302" diameter="6.477"/>
-<pad name="4" x="-15.113" y="0" drill="3.302" diameter="6.477"/>
-<text x="2.54" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-3.81" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<text x="15.24" y="-4.953" size="1.27" layer="51" ratio="10" rot="R90">3</text>
-<text x="-3.81" y="4.572" size="1.27" layer="51" ratio="10" rot="R90">2</text>
-<text x="-3.81" y="-6.223" size="1.27" layer="51" ratio="10" rot="R90">1</text>
-<text x="-13.97" y="-4.953" size="1.27" layer="51" ratio="10" rot="R90">4</text>
-</package>
-<package name="TO3/">
-<description>&lt;b&gt;TO 3; 45 degree&lt;/b&gt;</description>
-<wire x1="15.1892" y1="-8.9916" x2="12.319" y2="2.4892" width="0.254" layer="21"/>
-<wire x1="-15.1892" y1="8.9916" x2="-12.319" y2="-2.4892" width="0.254" layer="21"/>
-<wire x1="-8.9916" y1="15.1892" x2="2.9972" y2="12.192" width="0.254" layer="21"/>
-<wire x1="8.9916" y1="-15.1892" x2="-2.4892" y2="-12.319" width="0.254" layer="21"/>
-<wire x1="13.97" y1="-13.97" x2="15.1759" y2="-8.9223" width="0.254" layer="21" curve="63.129135" cap="flat"/>
-<wire x1="2.6343" y1="12.2933" x2="8.89" y2="8.89" width="0.254" layer="21" curve="-32.905092" cap="flat"/>
-<wire x1="8.89" y1="8.89" x2="12.3282" y2="2.4656" width="0.254" layer="21" curve="-33.690295" cap="flat"/>
-<wire x1="8.9123" y1="-15.1725" x2="13.9698" y2="-13.9698" width="0.254" layer="21" curve="63.25073" cap="flat"/>
-<wire x1="-15.1758" y1="8.9223" x2="-13.9699" y2="13.9699" width="0.254" layer="21" curve="-63.129366" cap="flat"/>
-<wire x1="-13.97" y1="13.97" x2="-8.9123" y2="15.1727" width="0.254" layer="21" curve="-63.250262" cap="flat"/>
-<wire x1="-12.3282" y1="-2.4656" x2="-8.89" y2="-8.89" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<wire x1="-8.89" y1="-8.89" x2="-2.4656" y2="-12.3282" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="10.668" y="-10.668" radius="2.159" width="0.254" layer="51"/>
-<circle x="-10.668" y="10.668" radius="2.159" width="0.254" layer="51"/>
-<pad name="1" x="-5.08" y="-2.54" drill="1.1938" diameter="3.1496" shape="octagon"/>
-<pad name="2" x="2.54" y="5.08" drill="1.1938" diameter="3.1496" shape="octagon"/>
-<pad name="3" x="10.668" y="-10.668" drill="4.1148" diameter="6.477"/>
-<pad name="4" x="-10.668" y="10.668" drill="4.1148" diameter="6.477"/>
-<text x="-1.905" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="5.08" y="-12.7" size="1.27" layer="51" ratio="10">3</text>
-<text x="-6.35" y="0" size="1.27" layer="51" ratio="10">1</text>
-<text x="5.08" y="4.445" size="1.27" layer="51" ratio="10">2</text>
-<text x="-13.97" y="6.35" size="1.27" layer="51" ratio="10">4</text>
-</package>
-<package name="TO3/A">
-<description>&lt;b&gt;&lt;/b&gt;</description>
-<wire x1="15.1892" y1="-8.9916" x2="12.319" y2="2.4892" width="0.254" layer="21"/>
-<wire x1="-15.1892" y1="8.9916" x2="-12.319" y2="-2.4892" width="0.254" layer="21"/>
-<wire x1="-8.9916" y1="15.1892" x2="2.9972" y2="12.192" width="0.254" layer="21"/>
-<wire x1="8.9916" y1="-15.1892" x2="-2.4892" y2="-12.319" width="0.254" layer="21"/>
-<wire x1="13.97" y1="-13.97" x2="15.1759" y2="-8.9223" width="0.254" layer="21" curve="63.129135" cap="flat"/>
-<wire x1="2.6343" y1="12.2933" x2="8.89" y2="8.89" width="0.254" layer="21" curve="-32.905092" cap="flat"/>
-<wire x1="8.89" y1="8.89" x2="12.3282" y2="2.4656" width="0.254" layer="21" curve="-33.690295" cap="flat"/>
-<wire x1="8.9123" y1="-15.1725" x2="13.9698" y2="-13.9698" width="0.254" layer="21" curve="63.25073" cap="flat"/>
-<wire x1="-15.1758" y1="8.9223" x2="-13.9699" y2="13.9699" width="0.254" layer="21" curve="-63.129366" cap="flat"/>
-<wire x1="-13.97" y1="13.97" x2="-8.9123" y2="15.1727" width="0.254" layer="21" curve="-63.250262" cap="flat"/>
-<wire x1="-12.3282" y1="-2.4656" x2="-8.89" y2="-8.89" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<wire x1="-8.89" y1="-8.89" x2="-2.4656" y2="-12.3282" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="10.668" y="-10.668" radius="2.159" width="0.254" layer="51"/>
-<circle x="-10.668" y="10.668" radius="2.159" width="0.254" layer="51"/>
-<pad name="1" x="-5.08" y="-2.54" drill="1.1938" diameter="3.1496" shape="octagon"/>
-<pad name="2" x="2.54" y="5.08" drill="1.1938" diameter="3.1496" shape="octagon"/>
-<pad name="3" x="10.668" y="-10.668" drill="3.302" diameter="6.477"/>
-<pad name="4" x="-10.668" y="10.668" drill="3.302" diameter="6.477"/>
-<text x="-1.905" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="6.35" y="-13.97" size="1.27" layer="51" ratio="10">3</text>
-<text x="-6.35" y="0" size="1.27" layer="51" ratio="10">1</text>
-<text x="5.08" y="4.445" size="1.27" layer="51" ratio="10">2</text>
-<text x="-13.97" y="6.35" size="1.27" layer="51" ratio="10">4</text>
+<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.2032" layer="21" curve="-60.173068" cap="flat"/>
+<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.2032" layer="21" curve="59.404169" cap="flat"/>
+<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.2032" layer="21" curve="-30.113639" cap="flat"/>
+<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.2032" layer="21"/>
+<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.2032" layer="21" curve="28.0726" cap="flat"/>
+<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.2032" layer="21"/>
+<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.2032" layer="21" curve="30.113639" cap="flat"/>
+<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.2032" layer="21" curve="-28.0726" cap="flat"/>
+<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.2032" layer="21"/>
+<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.2032" layer="21"/>
+<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="57.148737" cap="flat"/>
+<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="-57.148737" cap="flat"/>
 </package>
 <package name="TO72">
-<description>&lt;b&gt;&lt;/b&gt;</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="51" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-72 (4 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-72.
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
 <pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="4" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.651" y="-1.651" size="1.27" layer="51" ratio="10">1</text>
-<text x="0.508" y="-1.651" size="1.27" layer="51" ratio="10">2</text>
-<text x="0.508" y="0.381" size="1.27" layer="51" ratio="10">3</text>
-<text x="-1.651" y="0.381" size="1.27" layer="51" ratio="10">4</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="51" curve="-45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
 </package>
 <package name="TO202">
 <description>&lt;b&gt;&lt;/b&gt;</description>
@@ -295,47 +204,27 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <rectangle x1="-2.921" y1="-5.08" x2="-2.159" y2="-3.429" layer="51"/>
 <hole x="0" y="17.78" drill="3.302"/>
 </package>
-<package name="TO18-">
-<description>&lt;b&gt;&lt;/b&gt;</description>
-<wire x1="-2.2098" y1="-0.9692" x2="2.2098" y2="-0.9692" width="0.0508" layer="51" curve="132.636282" cap="flat"/>
-<wire x1="-0.9692" y1="2.2098" x2="0.9692" y2="2.2098" width="0.0508" layer="51" curve="-47.363718" cap="flat"/>
-<wire x1="-2.2098" y1="0.9692" x2="-2.2098" y2="-0.9692" width="0.0508" layer="51" curve="47.363718" cap="flat"/>
-<wire x1="-2.2098" y1="0.9692" x2="-0.9692" y2="2.2098" width="0.0508" layer="51" curve="-42.636282" cap="flat"/>
-<wire x1="2.2098" y1="-0.9692" x2="2.2098" y2="0.9692" width="0.0508" layer="51" curve="47.363718" cap="flat"/>
-<wire x1="1.649" y1="-2.411" x2="2.413" y2="-3.175" width="0.2032" layer="21"/>
-<wire x1="2.411" y1="-1.649" x2="3.175" y2="-2.413" width="0.2032" layer="21"/>
-<wire x1="2.413" y1="-3.175" x2="3.175" y2="-2.413" width="0.2032" layer="21"/>
-<wire x1="0.9692" y1="2.2098" x2="2.2098" y2="0.9692" width="0.0508" layer="51" curve="-42.636282" cap="flat"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="1" x="1.905" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="-1.905" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.302" y="0.381" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.302" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="1.016" y="-1.143" size="1.27" layer="51" ratio="10">1</text>
-<text x="-0.508" y="0.635" size="1.27" layer="51" ratio="10">2</text>
-<text x="-1.905" y="-1.27" size="1.27" layer="51" ratio="10">3</text>
-</package>
 <package name="TO18">
-<description>&lt;b&gt;&lt;/b&gt;</description>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="51" curve="-135.281008" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-2.8765" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8765" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<description>&lt;b&gt;TO-18 (2.54mm lead pitch, 3 leads)&lt;/b&gt;&lt;p&gt;
+Header family package. 2.54mm lead pitch, 3 leads, metal can.
+&lt;p/&gt;&lt;p&gt;
+JEDEC TO-18.
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
 <pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.905" y="-1.27" size="1.27" layer="51" ratio="10">1</text>
-<text x="0.635" y="-1.27" size="1.27" layer="51" ratio="10">2</text>
-<text x="0" y="0.635" size="1.27" layer="51" ratio="10">3</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="-0.508" x2="-2.8765" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="0.508" x2="-2.8765" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="51" curve="-135.281008" cap="flat"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
 </package>
 <package name="TO218">
 <description>&lt;b&gt;&lt;/b&gt;</description>
@@ -509,17 +398,19 @@ Also known as SOT78.</description>
 <rectangle x1="4.064" y1="-1.524" x2="6.858" y2="-1.143" layer="51"/>
 </package>
 <package name="TO5">
-<description>&lt;b&gt;&lt;/b&gt;</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-5 (3 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-5
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
 <circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
 <pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
 <package name="TO126">
 <description>&lt;b&gt;&lt;/b&gt;</description>
@@ -557,53 +448,28 @@ Also known as SOT78.</description>
 <rectangle x1="1.905" y1="-5.207" x2="2.667" y2="-3.429" layer="51"/>
 <hole x="0" y="5.08" drill="3.302"/>
 </package>
-<package name="TO66/">
-<description>&lt;b&gt;&lt;/b&gt;</description>
-<wire x1="3.1066" y1="8.0579" x2="-7.3141" y2="12.0755" width="0.254" layer="21"/>
-<wire x1="-3.1066" y1="-8.0579" x2="7.3141" y2="-12.0755" width="0.254" layer="21"/>
-<wire x1="-8.0579" y1="-3.1066" x2="-12.0755" y2="7.3141" width="0.254" layer="21"/>
-<wire x1="-8.0579" y1="-3.1066" x2="-3.1066" y2="-8.0578" width="0.254" layer="21" curve="47.833617" cap="flat"/>
-<wire x1="-12.0755" y1="7.3141" x2="-7.3141" y2="12.0755" width="0.254" layer="21" curve="-132.167054"/>
-<wire x1="8.0579" y1="3.1066" x2="12.0755" y2="-7.3141" width="0.254" layer="21"/>
-<wire x1="7.3141" y1="-12.0755" x2="12.0755" y2="-7.3141" width="0.254" layer="21" curve="132.167054"/>
-<wire x1="3.1066" y1="8.0579" x2="8.058" y2="3.1066" width="0.254" layer="21" curve="-47.834094" cap="flat"/>
-<circle x="0" y="0" radius="7.874" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="6.35" width="0.254" layer="51"/>
-<circle x="-8.621" y="8.621" radius="1.905" width="0.254" layer="51"/>
-<circle x="8.621" y="-8.621" radius="1.905" width="0.254" layer="51"/>
-<pad name="1" x="-3.5814" y="0" drill="1.1176" diameter="2.54" shape="octagon"/>
-<pad name="2" x="0" y="3.5814" drill="1.1176" diameter="2.54" shape="octagon"/>
-<pad name="TO66" x="-8.636" y="8.636" drill="3.302" diameter="6.35"/>
-<pad name="3" x="8.636" y="-8.636" drill="3.302" diameter="6.35"/>
-<text x="-5.588" y="1.143" size="1.016" layer="21" ratio="18">1</text>
-<text x="-2.54" y="4.318" size="1.016" layer="21" ratio="18">2</text>
-<text x="3.81" y="-10.16" size="1.016" layer="21" ratio="18">3</text>
-<text x="0" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.143" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="TO66">
-<description>&lt;b&gt;&lt;/b&gt;</description>
-<wire x1="-3.5011" y1="-7.8945" x2="3.5011" y2="-7.8945" width="0.254" layer="21" curve="47.833229"/>
-<wire x1="-3.5011" y1="7.8945" x2="3.5011" y2="7.8945" width="0.254" layer="21" curve="-47.833229"/>
-<wire x1="-13.7105" y1="3.3668" x2="-13.7105" y2="-3.3668" width="0.254" layer="21" curve="132.167583"/>
-<wire x1="-3.5011" y1="-7.8945" x2="-13.7105" y2="-3.3668" width="0.254" layer="21"/>
-<wire x1="-3.5011" y1="7.8945" x2="-13.7105" y2="3.3668" width="0.254" layer="21"/>
-<wire x1="13.7105" y1="-3.3668" x2="13.7105" y2="3.3668" width="0.254" layer="21" curve="132.167583"/>
-<wire x1="3.5011" y1="-7.8945" x2="13.7105" y2="-3.3668" width="0.254" layer="21"/>
-<wire x1="3.5011" y1="7.8945" x2="13.7105" y2="3.3668" width="0.254" layer="21"/>
-<circle x="0" y="0" radius="7.874" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="6.35" width="0.254" layer="51"/>
-<circle x="-12.192" y="0" radius="1.905" width="0.254" layer="51"/>
-<circle x="12.192" y="0" radius="1.905" width="0.254" layer="51"/>
-<pad name="TO66" x="-12.192" y="0" drill="3.302" diameter="6.35"/>
-<pad name="3" x="12.192" y="0" drill="3.302" diameter="6.35"/>
-<pad name="2" x="-2.54" y="2.54" drill="1.1176" diameter="2.54" shape="long"/>
+<description>&lt;b&gt;TO-66 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-66.
+&lt;/p&gt;</description>
+<circle x="-12.192" y="0" radius="1.905" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="7.874" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="6.35" width="0.2032" layer="51"/>
+<circle x="12.192" y="0" radius="1.905" width="0.2032" layer="51"/>
 <pad name="1" x="-2.54" y="-2.54" drill="1.1176" diameter="2.54" shape="long"/>
-<text x="8.89" y="-4.445" size="1.016" layer="21" ratio="18">3</text>
+<pad name="2" x="-2.54" y="2.54" drill="1.1176" diameter="2.54" shape="long"/>
+<pad name="3" x="12.192" y="0" drill="3.302" diameter="6.35"/>
+<pad name="4" x="-12.192" y="0" drill="3.302" diameter="6.35"/>
 <text x="1.27" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.175" y="-3.175" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<text x="-5.08" y="1.905" size="1.016" layer="21" ratio="18">2</text>
-<text x="-5.08" y="-3.175" size="1.016" layer="21" ratio="18">1</text>
+<wire x1="-13.711" y1="3.3666" x2="-13.711" y2="-3.367" width="0.2032" layer="21" curve="132.167583" cap="flat"/>
+<wire x1="-3.501" y1="-7.895" x2="3.5012" y2="-7.895" width="0.2032" layer="21" curve="47.833229" cap="flat"/>
+<wire x1="-3.501" y1="-7.895" x2="-13.711" y2="-3.367" width="0.2032" layer="21"/>
+<wire x1="-3.501" y1="7.895" x2="3.5012" y2="7.895" width="0.2032" layer="21" curve="-47.833229" cap="flat"/>
+<wire x1="-3.501" y1="7.895" x2="-13.711" y2="3.367" width="0.2032" layer="21"/>
+<wire x1="3.501" y1="-7.895" x2="13.711" y2="-3.367" width="0.2032" layer="21"/>
+<wire x1="3.501" y1="7.895" x2="13.711" y2="3.367" width="0.2032" layer="21"/>
+<wire x1="13.711" y1="-3.367" x2="13.711" y2="3.3666" width="0.2032" layer="21" curve="132.167583" cap="flat"/>
 </package>
 <package name="TO202V">
 <description>&lt;b&gt;&lt;/b&gt;</description>
@@ -659,18 +525,20 @@ Also known as SOT78.</description>
 <rectangle x1="-0.889" y1="-0.381" x2="0.889" y2="0" layer="51"/>
 <rectangle x1="1.397" y1="-0.381" x2="3.175" y2="0" layer="51"/>
 </package>
-<package name="TO-39">
-<description>&lt;b&gt;TP 39&lt;/b&gt;</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<package name="TO39">
+<description>&lt;b&gt;TO-39&lt;/b&gt;&lt;p&gt;
+JEDEC TO-39
+&lt;p/&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
 <circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
 <pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.6162" y="5.5626" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-6.35" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
 <package name="TO-52">
 <description>&lt;b&gt;TO 52&lt;/b&gt;</description>
@@ -4362,7 +4230,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EP-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO-39">
+<device name="" package="TO39">
 <connects>
 <connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
@@ -4380,7 +4248,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EP-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO-39">
+<device name="" package="TO39">
 <connects>
 <connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
@@ -4398,7 +4266,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EN-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO-39">
+<device name="" package="TO39">
 <connects>
 <connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>
@@ -4535,7 +4403,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EN-GDS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO-39">
+<device name="" package="TO39">
 <connects>
 <connect gate="G$1" pin="D" pad="3"/>
 <connect gate="G$1" pin="G" pad="2"/>

--- a/transistor-fet.lbr
+++ b/transistor-fet.lbr
@@ -691,33 +691,12 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <rectangle x1="1.25" y1="-2.15" x2="1.75" y2="-1.15" layer="51"/>
 <rectangle x1="-0.85" y1="1.65" x2="0.85" y2="2.2" layer="51"/>
 </package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
-<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -726,6 +705,28 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
 <package name="POWERPAK-SO-08">
 <description>&lt;b&gt;PowerPAK SO-8&lt;/b&gt;&lt;p&gt;</description>
@@ -840,24 +841,12 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <rectangle x1="-0.8731" y1="3.175" x2="-0.3969" y2="3.3338" layer="51"/>
 <rectangle x1="-2.1431" y1="3.175" x2="-1.6669" y2="3.3338" layer="51"/>
 </package>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="3.175" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -866,6 +855,18 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
 <package name="TO71">
 <description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
@@ -4641,9 +4642,9 @@ Panasonic SMini3-F2-B</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="D2PAK">
+<device name="NS" package="TO263-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="2"/>
+<connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="3"/>
 </connects>
@@ -4660,9 +4661,9 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="MFNS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="NS" package="D2PAK">
+<device name="NS" package="TO263-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="2"/>
+<connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="3"/>
 </connects>
@@ -4688,7 +4689,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="MFNS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -4788,7 +4789,7 @@ Vgs=12V</description>
 <gate name="G$1" symbol="MFNS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -4825,7 +4826,7 @@ Vgs=12V</description>
 <gate name="G$1" symbol="EMOS-N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -5117,7 +5118,7 @@ SuperMESH MOSFET</description>
 <gate name="G$1" symbol="MFNS" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -5252,9 +5253,9 @@ Supertex Inc.</description>
 <gate name="G$1" symbol="MFNS" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="D2PAK">
+<device name="" package="TO263-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="2"/>
+<connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="3"/>
 </connects>
@@ -5344,7 +5345,7 @@ Monolithic Dual, Ultra Low Noise</description>
 <gate name="G$1" symbol="EMOS-PD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -5458,7 +5459,7 @@ Supertex Inc.</description>
 <gate name="G$1" symbol="MFPS" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -5514,7 +5515,7 @@ N-CHANNEL 650V@Tjmax - 0.9 ohm - 8A</description>
 <gate name="G$1" symbol="MFNS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="T4" package="DPAK">
+<device name="T4" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -5573,9 +5574,9 @@ N-CHANNEL 650V@Tjmax - 0.9 ohm - 8A</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T4" package="D2PAK">
+<device name="T4" package="TO263-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="2"/>
+<connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="3"/>
 </connects>
@@ -5789,7 +5790,7 @@ N-CHANNEL 650V@Tjmax - 0.9 ohm - 8A</description>
 <gate name="G$1" symbol="EMOS-ND" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -5808,7 +5809,7 @@ N-channel 60V - 0.08 ohm - 12A</description>
 <gate name="G$1" symbol="MFNS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="T4" package="DPAK">
+<device name="T4" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -6776,7 +6777,7 @@ OMNIFET-II 40V 6A DPAK</description>
 <gate name="G$1" symbol="EMOS-ND" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -7348,9 +7349,9 @@ PowerTrench, 30V, 4.9A, 42mOhm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="D2PAK">
+<device name="S" package="TO263-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="2"/>
+<connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="3"/>
 </connects>
@@ -7475,9 +7476,9 @@ PowerTrench, 30V, 4.9A, 42mOhm</description>
 <gate name="G$1" symbol="EMOS-ND" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="D2PAK">
+<device name="" package="TO263-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="2"/>
+<connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="3"/>
 </connects>
@@ -7551,7 +7552,7 @@ PowerTrench, 30V, 4.9A, 42mOhm</description>
 <gate name="G$1" symbol="EMOS-ND" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -7691,9 +7692,9 @@ N-FET AND P-FET</description>
 <gate name="G$1" symbol="MFNS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="D2PAK">
+<device name="" package="TO263-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="2"/>
+<connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="3"/>
 </connects>
@@ -7710,7 +7711,7 @@ MOSFET P-CH 55V 18A DPAK</description>
 <gate name="G$1" symbol="MFPS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -7949,7 +7950,7 @@ MOSFET P-CH 55V 18A DPAK</description>
 <gate name="G$1" symbol="EMOS-PD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -7967,7 +7968,7 @@ MOSFET P-CH 55V 18A DPAK</description>
 <gate name="G$1" symbol="MFNS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DPAK">
+<device name="N" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>

--- a/transistor-npn.lbr
+++ b/transistor-npn.lbr
@@ -788,33 +788,12 @@ grid 2.54 mm</description>
 <rectangle x1="-1.1938" y1="-1.3208" x2="-0.3048" y2="-0.635" layer="51"/>
 <rectangle x1="-0.4001" y1="-0.3" x2="0.4001" y2="0.5001" layer="35"/>
 </package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
-<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -823,6 +802,28 @@ grid 2.54 mm</description>
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
 <package name="TO225AAV">
 <description>&lt;b&gt;TO-225&lt;/b&gt;&lt;p&gt;
@@ -838,24 +839,12 @@ grid 2.54 mm, vertical</description>
 <text x="-3.175" y="1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <rectangle x1="-3.4925" y1="1.1113" x2="3.4925" y2="1.5875" layer="21"/>
 </package>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="3.175" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -864,6 +853,18 @@ grid 2.54 mm, vertical</description>
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
 <package name="TO220-AB-H">
 <description>&lt;b&gt;TO-220 AB (2.54mm lead pitch, 3 leads, exposed pad, horizontal, 17.5mm lead-to-hole)&lt;/b&gt;&lt;p&gt;
@@ -5576,7 +5577,7 @@ complimentary to CMPTA56</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
 <connect gate="G$1" pin="C" pad="4"/>
@@ -5702,7 +5703,7 @@ complimentary to CMPTA56</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
 <connect gate="G$1" pin="C" pad="4"/>
@@ -5748,7 +5749,7 @@ complimentary to CMPTA56</description>
 <gate name="G$1" symbol="NPN-DAR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
 <connect gate="G$1" pin="C" pad="4"/>

--- a/transistor-npn.lbr
+++ b/transistor-npn.lbr
@@ -79,143 +79,54 @@
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
 <package name="TO3">
-<description>&lt;b&gt;TO-3&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
-<pad name="B" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
-<pad name="C" x="15.113" y="0" drill="4.1148" diameter="6.477"/>
-<pad name="C/" x="-15.113" y="0" drill="4.1148" diameter="6.477"/>
-<text x="-5.08" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-5.08" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="15.24" y="-4.953" size="1.27" layer="51" ratio="10" rot="R90">C</text>
-<text x="-3.81" y="-6.223" size="1.27" layer="51" ratio="10" rot="R90">E</text>
-<text x="-3.81" y="4.572" size="1.27" layer="51" ratio="10" rot="R90">B</text>
-</package>
-<package name="TO3A">
-<description>&lt;b&gt;TO-3&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
-<pad name="B" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
-<pad name="C" x="15.113" y="0" drill="3.302" diameter="6.477"/>
-<pad name="C/" x="-15.113" y="0" drill="3.302" diameter="6.477"/>
-<text x="-6.35" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-6.35" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-5.588" y="5.08" size="1.27" layer="51" ratio="10">B</text>
-<text x="-4.953" y="-6.35" size="1.27" layer="51" ratio="10">E</text>
-<text x="11.557" y="-3.81" size="1.27" layer="51" ratio="10">C</text>
-</package>
-<package name="TO3/">
-<description>&lt;b&gt;TO-3&lt;/b&gt;&lt;p&gt;
-rotated 45 deg.</description>
-<wire x1="15.1892" y1="-8.9916" x2="12.319" y2="2.4892" width="0.254" layer="21"/>
-<wire x1="-15.1892" y1="8.9916" x2="-12.319" y2="-2.4892" width="0.254" layer="21"/>
-<wire x1="-8.9916" y1="15.1892" x2="2.9972" y2="12.192" width="0.254" layer="21"/>
-<wire x1="8.9916" y1="-15.1892" x2="-2.4892" y2="-12.319" width="0.254" layer="21"/>
-<wire x1="13.97" y1="-13.97" x2="15.1759" y2="-8.9223" width="0.254" layer="21" curve="63.129135" cap="flat"/>
-<wire x1="2.6343" y1="12.2933" x2="8.89" y2="8.89" width="0.254" layer="21" curve="-32.905092" cap="flat"/>
-<wire x1="8.89" y1="8.89" x2="12.3282" y2="2.4656" width="0.254" layer="21" curve="-33.690295" cap="flat"/>
-<wire x1="8.9123" y1="-15.1725" x2="13.9696" y2="-13.9696" width="0.254" layer="21" curve="63.249953" cap="flat"/>
-<wire x1="-15.1758" y1="8.9223" x2="-13.9699" y2="13.9699" width="0.254" layer="21" curve="-63.129366" cap="flat"/>
-<wire x1="-13.97" y1="13.97" x2="-8.9123" y2="15.1729" width="0.254" layer="21" curve="-63.249016" cap="flat"/>
-<wire x1="-12.3282" y1="-2.4656" x2="-8.89" y2="-8.89" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<wire x1="-8.89" y1="-8.89" x2="-2.4656" y2="-12.3282" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="10.668" y="-10.668" radius="2.159" width="0.254" layer="51"/>
-<circle x="-10.668" y="10.668" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-5.08" y="-2.54" drill="1.1938" diameter="3.1496" shape="octagon"/>
-<pad name="B" x="2.54" y="5.08" drill="1.1938" diameter="3.1496" shape="octagon"/>
-<pad name="C" x="10.668" y="-10.668" drill="4.1148" diameter="6.477"/>
-<pad name="C/" x="-10.668" y="10.668" drill="4.1148" diameter="6.477"/>
-<text x="-1.905" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-7.62" y="-1.27" size="1.27" layer="51" ratio="10">E</text>
-<text x="0" y="5.715" size="1.27" layer="51" ratio="10">B</text>
-<text x="6.35" y="-11.43" size="1.27" layer="51" ratio="10">C</text>
-</package>
-<package name="TO3/A">
-<description>&lt;b&gt;TO-3&lt;/b&gt;&lt;p&gt;
-rotated 45 deg.</description>
-<wire x1="15.1892" y1="-8.9916" x2="12.319" y2="2.4892" width="0.254" layer="21"/>
-<wire x1="-15.1892" y1="8.9916" x2="-12.319" y2="-2.4892" width="0.254" layer="21"/>
-<wire x1="-8.9916" y1="15.1892" x2="2.9972" y2="12.192" width="0.254" layer="21"/>
-<wire x1="8.9916" y1="-15.1892" x2="-2.4892" y2="-12.319" width="0.254" layer="21"/>
-<wire x1="13.97" y1="-13.97" x2="15.1759" y2="-8.9223" width="0.254" layer="21" curve="63.129135" cap="flat"/>
-<wire x1="2.6343" y1="12.2933" x2="8.89" y2="8.89" width="0.254" layer="21" curve="-32.905092" cap="flat"/>
-<wire x1="8.89" y1="8.89" x2="12.3282" y2="2.4656" width="0.254" layer="21" curve="-33.690295" cap="flat"/>
-<wire x1="8.9123" y1="-15.1725" x2="13.9696" y2="-13.9696" width="0.254" layer="21" curve="63.249953" cap="flat"/>
-<wire x1="-15.1758" y1="8.9223" x2="-13.9699" y2="13.9699" width="0.254" layer="21" curve="-63.129366" cap="flat"/>
-<wire x1="-13.97" y1="13.97" x2="-8.9123" y2="15.1729" width="0.254" layer="21" curve="-63.249016" cap="flat"/>
-<wire x1="-12.3282" y1="-2.4656" x2="-8.89" y2="-8.89" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<wire x1="-8.89" y1="-8.89" x2="-2.4656" y2="-12.3282" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="10.668" y="-10.668" radius="2.159" width="0.254" layer="51"/>
-<circle x="-10.668" y="10.668" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-5.08" y="-2.54" drill="1.1938" diameter="3.1496" shape="octagon"/>
-<pad name="B" x="2.54" y="5.08" drill="1.1938" diameter="3.1496" shape="octagon"/>
-<pad name="C" x="10.668" y="-10.668" drill="3.302" diameter="6.477"/>
-<pad name="C/" x="-10.668" y="10.668" drill="3.302" diameter="6.477"/>
-<text x="-3.175" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-7.62" y="-1.27" size="1.27" layer="51" ratio="10">E</text>
-<text x="0" y="5.715" size="1.27" layer="51" ratio="10">B</text>
-<text x="6.35" y="-11.43" size="1.27" layer="51" ratio="10">C</text>
+<description>&lt;b&gt;TO-3 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-3.
+&lt;/p&gt;</description>
+<circle x="-15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="9.3726" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
+<circle x="15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<pad name="1" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="2" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="3" x="15.113" y="0" drill="4.1148" diameter="6.477"/>
+<pad name="4" x="-15.113" y="0" drill="4.1148" diameter="6.477"/>
+<text x="2.54" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="5.08" y="-3.81" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.2032" layer="21" curve="-60.173068" cap="flat"/>
+<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.2032" layer="21" curve="59.404169" cap="flat"/>
+<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.2032" layer="21" curve="-30.113639" cap="flat"/>
+<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.2032" layer="21"/>
+<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.2032" layer="21" curve="28.0726" cap="flat"/>
+<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.2032" layer="21"/>
+<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.2032" layer="21" curve="30.113639" cap="flat"/>
+<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.2032" layer="21" curve="-28.0726" cap="flat"/>
+<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.2032" layer="21"/>
+<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.2032" layer="21"/>
+<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="57.148737" cap="flat"/>
+<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="-57.148737" cap="flat"/>
 </package>
 <package name="TO72">
-<description>&lt;b&gt;TO-72&lt;/b&gt;</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="51" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-72 (4 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-72.
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
 <pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="4" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.651" y="-1.651" size="1.27" layer="51" ratio="10">1</text>
-<text x="0.508" y="-1.651" size="1.27" layer="51" ratio="10">2</text>
-<text x="0.508" y="0.381" size="1.27" layer="51" ratio="10">3</text>
-<text x="-1.651" y="0.381" size="1.27" layer="51" ratio="10">4</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="51" curve="-45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
 </package>
 <package name="TO202">
 <description>&lt;b&gt;TO-202&lt;/b&gt;&lt;p&gt;
@@ -256,47 +167,27 @@ grid 2.54 mm, vertical</description>
 <rectangle x1="-2.921" y1="-5.08" x2="-2.159" y2="-3.429" layer="51"/>
 <hole x="0" y="17.78" drill="3.302"/>
 </package>
-<package name="TO18-">
-<description>&lt;b&gt;TO-18&lt;/b&gt;</description>
-<wire x1="-2.2098" y1="-0.9692" x2="2.2098" y2="-0.9692" width="0.0508" layer="51" curve="132.636282" cap="flat"/>
-<wire x1="-0.9692" y1="2.2098" x2="0.9692" y2="2.2098" width="0.0508" layer="51" curve="-47.363718" cap="flat"/>
-<wire x1="-2.2098" y1="0.9692" x2="-2.2098" y2="-0.9692" width="0.0508" layer="51" curve="47.363718" cap="flat"/>
-<wire x1="-2.2098" y1="0.9692" x2="-0.9692" y2="2.2098" width="0.0508" layer="51" curve="-42.636282" cap="flat"/>
-<wire x1="2.2098" y1="-0.9692" x2="2.2098" y2="0.9692" width="0.0508" layer="51" curve="47.363718" cap="flat"/>
-<wire x1="1.649" y1="-2.411" x2="2.413" y2="-3.175" width="0.2032" layer="21"/>
-<wire x1="2.411" y1="-1.649" x2="3.175" y2="-2.413" width="0.2032" layer="21"/>
-<wire x1="2.413" y1="-3.175" x2="3.175" y2="-2.413" width="0.2032" layer="21"/>
-<wire x1="0.9692" y1="2.2098" x2="2.2098" y2="0.9692" width="0.0508" layer="51" curve="-42.636282" cap="flat"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="1" x="1.905" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="-1.905" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.302" y="0.381" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.302" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="1.016" y="-1.143" size="1.27" layer="51" ratio="10">1</text>
-<text x="-0.508" y="0.635" size="1.27" layer="51" ratio="10">2</text>
-<text x="-1.905" y="-1.27" size="1.27" layer="51" ratio="10">3</text>
-</package>
 <package name="TO18">
-<description>&lt;b&gt;TO-18&lt;/b&gt;</description>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="51" curve="-135.281008" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-2.877" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="-3.937" y1="0.508" x2="-2.877" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<description>&lt;b&gt;TO-18 (2.54mm lead pitch, 3 leads)&lt;/b&gt;&lt;p&gt;
+Header family package. 2.54mm lead pitch, 3 leads, metal can.
+&lt;p/&gt;&lt;p&gt;
+JEDEC TO-18.
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
 <pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.905" y="-1.27" size="1.27" layer="51" ratio="10">1</text>
-<text x="0.635" y="-1.27" size="1.27" layer="51" ratio="10">2</text>
-<text x="0" y="0.635" size="1.27" layer="51" ratio="10">3</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="-0.508" x2="-2.8765" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="0.508" x2="-2.8765" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="51" curve="-135.281008" cap="flat"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
 </package>
 <package name="TO92-AB">
 <description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
@@ -472,17 +363,19 @@ grid 5.45 mm, vertical</description>
 <rectangle x1="4.064" y1="-1.524" x2="6.858" y2="-1.143" layer="51"/>
 </package>
 <package name="TO5">
-<description>&lt;b&gt;TO-5&lt;/b&gt;</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-5 (3 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-5
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
 <circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
 <pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
 <package name="TO126">
 <description>&lt;b&gt;TO-126&lt;/b&gt;&lt;p&gt;
@@ -521,54 +414,28 @@ grid 2.3 mm, vertical</description>
 <rectangle x1="1.905" y1="-5.207" x2="2.667" y2="-3.048" layer="51"/>
 <hole x="0" y="5.08" drill="3.302"/>
 </package>
-<package name="TO66/">
-<description>&lt;b&gt;TO-66&lt;/b&gt;&lt;p&gt;
-rotated 45 deg.</description>
-<wire x1="3.107" y1="8.058" x2="-7.314" y2="12.076" width="0.254" layer="21"/>
-<wire x1="-3.107" y1="-8.058" x2="7.314" y2="-12.076" width="0.254" layer="21"/>
-<wire x1="-8.058" y1="-3.107" x2="-12.076" y2="7.314" width="0.254" layer="21"/>
-<wire x1="-8.058" y1="-3.107" x2="-3.1067" y2="-8.0582" width="0.254" layer="21" curve="47.833617" cap="flat"/>
-<wire x1="-12.076" y1="7.314" x2="-7.3146" y2="12.0754" width="0.254" layer="21" curve="-132.167054" cap="flat"/>
-<wire x1="8.058" y1="3.107" x2="12.076" y2="-7.314" width="0.254" layer="21"/>
-<wire x1="7.314" y1="-12.076" x2="12.0754" y2="-7.3146" width="0.254" layer="21" curve="132.167054" cap="flat"/>
-<wire x1="3.107" y1="8.058" x2="8.0584" y2="3.1067" width="0.254" layer="21" curve="-47.834094" cap="flat"/>
-<circle x="0" y="0" radius="7.874" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="6.35" width="0.254" layer="51"/>
-<circle x="-8.621" y="8.621" radius="1.905" width="0.254" layer="51"/>
-<circle x="8.621" y="-8.621" radius="1.905" width="0.254" layer="51"/>
-<pad name="1" x="-3.5814" y="0" drill="1.1176" diameter="2.54" shape="octagon"/>
-<pad name="2" x="0" y="3.5814" drill="1.1176" diameter="2.54" shape="octagon"/>
-<pad name="TO66" x="-8.636" y="8.636" drill="3.302" diameter="6.35"/>
-<pad name="3" x="8.636" y="-8.636" drill="3.302" diameter="6.35"/>
-<text x="-5.588" y="1.143" size="1.016" layer="21" ratio="18">1</text>
-<text x="-2.54" y="4.318" size="1.016" layer="21" ratio="18">2</text>
-<text x="3.81" y="-10.16" size="1.016" layer="21" ratio="18">3</text>
-<text x="0" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.143" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="TO66">
-<description>&lt;b&gt;TO-66&lt;/b&gt;</description>
-<wire x1="-3.501" y1="-7.895" x2="3.5012" y2="-7.895" width="0.254" layer="21" curve="47.833229" cap="flat"/>
-<wire x1="-3.501" y1="7.895" x2="3.5012" y2="7.895" width="0.254" layer="21" curve="-47.833229" cap="flat"/>
-<wire x1="-13.711" y1="3.3666" x2="-13.711" y2="-3.367" width="0.254" layer="21" curve="132.167583" cap="flat"/>
-<wire x1="-3.501" y1="-7.895" x2="-13.711" y2="-3.367" width="0.254" layer="21"/>
-<wire x1="-3.501" y1="7.895" x2="-13.711" y2="3.367" width="0.254" layer="21"/>
-<wire x1="13.711" y1="-3.367" x2="13.711" y2="3.3666" width="0.254" layer="21" curve="132.167583" cap="flat"/>
-<wire x1="3.501" y1="-7.895" x2="13.711" y2="-3.367" width="0.254" layer="21"/>
-<wire x1="3.501" y1="7.895" x2="13.711" y2="3.367" width="0.254" layer="21"/>
-<circle x="0" y="0" radius="7.874" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="6.35" width="0.254" layer="51"/>
-<circle x="-12.192" y="0" radius="1.905" width="0.254" layer="51"/>
-<circle x="12.192" y="0" radius="1.905" width="0.254" layer="51"/>
-<pad name="TO66" x="-12.192" y="0" drill="3.302" diameter="6.35"/>
-<pad name="3" x="12.192" y="0" drill="3.302" diameter="6.35"/>
-<pad name="2" x="-2.54" y="2.54" drill="1.1176" diameter="2.54" shape="long"/>
+<description>&lt;b&gt;TO-66 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-66.
+&lt;/p&gt;</description>
+<circle x="-12.192" y="0" radius="1.905" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="7.874" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="6.35" width="0.2032" layer="51"/>
+<circle x="12.192" y="0" radius="1.905" width="0.2032" layer="51"/>
 <pad name="1" x="-2.54" y="-2.54" drill="1.1176" diameter="2.54" shape="long"/>
-<text x="8.89" y="-4.445" size="1.016" layer="21" ratio="18">3</text>
+<pad name="2" x="-2.54" y="2.54" drill="1.1176" diameter="2.54" shape="long"/>
+<pad name="3" x="12.192" y="0" drill="3.302" diameter="6.35"/>
+<pad name="4" x="-12.192" y="0" drill="3.302" diameter="6.35"/>
 <text x="1.27" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.175" y="-3.175" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<text x="-5.08" y="1.905" size="1.016" layer="21" ratio="18">2</text>
-<text x="-5.08" y="-3.175" size="1.016" layer="21" ratio="18">1</text>
+<wire x1="-13.711" y1="3.3666" x2="-13.711" y2="-3.367" width="0.2032" layer="21" curve="132.167583" cap="flat"/>
+<wire x1="-3.501" y1="-7.895" x2="3.5012" y2="-7.895" width="0.2032" layer="21" curve="47.833229" cap="flat"/>
+<wire x1="-3.501" y1="-7.895" x2="-13.711" y2="-3.367" width="0.2032" layer="21"/>
+<wire x1="-3.501" y1="7.895" x2="3.5012" y2="7.895" width="0.2032" layer="21" curve="-47.833229" cap="flat"/>
+<wire x1="-3.501" y1="7.895" x2="-13.711" y2="3.367" width="0.2032" layer="21"/>
+<wire x1="3.501" y1="-7.895" x2="13.711" y2="-3.367" width="0.2032" layer="21"/>
+<wire x1="3.501" y1="7.895" x2="13.711" y2="3.367" width="0.2032" layer="21"/>
+<wire x1="13.711" y1="-3.367" x2="13.711" y2="3.3666" width="0.2032" layer="21" curve="132.167583" cap="flat"/>
 </package>
 <package name="SOT93">
 <description>&lt;b&gt;SOT-93&lt;/b&gt;&lt;p&gt;
@@ -636,17 +503,19 @@ b-c-e, grid 5.45 mm, vertical</description>
 <rectangle x1="-7.62" y1="-2.032" x2="7.62" y2="0" layer="51"/>
 </package>
 <package name="TO39">
-<description>&lt;b&gt;TO-39&lt;/b&gt;</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-39&lt;/b&gt;&lt;p&gt;
+JEDEC TO-39
+&lt;p/&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
 <circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
 <pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
 <package name="TO202V">
 <description>&lt;b&gt;TO-202&lt;/b&gt;&lt;p&gt;
@@ -703,27 +572,6 @@ grid 2.3 mm, horizontal</description>
 <rectangle x1="-3.175" y1="-0.381" x2="-1.397" y2="0" layer="51"/>
 <rectangle x1="-0.889" y1="-0.381" x2="0.889" y2="0" layer="51"/>
 <rectangle x1="1.397" y1="-0.381" x2="3.175" y2="0" layer="51"/>
-</package>
-<package name="TO18A">
-<description>&lt;b&gt;TO-18&lt;/b&gt;</description>
-<wire x1="-2.2098" y1="-0.9693" x2="2.2098" y2="-0.9693" width="0.0508" layer="51" curve="132.631933" cap="flat"/>
-<wire x1="-0.9693" y1="2.2098" x2="0.9693" y2="2.2098" width="0.0508" layer="51" curve="-47.368067" cap="flat"/>
-<wire x1="-2.2098" y1="0.9693" x2="-2.2098" y2="-0.9693" width="0.0508" layer="51" curve="47.368067" cap="flat"/>
-<wire x1="-2.2098" y1="0.9693" x2="-0.9693" y2="2.2098" width="0.0508" layer="51" curve="-42.631933" cap="flat"/>
-<wire x1="2.2098" y1="-0.9693" x2="2.2098" y2="0.9693" width="0.0508" layer="51" curve="47.368067" cap="flat"/>
-<wire x1="1.649" y1="-2.411" x2="2.413" y2="-3.175" width="0.2032" layer="21"/>
-<wire x1="2.411" y1="-1.649" x2="3.175" y2="-2.413" width="0.2032" layer="21"/>
-<wire x1="2.413" y1="-3.175" x2="3.175" y2="-2.413" width="0.2032" layer="21"/>
-<wire x1="0.9693" y1="2.2098" x2="2.2098" y2="0.9693" width="0.0508" layer="51" curve="-42.631933" cap="flat"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="3" x="-1.905" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="1" x="1.905" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.302" y="0.381" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.302" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="0.9426" y="-1.5799" size="1.27" layer="51" ratio="10">1</text>
-<text x="-0.508" y="0.1588" size="1.27" layer="51" ratio="10">2</text>
-<text x="-1.5875" y="-1.5875" size="1.27" layer="51" ratio="10">3</text>
 </package>
 <package name="TO18V">
 <description>&lt;b&gt;TO-18&lt;/b&gt;</description>
@@ -1208,21 +1056,23 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <wire x1="5.207" y1="1.905" x2="5.207" y2="-1.905" width="0.2032" layer="51"/>
 </package>
 <package name="TO78">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="-4.572" y1="0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-5.334" y1="-0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-5.334" y1="-0.508" x2="-4.572" y2="-0.508" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-78 (6 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-78.
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
 <circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
-<pad name="4" x="1.905" y="1.905" drill="0.8128" diameter="1.524"/>
+<pad name="1" x="-1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
 <pad name="2" x="0" y="-2.54" drill="0.8128" diameter="1.524"/>
+<pad name="3" x="1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
+<pad name="4" x="1.905" y="1.905" drill="0.8128" diameter="1.524"/>
 <pad name="5" x="0" y="2.54" drill="0.8128" diameter="1.524"/>
 <pad name="6" x="-1.905" y="1.905" drill="0.8128" diameter="1.524"/>
-<pad name="3" x="1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
-<pad name="1" x="-1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <rectangle x1="-5.334" y1="-0.508" x2="-4.572" y2="0.508" layer="21"/>
+<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-5.334" y1="-0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-5.334" y1="-0.508" x2="-4.572" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-4.572" y1="0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
 </package>
 <package name="DIP-300-14">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
@@ -1715,10 +1565,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1736,7 +1586,7 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
-<connect gate="A" pin="C@1" pad="TO66"/>
+<connect gate="A" pin="C@1" pad="4"/>
 <connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
@@ -2438,10 +2288,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2577,7 +2427,7 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
-<connect gate="A" pin="C@1" pad="TO66"/>
+<connect gate="A" pin="C@1" pad="4"/>
 <connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
@@ -2596,7 +2446,7 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
-<connect gate="A" pin="C@1" pad="TO66"/>
+<connect gate="A" pin="C@1" pad="4"/>
 <connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
@@ -2703,10 +2553,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2722,10 +2572,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2741,10 +2591,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2762,7 +2612,7 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
-<connect gate="A" pin="C@1" pad="TO66"/>
+<connect gate="A" pin="C@1" pad="4"/>
 <connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
@@ -2781,7 +2631,7 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
-<connect gate="A" pin="C@1" pad="TO66"/>
+<connect gate="A" pin="C@1" pad="4"/>
 <connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
@@ -2798,10 +2648,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2943,10 +2793,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2962,10 +2812,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2981,10 +2831,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3054,10 +2904,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3073,10 +2923,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3092,10 +2942,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3147,10 +2997,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3166,10 +3016,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3185,10 +3035,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3204,10 +3054,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3223,10 +3073,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3242,10 +3092,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3261,10 +3111,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3280,10 +3130,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3299,10 +3149,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3318,10 +3168,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3373,10 +3223,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3392,10 +3242,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3411,10 +3261,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3430,10 +3280,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3449,10 +3299,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3486,10 +3336,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3523,10 +3373,10 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3612,7 +3462,7 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <gate name="G$1" symbol="NPN" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO18-">
+<device name="" package="TO18">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
 <connect gate="G$1" pin="C" pad="3"/>
@@ -5128,7 +4978,7 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO18-">
+<device name="" package="TO18">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
 <connect gate="G$1" pin="C" pad="3"/>
@@ -5644,7 +5494,7 @@ complimentary to CMPTA56</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="_R" package="TO18-">
+<device name="_R" package="TO18">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
 <connect gate="G$1" pin="C" pad="3"/>

--- a/transistor-pnp.lbr
+++ b/transistor-pnp.lbr
@@ -592,33 +592,12 @@ grid 2.3 mm, horizontal</description>
 <rectangle x1="0.7112" y1="-1.4954" x2="1.1684" y2="-0.9112" layer="51"/>
 <rectangle x1="-1.1684" y1="-1.4954" x2="-0.7112" y2="-0.9112" layer="51"/>
 </package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
-<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -627,6 +606,28 @@ grid 2.3 mm, horizontal</description>
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
 <package name="TO225AA">
 <description>&lt;b&gt;TO-225&lt;/b&gt;&lt;p&gt;
@@ -681,24 +682,12 @@ grid 2.54 mm, vertical</description>
 <text x="-3.175" y="1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <rectangle x1="-3.4925" y1="1.1113" x2="3.4925" y2="1.5875" layer="21"/>
 </package>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="3.175" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -707,6 +696,18 @@ grid 2.54 mm, vertical</description>
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
 <package name="TO220-AB-H">
 <description>&lt;b&gt;TO-220 AB (2.54mm lead pitch, 3 leads, exposed pad, horizontal, 17.5mm lead-to-hole)&lt;/b&gt;&lt;p&gt;
@@ -3820,7 +3821,7 @@ Replacement for TIP42C</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
 <connect gate="G$1" pin="C" pad="4"/>
@@ -3911,7 +3912,7 @@ complimentary to CMPTA06</description>
 <gate name="G$1" symbol="PNP-DAR" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="T4" package="DPAK">
+<device name="T4" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
 <connect gate="G$1" pin="C" pad="4"/>
@@ -3970,7 +3971,7 @@ complimentary to CMPTA06</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
 <connect gate="G$1" pin="C" pad="4"/>
@@ -4007,7 +4008,7 @@ complimentary to CMPTA06</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
 <connect gate="G$1" pin="C" pad="4"/>

--- a/transistor-pnp.lbr
+++ b/transistor-pnp.lbr
@@ -79,143 +79,54 @@
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
 <package name="TO3">
-<description>&lt;b&gt;TO-3&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
-<pad name="B" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
-<pad name="C" x="15.113" y="0" drill="4.1148" diameter="6.477"/>
-<pad name="C/" x="-15.113" y="0" drill="4.1148" diameter="6.477"/>
-<text x="-3.81" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.81" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-3.81" y="-6.223" size="1.27" layer="51" ratio="10" rot="R90">E</text>
-<text x="-3.81" y="4.572" size="1.27" layer="51" ratio="10" rot="R90">B</text>
-<text x="12.7" y="-3.683" size="1.27" layer="51" ratio="10" rot="R90">C</text>
-</package>
-<package name="TO3A">
-<description>&lt;b&gt;TO-3&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-1.778" y="-5.461" drill="1.1938" diameter="3.81" shape="long"/>
-<pad name="B" x="-1.778" y="5.461" drill="1.1938" diameter="3.81" shape="long"/>
-<pad name="C" x="15.113" y="0" drill="3.302" diameter="6.477"/>
-<pad name="TO3" x="-15.113" y="0" drill="3.302" diameter="6.477"/>
-<text x="-5.08" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-5.08" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="15.24" y="-4.953" size="1.27" layer="51" ratio="10" rot="R90">C</text>
-<text x="-4.953" y="-6.35" size="1.27" layer="51" ratio="10">E</text>
-<text x="-5.588" y="5.08" size="1.27" layer="51" ratio="10">B</text>
-</package>
-<package name="TO3/">
-<description>&lt;b&gt;TO-3&lt;/b&gt;&lt;p&gt;
-rotated 45 deg.</description>
-<wire x1="15.1892" y1="-8.9916" x2="12.319" y2="2.4892" width="0.254" layer="21"/>
-<wire x1="-15.1892" y1="8.9916" x2="-12.319" y2="-2.4892" width="0.254" layer="21"/>
-<wire x1="-8.9916" y1="15.1892" x2="2.9972" y2="12.192" width="0.254" layer="21"/>
-<wire x1="8.9916" y1="-15.1892" x2="-2.4892" y2="-12.319" width="0.254" layer="21"/>
-<wire x1="13.97" y1="-13.97" x2="15.1759" y2="-8.9223" width="0.254" layer="21" curve="63.129135" cap="flat"/>
-<wire x1="2.6343" y1="12.2933" x2="8.89" y2="8.89" width="0.254" layer="21" curve="-32.905092" cap="flat"/>
-<wire x1="8.89" y1="8.89" x2="12.3282" y2="2.4656" width="0.254" layer="21" curve="-33.690295" cap="flat"/>
-<wire x1="8.9123" y1="-15.1725" x2="13.9695" y2="-13.9695" width="0.254" layer="21" curve="63.249564" cap="flat"/>
-<wire x1="-15.1758" y1="8.9223" x2="-13.9699" y2="13.9699" width="0.254" layer="21" curve="-63.129366" cap="flat"/>
-<wire x1="-13.97" y1="13.97" x2="-8.9123" y2="15.173" width="0.254" layer="21" curve="-63.248393" cap="flat"/>
-<wire x1="-12.3282" y1="-2.4656" x2="-8.89" y2="-8.89" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<wire x1="-8.89" y1="-8.89" x2="-2.4656" y2="-12.3282" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="10.668" y="-10.668" radius="2.159" width="0.254" layer="51"/>
-<circle x="-10.668" y="10.668" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-5.08" y="-2.54" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="B" x="2.54" y="5.08" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="C" x="10.668" y="-10.668" drill="4.1148" diameter="6.477"/>
-<pad name="C/" x="-10.668" y="10.668" drill="4.1148" diameter="6.477"/>
-<text x="-1.905" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-7.62" y="-1.27" size="1.27" layer="51" ratio="10">E</text>
-<text x="0" y="6.985" size="1.27" layer="51" ratio="10">B</text>
-<text x="6.35" y="-11.43" size="1.27" layer="51" ratio="10">C</text>
-</package>
-<package name="TO3/A">
-<description>&lt;b&gt;TO-3&lt;/b&gt;&lt;p&gt;
-rotated 45 deg.</description>
-<wire x1="15.1892" y1="-8.9916" x2="12.319" y2="2.4892" width="0.254" layer="21"/>
-<wire x1="-15.1892" y1="8.9916" x2="-12.319" y2="-2.4892" width="0.254" layer="21"/>
-<wire x1="-8.9916" y1="15.1892" x2="2.9972" y2="12.192" width="0.254" layer="21"/>
-<wire x1="8.9916" y1="-15.1892" x2="-2.4892" y2="-12.319" width="0.254" layer="21"/>
-<wire x1="13.97" y1="-13.97" x2="15.1759" y2="-8.9223" width="0.254" layer="21" curve="63.129135" cap="flat"/>
-<wire x1="2.6343" y1="12.2933" x2="8.89" y2="8.89" width="0.254" layer="21" curve="-32.905092" cap="flat"/>
-<wire x1="8.89" y1="8.89" x2="12.3282" y2="2.4656" width="0.254" layer="21" curve="-33.690295" cap="flat"/>
-<wire x1="8.9123" y1="-15.1725" x2="13.9695" y2="-13.9695" width="0.254" layer="21" curve="63.249564" cap="flat"/>
-<wire x1="-15.1758" y1="8.9223" x2="-13.9699" y2="13.9699" width="0.254" layer="21" curve="-63.129366" cap="flat"/>
-<wire x1="-13.97" y1="13.97" x2="-8.9123" y2="15.173" width="0.254" layer="21" curve="-63.248393" cap="flat"/>
-<wire x1="-12.3282" y1="-2.4656" x2="-8.89" y2="-8.89" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<wire x1="-8.89" y1="-8.89" x2="-2.4656" y2="-12.3282" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="10.668" y="-10.668" radius="2.159" width="0.254" layer="51"/>
-<circle x="-10.668" y="10.668" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-5.08" y="-2.54" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="B" x="2.54" y="5.08" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="C" x="10.668" y="-10.668" drill="3.302" diameter="6.477"/>
-<pad name="C/" x="-10.668" y="10.668" drill="3.302" diameter="6.477"/>
-<text x="-1.905" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-7.62" y="-1.27" size="1.27" layer="51" ratio="10">E</text>
-<text x="0" y="6.985" size="1.27" layer="51" ratio="10">B</text>
-<text x="6.35" y="-11.43" size="1.27" layer="51" ratio="10">C</text>
+<description>&lt;b&gt;TO-3 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-3.
+&lt;/p&gt;</description>
+<circle x="-15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="9.3726" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
+<circle x="15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<pad name="1" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="2" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="3" x="15.113" y="0" drill="4.1148" diameter="6.477"/>
+<pad name="4" x="-15.113" y="0" drill="4.1148" diameter="6.477"/>
+<text x="2.54" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="5.08" y="-3.81" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.2032" layer="21" curve="-60.173068" cap="flat"/>
+<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.2032" layer="21" curve="59.404169" cap="flat"/>
+<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.2032" layer="21" curve="-30.113639" cap="flat"/>
+<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.2032" layer="21"/>
+<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.2032" layer="21" curve="28.0726" cap="flat"/>
+<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.2032" layer="21"/>
+<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.2032" layer="21" curve="30.113639" cap="flat"/>
+<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.2032" layer="21" curve="-28.0726" cap="flat"/>
+<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.2032" layer="21"/>
+<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.2032" layer="21"/>
+<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="57.148737" cap="flat"/>
+<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="-57.148737" cap="flat"/>
 </package>
 <package name="TO72">
-<description>&lt;b&gt;TO-72&lt;/b&gt;</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="51" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-72 (4 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-72.
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
 <pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="4" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.651" y="-1.651" size="1.27" layer="51" ratio="10">1</text>
-<text x="0.508" y="-1.651" size="1.27" layer="51" ratio="10">2</text>
-<text x="0.508" y="0.381" size="1.27" layer="51" ratio="10">3</text>
-<text x="-1.651" y="0.381" size="1.27" layer="51" ratio="10">4</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="51" curve="-45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
 </package>
 <package name="TO202">
 <description>&lt;b&gt;TO-202&lt;/b&gt;&lt;p&gt;
@@ -256,47 +167,27 @@ grid 2.54 mm, vertical</description>
 <rectangle x1="-2.921" y1="-5.08" x2="-2.159" y2="-3.429" layer="51"/>
 <hole x="0" y="17.78" drill="3.302"/>
 </package>
-<package name="TO18-">
-<description>&lt;b&gt;TO-18&lt;/b&gt;</description>
-<wire x1="-2.2098" y1="-0.9692" x2="2.2098" y2="-0.9692" width="0.0508" layer="51" curve="132.636282" cap="flat"/>
-<wire x1="-0.9692" y1="2.2098" x2="0.9692" y2="2.2098" width="0.0508" layer="51" curve="-47.363718" cap="flat"/>
-<wire x1="-2.2098" y1="0.9692" x2="-2.2098" y2="-0.9692" width="0.0508" layer="51" curve="47.363718" cap="flat"/>
-<wire x1="-2.2098" y1="0.9692" x2="-0.9692" y2="2.2098" width="0.0508" layer="51" curve="-42.636282" cap="flat"/>
-<wire x1="2.2098" y1="-0.9692" x2="2.2098" y2="0.9692" width="0.0508" layer="51" curve="47.363718" cap="flat"/>
-<wire x1="1.649" y1="-2.411" x2="2.413" y2="-3.175" width="0.2032" layer="21"/>
-<wire x1="2.411" y1="-1.649" x2="3.175" y2="-2.413" width="0.2032" layer="21"/>
-<wire x1="2.413" y1="-3.175" x2="3.175" y2="-2.413" width="0.2032" layer="21"/>
-<wire x1="0.9692" y1="2.2098" x2="2.2098" y2="0.9692" width="0.0508" layer="51" curve="-42.636282" cap="flat"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="1" x="1.905" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="-1.905" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.302" y="0.381" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.302" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="1.016" y="-1.143" size="1.27" layer="51" ratio="10">1</text>
-<text x="-0.508" y="0.635" size="1.27" layer="51" ratio="10">2</text>
-<text x="-1.905" y="-1.27" size="1.27" layer="51" ratio="10">3</text>
-</package>
 <package name="TO18">
-<description>&lt;b&gt;TO-18&lt;/b&gt;</description>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="51" curve="-135.281008" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-2.877" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="-3.937" y1="0.508" x2="-2.877" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<description>&lt;b&gt;TO-18 (2.54mm lead pitch, 3 leads)&lt;/b&gt;&lt;p&gt;
+Header family package. 2.54mm lead pitch, 3 leads, metal can.
+&lt;p/&gt;&lt;p&gt;
+JEDEC TO-18.
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
 <pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.905" y="-1.27" size="1.27" layer="51" ratio="10">1</text>
-<text x="0.635" y="-1.27" size="1.27" layer="51" ratio="10">2</text>
-<text x="0" y="0.635" size="1.27" layer="51" ratio="10">3</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="-0.508" x2="-2.8765" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="0.508" x2="-2.8765" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="51" curve="-135.281008" cap="flat"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
 </package>
 <package name="TO92-AB">
 <description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
@@ -472,17 +363,19 @@ grid 5.45 mm, vertical</description>
 <rectangle x1="4.064" y1="-1.524" x2="6.858" y2="-1.143" layer="51"/>
 </package>
 <package name="TO5">
-<description>&lt;b&gt;TO-5&lt;/b&gt;</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-5 (3 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-5
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
 <circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
 <pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
 <package name="TO126">
 <description>&lt;b&gt;TO-126&lt;/b&gt;&lt;p&gt;
@@ -521,54 +414,28 @@ grid 2.3 mm, vertical</description>
 <rectangle x1="1.905" y1="-5.207" x2="2.667" y2="-3.429" layer="51"/>
 <hole x="0" y="5.08" drill="3.302"/>
 </package>
-<package name="TO66/">
-<description>&lt;b&gt;TO-66&lt;/b&gt;&lt;p&gt;
-rotated 45 deg.</description>
-<wire x1="3.107" y1="8.058" x2="-7.314" y2="12.076" width="0.254" layer="21"/>
-<wire x1="-3.107" y1="-8.058" x2="7.314" y2="-12.076" width="0.254" layer="21"/>
-<wire x1="-8.058" y1="-3.107" x2="-12.076" y2="7.314" width="0.254" layer="21"/>
-<wire x1="-8.058" y1="-3.107" x2="-3.1067" y2="-8.0582" width="0.254" layer="21" curve="47.833617" cap="flat"/>
-<wire x1="-12.076" y1="7.314" x2="-7.3146" y2="12.0754" width="0.254" layer="21" curve="-132.167054" cap="flat"/>
-<wire x1="8.058" y1="3.107" x2="12.076" y2="-7.314" width="0.254" layer="21"/>
-<wire x1="7.314" y1="-12.076" x2="12.0754" y2="-7.3146" width="0.254" layer="21" curve="132.167054" cap="flat"/>
-<wire x1="3.107" y1="8.058" x2="8.0584" y2="3.1067" width="0.254" layer="21" curve="-47.834094" cap="flat"/>
-<circle x="0" y="0" radius="7.874" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="6.35" width="0.254" layer="51"/>
-<circle x="-8.621" y="8.621" radius="1.905" width="0.254" layer="51"/>
-<circle x="8.621" y="-8.621" radius="1.905" width="0.254" layer="51"/>
-<pad name="1" x="-3.5814" y="0" drill="1.1176" diameter="2.54" shape="octagon"/>
-<pad name="2" x="0" y="3.5814" drill="1.1176" diameter="2.54" shape="octagon"/>
-<pad name="TO66" x="-8.636" y="8.636" drill="3.302" diameter="6.35"/>
-<pad name="3" x="8.636" y="-8.636" drill="3.302" diameter="6.35"/>
-<text x="-5.588" y="1.143" size="1.016" layer="21" ratio="18">1</text>
-<text x="-2.54" y="4.318" size="1.016" layer="21" ratio="18">2</text>
-<text x="3.81" y="-10.16" size="1.016" layer="21" ratio="18">3</text>
-<text x="0" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.143" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="TO66">
-<description>&lt;b&gt;TO-66&lt;/b&gt;</description>
-<wire x1="-3.501" y1="-7.895" x2="3.5012" y2="-7.895" width="0.254" layer="21" curve="47.833229" cap="flat"/>
-<wire x1="-3.501" y1="7.895" x2="3.5012" y2="7.895" width="0.254" layer="21" curve="-47.833229" cap="flat"/>
-<wire x1="-13.711" y1="3.3666" x2="-13.711" y2="-3.367" width="0.254" layer="21" curve="132.167583" cap="flat"/>
-<wire x1="-3.501" y1="-7.895" x2="-13.711" y2="-3.367" width="0.254" layer="21"/>
-<wire x1="-3.501" y1="7.895" x2="-13.711" y2="3.367" width="0.254" layer="21"/>
-<wire x1="13.711" y1="-3.367" x2="13.711" y2="3.3666" width="0.254" layer="21" curve="132.167583" cap="flat"/>
-<wire x1="3.501" y1="-7.895" x2="13.711" y2="-3.367" width="0.254" layer="21"/>
-<wire x1="3.501" y1="7.895" x2="13.711" y2="3.367" width="0.254" layer="21"/>
-<circle x="0" y="0" radius="7.874" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="6.35" width="0.254" layer="51"/>
-<circle x="-12.192" y="0" radius="1.905" width="0.254" layer="51"/>
-<circle x="12.192" y="0" radius="1.905" width="0.254" layer="51"/>
-<pad name="TO66" x="-12.192" y="0" drill="3.302" diameter="6.35"/>
-<pad name="3" x="12.192" y="0" drill="3.302" diameter="6.35"/>
-<pad name="2" x="-2.54" y="2.54" drill="1.1176" diameter="2.54" shape="long"/>
+<description>&lt;b&gt;TO-66 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-66.
+&lt;/p&gt;</description>
+<circle x="-12.192" y="0" radius="1.905" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="7.874" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="6.35" width="0.2032" layer="51"/>
+<circle x="12.192" y="0" radius="1.905" width="0.2032" layer="51"/>
 <pad name="1" x="-2.54" y="-2.54" drill="1.1176" diameter="2.54" shape="long"/>
-<text x="8.89" y="-4.445" size="1.016" layer="21" ratio="18">3</text>
+<pad name="2" x="-2.54" y="2.54" drill="1.1176" diameter="2.54" shape="long"/>
+<pad name="3" x="12.192" y="0" drill="3.302" diameter="6.35"/>
+<pad name="4" x="-12.192" y="0" drill="3.302" diameter="6.35"/>
 <text x="1.27" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.175" y="-3.175" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<text x="-5.08" y="1.905" size="1.016" layer="21" ratio="18">2</text>
-<text x="-5.08" y="-3.175" size="1.016" layer="21" ratio="18">1</text>
+<wire x1="-13.711" y1="3.3666" x2="-13.711" y2="-3.367" width="0.2032" layer="21" curve="132.167583" cap="flat"/>
+<wire x1="-3.501" y1="-7.895" x2="3.5012" y2="-7.895" width="0.2032" layer="21" curve="47.833229" cap="flat"/>
+<wire x1="-3.501" y1="-7.895" x2="-13.711" y2="-3.367" width="0.2032" layer="21"/>
+<wire x1="-3.501" y1="7.895" x2="3.5012" y2="7.895" width="0.2032" layer="21" curve="-47.833229" cap="flat"/>
+<wire x1="-3.501" y1="7.895" x2="-13.711" y2="3.367" width="0.2032" layer="21"/>
+<wire x1="3.501" y1="-7.895" x2="13.711" y2="-3.367" width="0.2032" layer="21"/>
+<wire x1="3.501" y1="7.895" x2="13.711" y2="3.367" width="0.2032" layer="21"/>
+<wire x1="13.711" y1="-3.367" x2="13.711" y2="3.3666" width="0.2032" layer="21" curve="132.167583" cap="flat"/>
 </package>
 <package name="SOT93">
 <description>&lt;b&gt;SOT-93&lt;/b&gt;&lt;p&gt;
@@ -636,17 +503,19 @@ b-c-e, grid 5.45 mm, vertical</description>
 <rectangle x1="-7.62" y1="-2.032" x2="7.62" y2="0" layer="51"/>
 </package>
 <package name="TO39">
-<description>&lt;b&gt;TO-39&lt;/b&gt;</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-39&lt;/b&gt;&lt;p&gt;
+JEDEC TO-39
+&lt;p/&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
 <circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
 <pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
 <package name="TO202V">
 <description>&lt;b&gt;TO-202&lt;/b&gt;&lt;p&gt;
@@ -919,21 +788,23 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <wire x1="3.25" y1="1.75" x2="3.25" y2="-1.75" width="0.2032" layer="21"/>
 </package>
 <package name="TO78">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="-4.572" y1="0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-5.334" y1="-0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-5.334" y1="-0.508" x2="-4.572" y2="-0.508" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-78 (6 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-78.
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
 <circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
-<pad name="4" x="1.905" y="1.905" drill="0.8128" diameter="1.524"/>
+<pad name="1" x="-1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
 <pad name="2" x="0" y="-2.54" drill="0.8128" diameter="1.524"/>
+<pad name="3" x="1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
+<pad name="4" x="1.905" y="1.905" drill="0.8128" diameter="1.524"/>
 <pad name="5" x="0" y="2.54" drill="0.8128" diameter="1.524"/>
 <pad name="6" x="-1.905" y="1.905" drill="0.8128" diameter="1.524"/>
-<pad name="3" x="1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
-<pad name="1" x="-1.905" y="-1.905" drill="0.8128" diameter="1.524"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <rectangle x1="-5.334" y1="-0.508" x2="-4.572" y2="0.508" layer="21"/>
+<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-5.334" y1="-0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-5.334" y1="-0.508" x2="-4.572" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-4.572" y1="0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
 </package>
 <package name="SC70-3">
 <description>&lt;b&gt;SC70-3 (TSSOT, 0.65mm pitch, 1.25mm body, 3 leads)&lt;/b&gt;&lt;p&gt;
@@ -1313,10 +1184,10 @@ CASE 340L, STYLE 3</description>
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1332,10 +1203,10 @@ CASE 340L, STYLE 3</description>
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1369,10 +1240,10 @@ CASE 340L, STYLE 3</description>
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1388,10 +1259,10 @@ CASE 340L, STYLE 3</description>
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1407,10 +1278,10 @@ CASE 340L, STYLE 3</description>
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C/" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C/" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1426,10 +1297,10 @@ CASE 340L, STYLE 3</description>
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C/" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C/" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1517,10 +1388,10 @@ CASE 340L, STYLE 3</description>
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C/" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C/" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1536,10 +1407,10 @@ CASE 340L, STYLE 3</description>
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C/" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C/" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1555,10 +1426,10 @@ CASE 340L, STYLE 3</description>
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C/" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C/" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1574,10 +1445,10 @@ CASE 340L, STYLE 3</description>
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1593,10 +1464,10 @@ CASE 340L, STYLE 3</description>
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2139,7 +2010,7 @@ CASE 340L, STYLE 3</description>
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
-<connect gate="A" pin="C/" pad="TO66"/>
+<connect gate="A" pin="C/" pad="4"/>
 <connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
@@ -2158,7 +2029,7 @@ CASE 340L, STYLE 3</description>
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
-<connect gate="A" pin="C/" pad="TO66"/>
+<connect gate="A" pin="C/" pad="4"/>
 <connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
@@ -2177,7 +2048,7 @@ CASE 340L, STYLE 3</description>
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
-<connect gate="A" pin="C/" pad="TO66"/>
+<connect gate="A" pin="C/" pad="4"/>
 <connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
@@ -2194,10 +2065,10 @@ CASE 340L, STYLE 3</description>
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C/" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C/" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2231,10 +2102,10 @@ CASE 340L, STYLE 3</description>
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/transistor-power.lbr
+++ b/transistor-power.lbr
@@ -1415,31 +1415,6 @@ grid 1.7 mm</description>
 <rectangle x1="6.4262" y1="-8.509" x2="7.1882" y2="-4.445" layer="21"/>
 <rectangle x1="9.779" y1="-8.509" x2="10.541" y2="-4.445" layer="21"/>
 </package>
-<package name="D2PACK">
-<description>&lt;b&gt;D2PACK&lt;/b&gt;&lt;p&gt;
-INTERNATIONAL RECTIFIER, irg4bc15ud-s.pdf</description>
-<wire x1="-5.1308" y1="-4.0894" x2="5.1308" y2="-4.0894" width="0.2032" layer="21"/>
-<wire x1="5.1308" y1="-4.0894" x2="5.1308" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.1308" y1="4.445" x2="3.1242" y2="5.8166" width="0.2032" layer="51"/>
-<wire x1="3.1242" y1="5.8166" x2="-3.3782" y2="5.8166" width="0.2032" layer="51"/>
-<wire x1="-3.3782" y1="5.8166" x2="-5.1308" y2="4.699" width="0.2032" layer="51"/>
-<wire x1="-5.1308" y1="4.699" x2="-5.1308" y2="-4.0894" width="0.2032" layer="51"/>
-<wire x1="-5.1308" y1="4.445" x2="5.1308" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="-5.1308" y1="-4.0894" x2="-5.1308" y2="-2.3114" width="0.2032" layer="21"/>
-<wire x1="5.1308" y1="-4.0894" x2="5.1308" y2="-2.3114" width="0.2032" layer="21"/>
-<smd name="1" x="-2.54" y="-8.89" dx="2.0828" dy="3.81" layer="1"/>
-<smd name="3" x="2.54" y="-8.89" dx="2.0828" dy="3.81" layer="1"/>
-<smd name="2" x="0" y="2.54" dx="11.43" dy="8.89" layer="1"/>
-<text x="-5.588" y="7.239" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.81" y="-3.429" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="-3.0988" y1="-9.525" x2="-1.9812" y2="-8.1026" layer="51"/>
-<rectangle x1="-3.2512" y1="-8.1534" x2="-1.8288" y2="-6.731" layer="51"/>
-<rectangle x1="-3.2512" y1="-6.731" x2="-1.8288" y2="-4.2418" layer="21"/>
-<rectangle x1="1.9812" y1="-9.525" x2="3.0988" y2="-8.1026" layer="51"/>
-<rectangle x1="1.8288" y1="-8.1534" x2="3.2512" y2="-6.731" layer="51"/>
-<rectangle x1="1.8288" y1="-6.731" x2="3.2512" y2="-4.2418" layer="21"/>
-<rectangle x1="-0.7112" y1="-6.731" x2="0.7112" y2="-4.2418" layer="21"/>
-</package>
 <package name="TO262-V">
 <description>&lt;b&gt;Molded Package&lt;/b&gt;</description>
 <wire x1="-5.1308" y1="-4.9784" x2="5.1308" y2="-4.9784" width="0.2032" layer="21"/>
@@ -1613,61 +1588,12 @@ grid 5.6 mm - Special Face Down Mounting for Heatsink</description>
 <rectangle x1="4.953" y1="-10.541" x2="6.223" y2="-10.033" layer="51"/>
 <hole x="0" y="9.144" drill="6.4516"/>
 </package>
-<package name="TO263">
-<description>&lt;b&gt;TO-263 Package&lt;/b&gt;</description>
-<wire x1="-5.7" y1="-5" x2="-5.7" y2="4" width="0.2032" layer="21"/>
-<wire x1="5.7" y1="-5" x2="5.7" y2="4" width="0.2032" layer="21"/>
-<wire x1="5.7" y1="-5" x2="-5.7" y2="-5" width="0.2032" layer="21"/>
-<wire x1="-5.7" y1="4" x2="5.7" y2="4" width="0.2032" layer="51"/>
-<wire x1="-5.7" y1="4" x2="-4.6" y2="5.1" width="0.2032" layer="51"/>
-<wire x1="-4.6" y1="5.1" x2="4.6" y2="5.1" width="0.2032" layer="51"/>
-<wire x1="4.6" y1="5.1" x2="5.7" y2="4" width="0.2032" layer="51"/>
-<wire x1="-5.7" y1="3.3" x2="5.7" y2="3.3" width="0.2032" layer="51"/>
-<circle x="-3" y="-3.6" radius="0.4123" width="0" layer="51"/>
-<smd name="4" x="0" y="2" dx="10.8" dy="9" layer="1" rot="R180"/>
-<smd name="1" x="-2.54" y="-8.89" dx="3.81" dy="1.524" layer="1" rot="R90"/>
-<smd name="2" x="0" y="-8.89" dx="3.81" dy="1.524" layer="1" rot="R90"/>
-<smd name="3" x="2.54" y="-8.89" dx="3.81" dy="1.524" layer="1" rot="R90"/>
-<text x="-6.0325" y="-5.08" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="7.3025" y="-5.08" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<text x="-3.2" y="-2.8" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.3" y="-2.8" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.4" y="-2.8" size="1.016" layer="51" ratio="10">2</text>
-<text x="-0.55" y="1.75" size="1.016" layer="51" ratio="10">4</text>
-<rectangle x1="-3.04" y1="-6.5" x2="-2" y2="-5.005" layer="21"/>
-<rectangle x1="-0.5" y1="-6.5" x2="0.5" y2="-5.005" layer="21"/>
-<rectangle x1="2.04" y1="-6.5" x2="3" y2="-5.005" layer="21"/>
-<rectangle x1="-3.04" y1="-9.275" x2="-2" y2="-6.5" layer="51"/>
-<rectangle x1="-0.5" y1="-9.275" x2="0.5" y2="-6.5" layer="51"/>
-<rectangle x1="2.04" y1="-9.275" x2="3" y2="-6.5" layer="51"/>
-</package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
-<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<package name="TO263-AA">
+<description>&lt;b&gt;TO-263 AA (3 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 3 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AA, R-PSFM.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -1676,25 +1602,74 @@ grid 5.6 mm - Special Face Down Mounting for Heatsink</description>
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-7.62" x2="0.635" y2="-5.715" layer="51"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="2" x="0" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="3.175" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
+<polygon width="0.2032" layer="51">
+<vertex x="-5.3975" y="4.445"/>
+<vertex x="-5.3975" y="5.08"/>
+<vertex x="-4.445" y="5.715"/>
+<vertex x="4.445" y="5.715"/>
+<vertex x="5.3975" y="5.08"/>
+<vertex x="5.3975" y="4.445"/>
+</polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+</package>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -1703,6 +1678,18 @@ grid 5.6 mm - Special Face Down Mounting for Heatsink</description>
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
 <package name="SOP-127-390-8">
 <description>&lt;b&gt;SOP (1.27 pitch, 3.90mm width, 8 leads)&lt;/b&gt;&lt;p&gt;
@@ -3087,9 +3074,9 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm. JEDEC MS-012F. Vari
 <gate name="G$1" symbol="NCHAN_IGBT" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="D2PACK">
+<device name="S" package="TO263-AB">
 <connects>
-<connect gate="G$1" pin="C" pad="2"/>
+<connect gate="G$1" pin="C" pad="4"/>
 <connect gate="G$1" pin="E" pad="3"/>
 <connect gate="G$1" pin="G" pad="1"/>
 </connects>
@@ -3209,7 +3196,7 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm. JEDEC MS-012F. Vari
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="DPAK">
+<device name="R" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -3255,7 +3242,7 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm. JEDEC MS-012F. Vari
 <gate name="G$1" symbol="MFNS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="T4" package="DPAK">
+<device name="T4" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
@@ -3311,9 +3298,9 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm. JEDEC MS-012F. Vari
 <gate name="G$1" symbol="MFNS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="NS" package="D2PACK">
+<device name="NS" package="TO263-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="2"/>
+<connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="3"/>
 </connects>
@@ -3329,9 +3316,9 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm. JEDEC MS-012F. Vari
 <gate name="G$1" symbol="MFNS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="D2PAK">
+<device name="" package="TO263-AB">
 <connects>
-<connect gate="G$1" pin="D" pad="2"/>
+<connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="G" pad="1"/>
 <connect gate="G$1" pin="S" pad="3"/>
 </connects>
@@ -3347,7 +3334,7 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm. JEDEC MS-012F. Vari
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
 <connect gate="G$1" pin="C" pad="4"/>

--- a/transistor-power.lbr
+++ b/transistor-power.lbr
@@ -200,55 +200,32 @@ Also known as SOT78.</description>
 <wire x1="4.699" y1="-4.318" x2="-4.699" y2="-4.318" width="0.2032" layer="21"/>
 <wire x1="5.08" y1="-1.143" x2="4.953" y2="-4.064" width="0.2032" layer="21"/>
 </package>
-<package name="TO3/A">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="15.1892" y1="-8.9916" x2="12.319" y2="2.4892" width="0.254" layer="21"/>
-<wire x1="-15.1892" y1="8.9916" x2="-12.319" y2="-2.4892" width="0.254" layer="21"/>
-<wire x1="-8.9916" y1="15.1892" x2="2.9972" y2="12.192" width="0.254" layer="21"/>
-<wire x1="8.9916" y1="-15.1892" x2="-2.4892" y2="-12.319" width="0.254" layer="21"/>
-<wire x1="13.97" y1="-13.97" x2="15.1759" y2="-8.9223" width="0.254" layer="21" curve="63.129135" cap="flat"/>
-<wire x1="2.6343" y1="12.2933" x2="8.89" y2="8.89" width="0.254" layer="21" curve="-32.905092" cap="flat"/>
-<wire x1="8.89" y1="8.89" x2="12.3282" y2="2.4656" width="0.254" layer="21" curve="-33.690295" cap="flat"/>
-<wire x1="8.9123" y1="-15.1725" x2="13.9697" y2="-13.9697" width="0.254" layer="21" curve="63.250342" cap="flat"/>
-<wire x1="-15.1758" y1="8.9223" x2="-13.9699" y2="13.9699" width="0.254" layer="21" curve="-63.129366" cap="flat"/>
-<wire x1="-13.97" y1="13.97" x2="-8.9123" y2="15.1728" width="0.254" layer="21" curve="-63.249639" cap="flat"/>
-<wire x1="-12.3282" y1="-2.4656" x2="-8.89" y2="-8.89" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<wire x1="-8.89" y1="-8.89" x2="-2.4656" y2="-12.3282" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.0508" layer="51"/>
+<package name="TO3">
+<description>&lt;b&gt;TO-3 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-3.
+&lt;/p&gt;</description>
+<circle x="-15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="9.3726" width="0.2032" layer="51"/>
 <circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
-<circle x="10.668" y="-10.668" radius="2.159" width="0.254" layer="51"/>
-<circle x="-10.668" y="10.668" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-5.08" y="-2.54" drill="1.27" diameter="3.1496" shape="octagon"/>
-<pad name="B" x="2.54" y="5.08" drill="1.27" diameter="3.1496" shape="octagon"/>
-<pad name="C" x="10.668" y="-10.668" drill="3.048" diameter="6.477"/>
-<pad name="C1" x="-10.668" y="10.668" drill="3.048" diameter="6.477"/>
-<text x="-1.905" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO3A">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.0508" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-1.778" y="-5.461" drill="1.27" diameter="3.1496" shape="octagon"/>
-<pad name="B" x="-1.778" y="5.461" drill="1.27" diameter="3.1496" shape="octagon"/>
-<pad name="C" x="15.113" y="0" drill="3.048" diameter="6.477"/>
-<pad name="C1" x="-15.113" y="0" drill="3.048" diameter="6.477"/>
-<text x="2.54" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-5.08" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<circle x="15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<pad name="1" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="2" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="3" x="15.113" y="0" drill="4.1148" diameter="6.477"/>
+<pad name="4" x="-15.113" y="0" drill="4.1148" diameter="6.477"/>
+<text x="2.54" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="5.08" y="-3.81" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.2032" layer="21" curve="-60.173068" cap="flat"/>
+<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.2032" layer="21" curve="59.404169" cap="flat"/>
+<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.2032" layer="21" curve="-30.113639" cap="flat"/>
+<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.2032" layer="21"/>
+<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.2032" layer="21" curve="28.0726" cap="flat"/>
+<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.2032" layer="21"/>
+<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.2032" layer="21" curve="30.113639" cap="flat"/>
+<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.2032" layer="21" curve="-28.0726" cap="flat"/>
+<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.2032" layer="21"/>
+<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.2032" layer="21"/>
+<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="57.148737" cap="flat"/>
+<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="-57.148737" cap="flat"/>
 </package>
 <package name="TO127H">
 <description>&lt;b&gt;Molded Package&lt;/b&gt;&lt;p&gt;
@@ -519,95 +496,6 @@ grid 2.54 mm</description>
 <rectangle x1="-0.889" y1="-2.794" x2="0.889" y2="-2.286" layer="51"/>
 <rectangle x1="1.651" y1="-2.794" x2="3.429" y2="-2.286" layer="51"/>
 </package>
-<package name="BD679V">
-<description>&lt;b&gt;Molded Package&lt;/b&gt;&lt;p&gt;
-grid 2.3 mm</description>
-<wire x1="-3.937" y1="-0.127" x2="-3.937" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-1.27" x2="-3.683" y2="-2.794" width="0.2032" layer="21"/>
-<wire x1="3.683" y1="-2.794" x2="3.937" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="3.937" y1="-1.27" x2="3.937" y2="-0.127" width="0.2032" layer="21"/>
-<wire x1="3.683" y1="-2.794" x2="2.794" y2="-2.794" width="0.2032" layer="21"/>
-<wire x1="2.794" y1="-2.794" x2="1.778" y2="-2.794" width="0.2032" layer="51"/>
-<wire x1="1.778" y1="-2.794" x2="0.508" y2="-2.794" width="0.2032" layer="21"/>
-<wire x1="0.508" y1="-2.794" x2="-0.508" y2="-2.794" width="0.2032" layer="51"/>
-<wire x1="-0.508" y1="-2.794" x2="-1.778" y2="-2.794" width="0.2032" layer="21"/>
-<wire x1="-1.778" y1="-2.794" x2="-2.794" y2="-2.794" width="0.2032" layer="51"/>
-<wire x1="-2.794" y1="-2.794" x2="-3.683" y2="-2.794" width="0.2032" layer="21"/>
-<circle x="-3.175" y="-2.159" radius="0.4064" width="0" layer="21"/>
-<pad name="E" x="-2.286" y="-1.27" drill="1.016" shape="long" rot="R90"/>
-<pad name="C" x="0" y="-1.27" drill="1.016" shape="long" rot="R90"/>
-<pad name="B" x="2.286" y="-1.27" drill="1.016" shape="long" rot="R90"/>
-<text x="-3.9624" y="-4.5466" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.9878" y="-6.1976" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="-3.937" y1="-0.381" x2="-3.175" y2="0" layer="21"/>
-<rectangle x1="-1.397" y1="-0.381" x2="-0.889" y2="0" layer="21"/>
-<rectangle x1="0.889" y1="-0.381" x2="1.397" y2="0" layer="21"/>
-<rectangle x1="3.175" y1="-0.381" x2="3.937" y2="0" layer="21"/>
-<rectangle x1="-3.175" y1="-0.381" x2="-1.397" y2="0" layer="51"/>
-<rectangle x1="-0.889" y1="-0.381" x2="0.889" y2="0" layer="51"/>
-<rectangle x1="1.397" y1="-0.381" x2="3.175" y2="0" layer="51"/>
-</package>
-<package name="BD679H">
-<description>&lt;b&gt;Molded Package&lt;/b&gt;&lt;p&gt;
-grid 2.3 mm</description>
-<wire x1="-3.937" y1="-1.27" x2="-3.937" y2="9.144" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="9.144" x2="3.937" y2="9.144" width="0.2032" layer="21"/>
-<wire x1="3.937" y1="9.144" x2="3.937" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="0.381" y1="6.5532" x2="0.381" y2="7.366" width="0.2032" layer="21"/>
-<wire x1="0.381" y1="7.366" x2="-0.381" y2="7.366" width="0.2032" layer="21"/>
-<wire x1="-0.381" y1="7.366" x2="-0.381" y2="6.5532" width="0.2032" layer="21"/>
-<wire x1="2.1082" y1="4.2418" x2="1.7018" y2="3.6322" width="0.2032" layer="21"/>
-<wire x1="1.7018" y1="3.6322" x2="1.1176" y2="4.0386" width="0.2032" layer="21"/>
-<wire x1="-1.4732" y1="4.6736" x2="-2.1082" y2="4.2418" width="0.2032" layer="21"/>
-<wire x1="-2.1082" y1="4.2418" x2="-1.7018" y2="3.6322" width="0.2032" layer="21"/>
-<wire x1="-1.7018" y1="3.6322" x2="-1.0922" y2="4.0386" width="0.2032" layer="21"/>
-<wire x1="0.381" y1="6.5532" x2="0.508" y2="6.5278" width="0.2032" layer="21"/>
-<wire x1="0.508" y1="6.5278" x2="0.7112" y2="6.4262" width="0.2032" layer="21"/>
-<wire x1="0.7112" y1="6.4262" x2="0.9144" y2="6.2992" width="0.2032" layer="21"/>
-<wire x1="0.9144" y1="6.2992" x2="1.0922" y2="6.1468" width="0.2032" layer="21"/>
-<wire x1="1.0922" y1="6.1468" x2="1.2446" y2="5.9436" width="0.2032" layer="21"/>
-<wire x1="1.2446" y1="5.9436" x2="1.3716" y2="5.715" width="0.2032" layer="21"/>
-<wire x1="1.3716" y1="5.715" x2="1.4478" y2="5.5118" width="0.2032" layer="21"/>
-<wire x1="1.4478" y1="5.5118" x2="1.4986" y2="5.2324" width="0.2032" layer="21"/>
-<wire x1="1.4986" y1="5.2324" x2="1.4986" y2="5.0038" width="0.2032" layer="21"/>
-<wire x1="1.4732" y1="4.6736" x2="2.1082" y2="4.2418" width="0.2032" layer="21"/>
-<wire x1="1.4986" y1="4.9784" x2="1.4732" y2="4.6736" width="0.2032" layer="21"/>
-<wire x1="1.1176" y1="4.0386" x2="0.9144" y2="3.8608" width="0.2032" layer="21"/>
-<wire x1="0.9144" y1="3.8608" x2="0.762" y2="3.7592" width="0.2032" layer="21"/>
-<wire x1="0.762" y1="3.7592" x2="0.5588" y2="3.6576" width="0.2032" layer="21"/>
-<wire x1="0.5588" y1="3.6576" x2="0.254" y2="3.5814" width="0.2032" layer="21"/>
-<wire x1="0.254" y1="3.5814" x2="-0.0508" y2="3.556" width="0.2032" layer="21"/>
-<wire x1="-0.0508" y1="3.556" x2="-0.4064" y2="3.6068" width="0.2032" layer="21"/>
-<wire x1="-0.4064" y1="3.6068" x2="-0.6604" y2="3.7084" width="0.2032" layer="21"/>
-<wire x1="-0.6604" y1="3.7084" x2="-0.8636" y2="3.8354" width="0.2032" layer="21"/>
-<wire x1="-0.8636" y1="3.8354" x2="-1.0922" y2="4.0386" width="0.2032" layer="21"/>
-<wire x1="-1.4732" y1="4.6736" x2="-1.524" y2="4.9784" width="0.2032" layer="21"/>
-<wire x1="-1.524" y1="4.9784" x2="-1.524" y2="5.207" width="0.2032" layer="21"/>
-<wire x1="-1.524" y1="5.207" x2="-1.4732" y2="5.461" width="0.2032" layer="21"/>
-<wire x1="-1.4732" y1="5.461" x2="-1.3716" y2="5.7404" width="0.2032" layer="21"/>
-<wire x1="-1.3716" y1="5.7404" x2="-1.1938" y2="6.0198" width="0.2032" layer="21"/>
-<wire x1="-1.1938" y1="6.0198" x2="-0.9144" y2="6.2992" width="0.2032" layer="21"/>
-<wire x1="-0.9144" y1="6.2992" x2="-0.5842" y2="6.5024" width="0.2032" layer="21"/>
-<wire x1="-0.5842" y1="6.5024" x2="-0.381" y2="6.5532" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-1.27" x2="3.937" y2="-1.27" width="0.2032" layer="21"/>
-<circle x="-3.1242" y="-0.4826" radius="0.4318" width="0" layer="21"/>
-<circle x="0" y="5.08" radius="3.81" width="0" layer="42"/>
-<circle x="0" y="5.08" radius="3.81" width="0" layer="43"/>
-<circle x="0" y="5.08" radius="1.4478" width="0.2032" layer="21"/>
-<pad name="E" x="-2.286" y="-5.08" drill="1.1176" shape="long" rot="R90"/>
-<pad name="C" x="0" y="-5.08" drill="1.1176" shape="long" rot="R90"/>
-<pad name="B" x="2.286" y="-5.08" drill="1.1176" shape="long" rot="R90"/>
-<text x="-2.54" y="7.62" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.175" y="1.397" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="-0.635" y1="-3.048" x2="0.635" y2="-1.27" layer="21"/>
-<rectangle x1="-2.667" y1="-3.429" x2="-1.905" y2="-1.27" layer="21"/>
-<rectangle x1="-2.667" y1="-5.207" x2="-1.905" y2="-3.429" layer="51"/>
-<rectangle x1="-0.381" y1="-3.429" x2="0.381" y2="-1.27" layer="21"/>
-<rectangle x1="-0.381" y1="-5.207" x2="0.381" y2="-3.429" layer="51"/>
-<rectangle x1="1.905" y1="-3.429" x2="2.667" y2="-1.27" layer="21"/>
-<rectangle x1="1.905" y1="-5.207" x2="2.667" y2="-3.429" layer="51"/>
-<hole x="0" y="5.08" drill="3.302"/>
-</package>
 <package name="TO126BH">
 <description>&lt;b&gt;Molded Package&lt;/b&gt;&lt;p&gt;
 grid 2.3 mm</description>
@@ -870,56 +758,6 @@ grid 5.45 mm</description>
 <rectangle x1="3.556" y1="-2.032" x2="7.239" y2="-1.143" layer="51"/>
 <rectangle x1="-7.239" y1="-2.032" x2="-3.556" y2="-1.143" layer="51"/>
 <rectangle x1="-1.905" y1="-2.032" x2="1.905" y2="-1.143" layer="51"/>
-</package>
-<package name="TO3B">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.0508" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="S" x="-1.778" y="-5.461" drill="1.27" diameter="3.1496" shape="long"/>
-<pad name="G" x="-1.778" y="5.461" drill="1.27" diameter="3.1496" shape="long"/>
-<pad name="D" x="15.113" y="0" drill="3.048" diameter="6.477"/>
-<pad name="D1" x="-15.113" y="0" drill="3.048" diameter="6.477"/>
-<text x="2.54" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-5.08" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-</package>
-<package name="TO3/B">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="15.1892" y1="-8.9916" x2="12.319" y2="2.4892" width="0.254" layer="21"/>
-<wire x1="-15.1892" y1="8.9916" x2="-12.319" y2="-2.4892" width="0.254" layer="21"/>
-<wire x1="-8.9916" y1="15.1892" x2="2.9972" y2="12.192" width="0.254" layer="21"/>
-<wire x1="8.9916" y1="-15.1892" x2="-2.4892" y2="-12.319" width="0.254" layer="21"/>
-<wire x1="13.97" y1="-13.97" x2="15.1759" y2="-8.9223" width="0.254" layer="21" curve="63.129135" cap="flat"/>
-<wire x1="2.6343" y1="12.2933" x2="8.89" y2="8.89" width="0.254" layer="21" curve="-32.905092" cap="flat"/>
-<wire x1="8.89" y1="8.89" x2="12.3282" y2="2.4656" width="0.254" layer="21" curve="-33.690295" cap="flat"/>
-<wire x1="8.9123" y1="-15.1725" x2="13.9697" y2="-13.9697" width="0.254" layer="21" curve="63.250342" cap="flat"/>
-<wire x1="-15.1758" y1="8.9223" x2="-13.9699" y2="13.9699" width="0.254" layer="21" curve="-63.129366" cap="flat"/>
-<wire x1="-13.97" y1="13.97" x2="-8.9123" y2="15.1728" width="0.254" layer="21" curve="-63.249639" cap="flat"/>
-<wire x1="-12.3282" y1="-2.4656" x2="-8.89" y2="-8.89" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<wire x1="-8.89" y1="-8.89" x2="-2.4656" y2="-12.3282" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.0508" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
-<circle x="10.668" y="-10.668" radius="2.159" width="0.254" layer="51"/>
-<circle x="-10.668" y="10.668" radius="2.159" width="0.254" layer="51"/>
-<pad name="S" x="-5.08" y="-2.54" drill="1.27" diameter="3.1496" shape="octagon"/>
-<pad name="G" x="2.54" y="5.08" drill="1.27" diameter="3.1496" shape="octagon"/>
-<pad name="D" x="10.668" y="-10.668" drill="3.048" diameter="6.477"/>
-<pad name="D1" x="-10.668" y="10.668" drill="3.048" diameter="6.477"/>
-<text x="-1.905" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="TOP3BH">
 <description>&lt;b&gt;Molded Package&lt;/b&gt;&lt;p&gt;
@@ -1484,139 +1322,28 @@ grid 5.6 mm</description>
 <text x="-7.62" y="-6.858" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-1.524" y="-6.858" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="TO3AA">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.0508" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-1.778" y="-5.461" drill="1.27" diameter="3.1496" shape="long"/>
-<pad name="B" x="-1.778" y="5.461" drill="1.27" diameter="3.1496" shape="long"/>
-<pad name="C" x="15.113" y="0" drill="3.048" diameter="6.477"/>
-<pad name="C1" x="-15.113" y="0" drill="3.048" diameter="6.477"/>
-<text x="2.54" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-5.08" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-</package>
-<package name="TO3/AA">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="15.1892" y1="-8.9916" x2="12.319" y2="2.4892" width="0.254" layer="21"/>
-<wire x1="-15.1892" y1="8.9916" x2="-12.319" y2="-2.4892" width="0.254" layer="21"/>
-<wire x1="-8.9916" y1="15.1892" x2="2.9972" y2="12.192" width="0.254" layer="21"/>
-<wire x1="8.9916" y1="-15.1892" x2="-2.4892" y2="-12.319" width="0.254" layer="21"/>
-<wire x1="13.97" y1="-13.97" x2="15.1759" y2="-8.9223" width="0.254" layer="21" curve="63.129135" cap="flat"/>
-<wire x1="2.6343" y1="12.2933" x2="8.89" y2="8.89" width="0.254" layer="21" curve="-32.905092" cap="flat"/>
-<wire x1="8.89" y1="8.89" x2="12.3282" y2="2.4656" width="0.254" layer="21" curve="-33.690295" cap="flat"/>
-<wire x1="8.9123" y1="-15.1725" x2="13.9697" y2="-13.9697" width="0.254" layer="21" curve="63.250342" cap="flat"/>
-<wire x1="-15.1758" y1="8.9223" x2="-13.9699" y2="13.9699" width="0.254" layer="21" curve="-63.129366" cap="flat"/>
-<wire x1="-13.97" y1="13.97" x2="-8.9123" y2="15.1728" width="0.254" layer="21" curve="-63.249639" cap="flat"/>
-<wire x1="-12.3282" y1="-2.4656" x2="-8.89" y2="-8.89" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<wire x1="-8.89" y1="-8.89" x2="-2.4656" y2="-12.3282" width="0.254" layer="21" curve="33.690295" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.0508" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
-<circle x="10.668" y="-10.668" radius="2.159" width="0.254" layer="51"/>
-<circle x="-10.668" y="10.668" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-5.08" y="-2.54" drill="1.27" diameter="3.1496" shape="octagon"/>
-<pad name="B" x="2.54" y="5.08" drill="1.27" diameter="3.1496" shape="octagon"/>
-<pad name="C" x="10.668" y="-10.668" drill="3.048" diameter="6.477"/>
-<pad name="C1" x="-10.668" y="10.668" drill="3.048" diameter="6.477"/>
-<text x="-1.905" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="TO66">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="-3.5011" y1="-7.8945" x2="3.5011" y2="-7.8945" width="0.254" layer="21" curve="47.833229"/>
-<wire x1="-3.5011" y1="7.8945" x2="3.5011" y2="7.8945" width="0.254" layer="21" curve="-47.833229"/>
-<wire x1="-13.7105" y1="3.3668" x2="-13.7105" y2="-3.3668" width="0.254" layer="21" curve="132.167583"/>
-<wire x1="-3.5011" y1="-7.8945" x2="-13.7105" y2="-3.3668" width="0.254" layer="21"/>
-<wire x1="-3.5011" y1="7.8945" x2="-13.7105" y2="3.3668" width="0.254" layer="21"/>
-<wire x1="13.7105" y1="-3.3668" x2="13.7105" y2="3.3668" width="0.254" layer="21" curve="132.167583"/>
-<wire x1="3.5011" y1="-7.8945" x2="13.7105" y2="-3.3668" width="0.254" layer="21"/>
-<wire x1="3.5011" y1="7.8945" x2="13.7105" y2="3.3668" width="0.254" layer="21"/>
+<description>&lt;b&gt;TO-66 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-66.
+&lt;/p&gt;</description>
+<circle x="-12.192" y="0" radius="1.905" width="0.2032" layer="51"/>
 <circle x="0" y="0" radius="7.874" width="0.2032" layer="51"/>
-<circle x="0" y="0" radius="6.35" width="0.0508" layer="51"/>
-<circle x="-12.192" y="0" radius="1.905" width="0.254" layer="51"/>
-<circle x="12.192" y="0" radius="1.905" width="0.254" layer="51"/>
-<pad name="3-1" x="-12.192" y="0" drill="3.048" diameter="6.35"/>
-<pad name="3" x="12.192" y="0" drill="3.048" diameter="6.35"/>
-<pad name="2" x="-2.54" y="2.54" drill="1.1176" diameter="2.54" shape="long"/>
+<circle x="0" y="0" radius="6.35" width="0.2032" layer="51"/>
+<circle x="12.192" y="0" radius="1.905" width="0.2032" layer="51"/>
 <pad name="1" x="-2.54" y="-2.54" drill="1.1176" diameter="2.54" shape="long"/>
+<pad name="2" x="-2.54" y="2.54" drill="1.1176" diameter="2.54" shape="long"/>
+<pad name="3" x="12.192" y="0" drill="3.302" diameter="6.35"/>
+<pad name="4" x="-12.192" y="0" drill="3.302" diameter="6.35"/>
 <text x="1.27" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.175" y="-3.175" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-</package>
-<package name="TO66/">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="3.1066" y1="8.0579" x2="-7.3141" y2="12.0755" width="0.254" layer="21"/>
-<wire x1="-3.1066" y1="-8.0579" x2="7.3141" y2="-12.0755" width="0.254" layer="21"/>
-<wire x1="-8.0579" y1="-3.1066" x2="-12.0755" y2="7.3141" width="0.254" layer="21"/>
-<wire x1="-8.0579" y1="-3.1066" x2="-3.1066" y2="-8.0578" width="0.254" layer="21" curve="47.833617" cap="flat"/>
-<wire x1="-12.0755" y1="7.3141" x2="-7.3141" y2="12.0755" width="0.254" layer="21" curve="-132.167054"/>
-<wire x1="8.0579" y1="3.1066" x2="12.0755" y2="-7.3141" width="0.254" layer="21"/>
-<wire x1="7.3141" y1="-12.0755" x2="12.0755" y2="-7.3141" width="0.254" layer="21" curve="132.167054"/>
-<wire x1="3.1066" y1="8.0579" x2="8.058" y2="3.1066" width="0.254" layer="21" curve="-47.834094" cap="flat"/>
-<circle x="0" y="0" radius="7.874" width="0.2032" layer="51"/>
-<circle x="0" y="0" radius="6.35" width="0.0508" layer="51"/>
-<circle x="-8.621" y="8.621" radius="1.905" width="0.254" layer="51"/>
-<circle x="8.621" y="-8.621" radius="1.905" width="0.254" layer="51"/>
-<pad name="1" x="-3.5814" y="0" drill="1.1176" diameter="2.54" shape="octagon"/>
-<pad name="2" x="0" y="3.5814" drill="1.1176" diameter="2.54" shape="octagon"/>
-<pad name="3-1" x="-8.636" y="8.636" drill="3.048" diameter="6.35"/>
-<pad name="3" x="8.636" y="-8.636" drill="3.048" diameter="6.35"/>
-<text x="0" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.143" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO66A">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="-3.5011" y1="-7.8945" x2="3.5011" y2="-7.8945" width="0.254" layer="21" curve="47.833229"/>
-<wire x1="-3.5011" y1="7.8945" x2="3.5011" y2="7.8945" width="0.254" layer="21" curve="-47.833229"/>
-<wire x1="-13.7105" y1="3.3668" x2="-13.7105" y2="-3.3668" width="0.254" layer="21" curve="132.167583"/>
-<wire x1="-3.5011" y1="-7.8945" x2="-13.7105" y2="-3.3668" width="0.254" layer="21"/>
-<wire x1="-3.5011" y1="7.8945" x2="-13.7105" y2="3.3668" width="0.254" layer="21"/>
-<wire x1="13.7105" y1="-3.3668" x2="13.7105" y2="3.3668" width="0.254" layer="21" curve="132.167583"/>
-<wire x1="3.5011" y1="-7.8945" x2="13.7105" y2="-3.3668" width="0.254" layer="21"/>
-<wire x1="3.5011" y1="7.8945" x2="13.7105" y2="3.3668" width="0.254" layer="21"/>
-<circle x="0" y="0" radius="7.874" width="0.2032" layer="51"/>
-<circle x="0" y="0" radius="6.35" width="0.0508" layer="51"/>
-<circle x="-12.192" y="0" radius="1.905" width="0.254" layer="51"/>
-<circle x="12.192" y="0" radius="1.905" width="0.254" layer="51"/>
-<pad name="C1" x="-12.192" y="0" drill="3.048" diameter="6.35"/>
-<pad name="C" x="12.192" y="0" drill="3.048" diameter="6.35"/>
-<pad name="B" x="-2.54" y="2.54" drill="1.1176" diameter="2.54" shape="long"/>
-<pad name="E" x="-2.54" y="-2.54" drill="1.1176" diameter="2.54" shape="long"/>
-<text x="1.27" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="3.175" y="-3.175" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-</package>
-<package name="TO66/A">
-<description>&lt;b&gt;Metal Can Package&lt;/b&gt;</description>
-<wire x1="3.1066" y1="8.0579" x2="-7.3141" y2="12.0755" width="0.254" layer="21"/>
-<wire x1="-3.1066" y1="-8.0579" x2="7.3141" y2="-12.0755" width="0.254" layer="21"/>
-<wire x1="-8.0579" y1="-3.1066" x2="-12.0755" y2="7.3141" width="0.254" layer="21"/>
-<wire x1="-8.0579" y1="-3.1066" x2="-3.1066" y2="-8.0578" width="0.254" layer="21" curve="47.833617" cap="flat"/>
-<wire x1="-12.0755" y1="7.3141" x2="-7.3141" y2="12.0755" width="0.254" layer="21" curve="-132.167054"/>
-<wire x1="8.0579" y1="3.1066" x2="12.0755" y2="-7.3141" width="0.254" layer="21"/>
-<wire x1="7.3141" y1="-12.0755" x2="12.0755" y2="-7.3141" width="0.254" layer="21" curve="132.167054"/>
-<wire x1="3.1066" y1="8.0579" x2="8.058" y2="3.1066" width="0.254" layer="21" curve="-47.834094" cap="flat"/>
-<circle x="0" y="0" radius="7.874" width="0.2032" layer="51"/>
-<circle x="0" y="0" radius="6.35" width="0.0508" layer="51"/>
-<circle x="-8.621" y="8.621" radius="1.905" width="0.254" layer="51"/>
-<circle x="8.621" y="-8.621" radius="1.905" width="0.254" layer="51"/>
-<pad name="E" x="-3.5814" y="0" drill="1.1176" diameter="2.54" shape="octagon"/>
-<pad name="B" x="0" y="3.5814" drill="1.1176" diameter="2.54" shape="octagon"/>
-<pad name="C1" x="-8.636" y="8.636" drill="3.048" diameter="6.35"/>
-<pad name="C" x="8.636" y="-8.636" drill="3.048" diameter="6.35"/>
-<text x="0" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-1.143" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-13.711" y1="3.3666" x2="-13.711" y2="-3.367" width="0.2032" layer="21" curve="132.167583" cap="flat"/>
+<wire x1="-3.501" y1="-7.895" x2="3.5012" y2="-7.895" width="0.2032" layer="21" curve="47.833229" cap="flat"/>
+<wire x1="-3.501" y1="-7.895" x2="-13.711" y2="-3.367" width="0.2032" layer="21"/>
+<wire x1="-3.501" y1="7.895" x2="3.5012" y2="7.895" width="0.2032" layer="21" curve="-47.833229" cap="flat"/>
+<wire x1="-3.501" y1="7.895" x2="-13.711" y2="3.367" width="0.2032" layer="21"/>
+<wire x1="3.501" y1="-7.895" x2="13.711" y2="-3.367" width="0.2032" layer="21"/>
+<wire x1="3.501" y1="7.895" x2="13.711" y2="3.367" width="0.2032" layer="21"/>
+<wire x1="13.711" y1="-3.367" x2="13.711" y2="3.3666" width="0.2032" layer="21" curve="132.167583" cap="flat"/>
 </package>
 <package name="SIP11">
 <description>&lt;b&gt;Molded Package&lt;/b&gt;&lt;p&gt;
@@ -2678,12 +2405,12 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm. JEDEC MS-012F. Vari
 <gate name="A" symbol="NPN2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3A">
+<device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C1"/>
-<connect gate="A" pin="C@1" pad="C"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="4"/>
+<connect gate="A" pin="C@1" pad="3"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2823,12 +2550,12 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm. JEDEC MS-012F. Vari
 <gate name="A" symbol="N-DAR2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3A">
+<device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C1"/>
-<connect gate="A" pin="C@1" pad="C"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="4"/>
+<connect gate="A" pin="C@1" pad="3"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2842,12 +2569,12 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm. JEDEC MS-012F. Vari
 <gate name="A" symbol="P-DAR2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3A">
+<device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C1"/>
-<connect gate="A" pin="C@1" pad="C"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="4"/>
+<connect gate="A" pin="C@1" pad="3"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2971,12 +2698,12 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm. JEDEC MS-012F. Vari
 <gate name="A" symbol="PNP2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3A">
+<device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C1" pad="C1"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2990,12 +2717,12 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm. JEDEC MS-012F. Vari
 <gate name="A" symbol="NPN2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3A">
+<device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C1"/>
-<connect gate="A" pin="C@1" pad="C"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="4"/>
+<connect gate="A" pin="C@1" pad="3"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/transistor-small-signal.lbr
+++ b/transistor-small-signal.lbr
@@ -78,60 +78,20 @@ www.semiconductors.com;&lt;br&gt;
 www.irf.com&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="TO72B">
-<description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="21" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="E" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="B" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="C" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="GEH" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO18A">
-<description>&lt;b&gt;TO-18&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="21" curve="-135.281008" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-2.877" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="-3.937" y1="0.508" x2="-2.877" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="E" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="B" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="C" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO5A">
-<description>&lt;b&gt;TO-5&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.4798" y2="-2.9718" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5052" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<package name="TO5">
+<description>&lt;b&gt;TO-5 (3 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-5
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.191" width="0.0508" layer="51"/>
-<pad name="E" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="B" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="C" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
+<pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.81" y="-6.35" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
 <package name="TO202AH">
 <description>&lt;b&gt;TO-202&lt;/b&gt;&lt;p&gt;
@@ -304,142 +264,6 @@ grid 2.54 mm</description>
 <rectangle x1="-0.508" y1="2.413" x2="0.508" y2="2.794" layer="21"/>
 <hole x="0" y="0" drill="5.08"/>
 </package>
-<package name="TO72A">
-<description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="21" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="B" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="E" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="C" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="GEH" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO18C">
-<description>&lt;b&gt;TO-18&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="21" curve="-135.281008" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-2.877" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-3.937" y1="0.508" x2="-2.877" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="B" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="E" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="C" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO18I">
-<description>&lt;b&gt;TO-18&lt;/b&gt;&lt;p&gt;
-grid 2.54</description>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="21" curve="-135.281008" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-2.877" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-3.937" y1="0.508" x2="-2.877" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="C" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="A" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO18E">
-<description>&lt;b&gt;TO-18&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="21" curve="-135.281008" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-2.877" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-3.937" y1="0.508" x2="-2.877" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="S" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="D" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO18F">
-<description>&lt;b&gt;TO-18&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="21" curve="-135.281008" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-2.877" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-3.937" y1="0.508" x2="-2.877" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="S" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="D" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO18G">
-<description>&lt;b&gt;TO-18&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="21" curve="-135.281008" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-2.877" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-3.937" y1="0.508" x2="-2.877" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="D" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="S" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO18M">
-<description>&lt;b&gt;TO-18&lt;/b&gt;&lt;p&gt;
-grid 2.54</description>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="21" curve="-135.281008" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-2.877" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-3.937" y1="0.508" x2="-2.877" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="A" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="C" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="TO202CH">
 <description>&lt;b&gt;TO-202&lt;/b&gt;&lt;p&gt;
 grid 2.54 mm</description>
@@ -568,244 +392,6 @@ grid 2.54 mm</description>
 <rectangle x1="-0.889" y1="-2.794" x2="0.889" y2="-2.286" layer="51"/>
 <rectangle x1="1.651" y1="-2.794" x2="3.429" y2="-2.286" layer="51"/>
 </package>
-<package name="TO5D">
-<description>&lt;b&gt;TO-5&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.4798" y2="-2.9718" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5052" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.191" width="0.0508" layer="51"/>
-<pad name="D" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="S" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.81" y="-6.35" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO5E">
-<description>&lt;b&gt;TO-5&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.4798" y2="-2.9718" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5052" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.191" width="0.0508" layer="51"/>
-<pad name="C" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="A" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.81" y="-6.35" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO5F">
-<description>&lt;b&gt;TO-5&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.4798" y2="-2.9718" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5052" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.191" width="0.0508" layer="51"/>
-<pad name="S" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="D" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.81" y="-6.35" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO5I">
-<description>&lt;b&gt;TO-5&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.4798" y2="-2.9718" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5052" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.191" width="0.0508" layer="51"/>
-<pad name="S" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="D" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.81" y="-6.35" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO5M">
-<description>&lt;b&gt;TO-5&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.4798" y2="-2.9718" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5052" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.191" width="0.0508" layer="51"/>
-<pad name="S" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="D" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.81" y="-6.35" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO5H">
-<description>&lt;b&gt;TO-5&lt;/b&gt;&lt;p&gt;
-grid 5.08 mm</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.4798" y2="-2.9718" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5052" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.191" width="0.0508" layer="51"/>
-<pad name="A1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="A2" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.81" y="-6.35" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO72O">
-<description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="21" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="G1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="D" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="S" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO72N">
-<description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="21" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="D" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="S" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G1" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G2" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO72P">
-<description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="21" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="S" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G1" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="D" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G2" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO72Q">
-<description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="21" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="E1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="B" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="C" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="E2" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO72G">
-<description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="21" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="D" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="S" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="B" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO72E">
-<description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="21" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="S" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="D" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="SUB" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
-<package name="TO72H">
-<description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="21" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="D" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="G1" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="S" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="TO92H">
 <description>&lt;b&gt;TO-92&lt;/b&gt;&lt;p&gt;
 grid 2.54 mm</description>
@@ -889,23 +475,26 @@ grid 2.3 mm</description>
 <rectangle x1="-3.048" y1="-0.889" x2="3.048" y2="0" layer="51"/>
 </package>
 <package name="TO18">
-<description>&lt;b&gt;TO-18&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="21" curve="-135.281008" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-2.877" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
-<wire x1="-3.937" y1="0.508" x2="-2.877" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
+<description>&lt;b&gt;TO-18 (2.54mm lead pitch, 3 leads)&lt;/b&gt;&lt;p&gt;
+Header family package. 2.54mm lead pitch, 3 leads, metal can.
+&lt;p/&gt;&lt;p&gt;
+JEDEC TO-18.
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
 <pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="-0.508" x2="-2.8765" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="0.508" x2="-2.8765" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="51" curve="-135.281008" cap="flat"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
 </package>
 <package name="TO92-AB">
 <description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
@@ -922,23 +511,6 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
 <wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
 <wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
-</package>
-<package name="SOT54DA">
-<description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
-grid 4 mm</description>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<wire x1="-1.1105" y1="2.1423" x2="1.1105" y2="2.1423" width="0.2032" layer="51" curve="-54.801566" cap="flat"/>
-<wire x1="-2.1254" y1="1.1425" x2="-2.1254" y2="-1.1425" width="0.2032" layer="51" curve="56.520138" cap="flat"/>
-<wire x1="-2.1251" y1="-1.1425" x2="-1.631" y2="-1.778" width="0.2032" layer="21" curve="19.203018" cap="flat"/>
-<wire x1="-2.1254" y1="1.1425" x2="-1.1105" y2="2.1423" width="0.2032" layer="21" curve="-34.339012" cap="flat"/>
-<wire x1="2.1254" y1="-1.1425" x2="2.1254" y2="1.1425" width="0.2032" layer="51" curve="56.520138" cap="flat"/>
-<wire x1="1.631" y1="-1.778" x2="2.1251" y2="-1.1425" width="0.2032" layer="21" curve="19.203018" cap="flat"/>
-<wire x1="1.1105" y1="2.1423" x2="2.1254" y2="1.1425" width="0.2032" layer="21" curve="-34.339012" cap="flat"/>
-<pad name="E" x="-2.159" y="0" drill="0.8128" shape="octagon"/>
-<pad name="C" x="0" y="2.413" drill="0.8128" shape="octagon"/>
-<pad name="B" x="2.159" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.27" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 </package>
 <package name="C370-01">
 <description>&lt;b&gt;DIL&lt;/b&gt;</description>
@@ -981,63 +553,28 @@ grid 4 mm</description>
 <text x="1.6002" y="0.6604" size="1.016" layer="21" ratio="18">S</text>
 <text x="1.6002" y="-1.8796" size="1.016" layer="21" ratio="18">G</text>
 </package>
-<package name="SOT54DB">
-<description>&lt;b&gt;SOT-54&lt;/b&gt;&lt;p&gt;
-grid 4 mm</description>
-<wire x1="-1.631" y1="-1.778" x2="1.631" y2="-1.778" width="0.2032" layer="21"/>
-<wire x1="-1.2252" y1="2.0788" x2="1.2252" y2="2.0788" width="0.2032" layer="51" curve="-61.028365" cap="flat"/>
-<wire x1="-2.0638" y1="1.2504" x2="-2.0638" y2="-1.2504" width="0.2032" layer="51" curve="62.421053" cap="flat"/>
-<wire x1="-2.0638" y1="-1.2504" x2="-1.6313" y2="-1.7781" width="0.2032" layer="21" curve="16.254995" cap="flat"/>
-<wire x1="-2.0638" y1="1.2504" x2="-1.2252" y2="2.0788" width="0.2032" layer="21" curve="-28.276487" cap="flat"/>
-<wire x1="2.0638" y1="-1.2504" x2="2.0638" y2="1.2504" width="0.2032" layer="51" curve="62.421053" cap="flat"/>
-<wire x1="1.631" y1="-1.778" x2="2.0634" y2="-1.2504" width="0.2032" layer="21" curve="16.252389" cap="flat"/>
-<wire x1="1.2252" y1="2.0788" x2="2.0638" y2="1.2504" width="0.2032" layer="21" curve="-28.276487" cap="flat"/>
-<pad name="E" x="-2.159" y="0" drill="0.8128" shape="octagon"/>
-<pad name="C" x="0" y="2.413" drill="0.8128" shape="octagon"/>
-<pad name="B" x="2.159" y="0" drill="0.8128" shape="octagon"/>
-<text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="1.905" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-</package>
-<package name="TO18-">
-<description>&lt;b&gt;TO-18&lt;/b&gt;&lt;p&gt;
-grid 4 mm</description>
-<wire x1="-2.2098" y1="-0.9692" x2="2.2098" y2="-0.9692" width="0.0508" layer="51" curve="132.636282" cap="flat"/>
-<wire x1="-0.9692" y1="2.2098" x2="0.9692" y2="2.2098" width="0.0508" layer="51" curve="-47.363718" cap="flat"/>
-<wire x1="-2.2098" y1="0.9692" x2="-2.2098" y2="-0.9692" width="0.0508" layer="51" curve="47.363718" cap="flat"/>
-<wire x1="-2.2098" y1="0.9692" x2="-0.9692" y2="2.2098" width="0.0508" layer="21" curve="-42.636282" cap="flat"/>
-<wire x1="2.2098" y1="-0.9692" x2="2.2098" y2="0.9692" width="0.0508" layer="51" curve="47.363718" cap="flat"/>
-<wire x1="1.649" y1="-2.411" x2="2.413" y2="-3.175" width="0.2032" layer="21"/>
-<wire x1="2.411" y1="-1.649" x2="3.175" y2="-2.413" width="0.2032" layer="21"/>
-<wire x1="2.413" y1="-3.175" x2="3.175" y2="-2.413" width="0.2032" layer="21"/>
-<wire x1="0.9692" y1="2.2098" x2="2.2098" y2="0.9692" width="0.0508" layer="21" curve="-42.636282" cap="flat"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="1" x="1.905" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="-1.905" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-</package>
 <package name="TO72">
-<description>&lt;b&gt;TO-72&lt;/b&gt;&lt;p&gt;
-grid 2.54 mm</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="21" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-72 (4 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-72.
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
 <pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="4" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="51" curve="-45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
 </package>
 <package name="SOT143B">
 <description>&lt;b&gt;Small Outline Transistor&lt;/b&gt;</description>
@@ -1634,17 +1171,19 @@ INFINEON, www.infineon.com</description>
 <rectangle x1="0.7" y1="-0.3" x2="1.3" y2="0.3" layer="51"/>
 </package>
 <package name="TO39">
-<description>&lt;b&gt;TO-39&lt;/b&gt;</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-39&lt;/b&gt;&lt;p&gt;
+JEDEC TO-39
+&lt;p/&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
 <circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
 <pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
 <package name="VMT3">
 <description>&lt;b&gt;ROHM : VMT3&lt;/b&gt;&lt;p&gt;
@@ -2396,12 +1935,12 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="I2GFN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO72H">
+<device name="" package="TO72">
 <connects>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G1" pad="G1"/>
-<connect gate="1" pin="G2" pad="G2"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="D" pad="1"/>
+<connect gate="1" pin="G1" pad="3"/>
+<connect gate="1" pin="G2" pad="2"/>
+<connect gate="1" pin="S" pad="4"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2433,11 +1972,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="JFETN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO18E">
+<device name="" package="TO18">
 <connects>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G" pad="G"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="D" pad="2"/>
+<connect gate="1" pin="G" pad="3"/>
+<connect gate="1" pin="S" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2505,11 +2044,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO18A">
+<device name="" package="TO18">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2523,12 +2062,12 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="I2GFN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO72H">
+<device name="" package="TO72">
 <connects>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G1" pad="G1"/>
-<connect gate="1" pin="G2" pad="G2"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="D" pad="1"/>
+<connect gate="1" pin="G1" pad="3"/>
+<connect gate="1" pin="G2" pad="2"/>
+<connect gate="1" pin="S" pad="4"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2542,12 +2081,12 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="IGFNAD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO72G">
+<device name="" package="TO72">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G" pad="G"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="B" pad="4"/>
+<connect gate="1" pin="D" pad="1"/>
+<connect gate="1" pin="G" pad="3"/>
+<connect gate="1" pin="S" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2561,12 +2100,12 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="IGFNAD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO72G">
+<device name="" package="TO72">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G" pad="G"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="B" pad="4"/>
+<connect gate="1" pin="D" pad="1"/>
+<connect gate="1" pin="G" pad="3"/>
+<connect gate="1" pin="S" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2580,11 +2119,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO72B">
+<device name="" package="TO72">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2598,11 +2137,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO5A">
+<device name="" package="TO5">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2616,11 +2155,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO18A">
+<device name="" package="TO18">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2670,11 +2209,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO5A">
+<device name="" package="TO5">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2706,11 +2245,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO18A">
+<device name="" package="TO18">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2742,11 +2281,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO72A">
+<device name="" package="TO72">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="1"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2778,11 +2317,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO72B">
+<device name="" package="TO72">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2904,11 +2443,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO5A">
+<device name="" package="TO5">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3030,12 +2569,12 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="I2GFN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO72H">
+<device name="" package="TO72">
 <connects>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G1" pad="G1"/>
-<connect gate="1" pin="G2" pad="G2"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="D" pad="1"/>
+<connect gate="1" pin="G1" pad="3"/>
+<connect gate="1" pin="G2" pad="2"/>
+<connect gate="1" pin="S" pad="4"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3049,11 +2588,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="JFETN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO72E">
+<device name="" package="TO72">
 <connects>
-<connect gate="1" pin="D" pad="D"/>
-<connect gate="1" pin="G" pad="G"/>
-<connect gate="1" pin="S" pad="S"/>
+<connect gate="1" pin="D" pad="2"/>
+<connect gate="1" pin="G" pad="3"/>
+<connect gate="1" pin="S" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3175,11 +2714,11 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO18A">
+<device name="" package="TO18">
 <connects>
-<connect gate="1" pin="B" pad="B"/>
-<connect gate="1" pin="C" pad="C"/>
-<connect gate="1" pin="E" pad="E"/>
+<connect gate="1" pin="B" pad="2"/>
+<connect gate="1" pin="C" pad="3"/>
+<connect gate="1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/transistor-small-signal.lbr
+++ b/transistor-small-signal.lbr
@@ -1248,33 +1248,12 @@ JEDEC TO-39
 <rectangle x1="0.7112" y1="-1.4954" x2="1.1684" y2="-0.9112" layer="51"/>
 <rectangle x1="-1.1684" y1="-1.4954" x2="-0.7112" y2="-0.9112" layer="51"/>
 </package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
-<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -1283,25 +1262,35 @@ JEDEC TO-39
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="3.175" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -1310,6 +1299,18 @@ JEDEC TO-39
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
 <package name="SOT23">
 <description>&lt;b&gt;SOT23 (0.95mm pitch, 1.3mm body, 3 leads)&lt;/b&gt;&lt;p&gt;

--- a/transistor.lbr
+++ b/transistor.lbr
@@ -79,85 +79,54 @@
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
 <package name="TO3">
-<description>&lt;b&gt;TO-3&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="21"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="21"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
-<pad name="B" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
-<pad name="C" x="15.113" y="0" drill="4.1148" diameter="6.477"/>
-<pad name="C/" x="-15.113" y="0" drill="4.1148" diameter="6.477"/>
-<text x="-5.08" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-5.08" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="15.24" y="-4.953" size="1.27" layer="51" ratio="10" rot="R90">C</text>
-<text x="-3.81" y="-6.223" size="1.27" layer="51" ratio="10" rot="R90">E</text>
-<text x="-3.81" y="4.572" size="1.27" layer="51" ratio="10" rot="R90">B</text>
-</package>
-<package name="TO3A">
-<description>&lt;b&gt;TO-3&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="21"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="21"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="E" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
-<pad name="B" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
-<pad name="C" x="15.113" y="0" drill="3.302" diameter="6.477"/>
-<pad name="C/" x="-15.113" y="0" drill="3.302" diameter="6.477"/>
-<text x="-6.35" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-6.35" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-5.588" y="5.08" size="1.27" layer="51" ratio="10">B</text>
-<text x="-4.953" y="-6.35" size="1.27" layer="51" ratio="10">E</text>
-<text x="11.557" y="-3.81" size="1.27" layer="51" ratio="10">C</text>
+<description>&lt;b&gt;TO-3 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-3.
+&lt;/p&gt;</description>
+<circle x="-15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="9.3726" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
+<circle x="15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<pad name="1" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="2" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="3" x="15.113" y="0" drill="4.1148" diameter="6.477"/>
+<pad name="4" x="-15.113" y="0" drill="4.1148" diameter="6.477"/>
+<text x="2.54" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="5.08" y="-3.81" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.2032" layer="21" curve="-60.173068" cap="flat"/>
+<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.2032" layer="21" curve="59.404169" cap="flat"/>
+<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.2032" layer="21" curve="-30.113639" cap="flat"/>
+<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.2032" layer="21"/>
+<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.2032" layer="21" curve="28.0726" cap="flat"/>
+<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.2032" layer="21"/>
+<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.2032" layer="21" curve="30.113639" cap="flat"/>
+<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.2032" layer="21" curve="-28.0726" cap="flat"/>
+<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.2032" layer="21"/>
+<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.2032" layer="21"/>
+<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="57.148737" cap="flat"/>
+<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="-57.148737" cap="flat"/>
 </package>
 <package name="TO72">
-<description>&lt;b&gt;TO-72&lt;/b&gt;</description>
-<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="21" curve="-45.282836" cap="flat"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-72 (4 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-72.
+&lt;/p&gt;</description>
+<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
+<pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="4" x="-1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
 <wire x1="-3.937" y1="0.508" x2="-2.8956" y2="0.508" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="1" x="-1.27" y="-1.27" drill="0.8128" shape="octagon"/>
-<pad name="3" x="1.27" y="1.27" drill="0.8128" shape="octagon"/>
-<pad name="2" x="1.27" y="-1.27" drill="0.8128" shape="octagon"/>
-<pad name="4" x="-1.27" y="1.27" drill="0.8128" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.651" y="-1.651" size="1.27" layer="51" ratio="10">1</text>
-<text x="0.508" y="-1.651" size="1.27" layer="51" ratio="10">2</text>
-<text x="0.508" y="0.381" size="1.27" layer="51" ratio="10">3</text>
-<text x="-1.651" y="0.381" size="1.27" layer="51" ratio="10">4</text>
+<wire x1="-2.8956" y1="-0.508" x2="-3.937" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-2.227" y1="0.9289" x2="-2.227" y2="-0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="-2.227" y1="0.9289" x2="-0.9289" y2="2.227" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="-0.9289" y1="2.227" x2="0.9289" y2="2.227" width="0.0508" layer="51" curve="-45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
 </package>
 <package name="TO202">
 <description>&lt;b&gt;TO-202&lt;/b&gt;&lt;p&gt;
@@ -202,48 +171,27 @@ grid 2.54 mm, vertical</description>
 <rectangle x1="-2.921" y1="-5.08" x2="-2.159" y2="-3.429" layer="51"/>
 <hole x="0" y="17.78" drill="3.302"/>
 </package>
-<package name="TO18-">
-<description>&lt;b&gt;TO-18&lt;/b&gt;</description>
-<wire x1="-2.2098" y1="-0.9692" x2="2.2098" y2="-0.9692" width="0.0508" layer="21" curve="132.636282" cap="flat"/>
-<wire x1="-0.9692" y1="2.2098" x2="0.9692" y2="2.2098" width="0.0508" layer="51" curve="-47.363718" cap="flat"/>
-<wire x1="-2.2098" y1="0.9692" x2="-2.2098" y2="-0.9692" width="0.0508" layer="51" curve="47.363718" cap="flat"/>
-<wire x1="-2.2098" y1="0.9692" x2="-0.9692" y2="2.2098" width="0.0508" layer="21" curve="-42.636282" cap="flat"/>
-<wire x1="2.2098" y1="-0.9692" x2="2.2098" y2="0.9692" width="0.0508" layer="51" curve="47.363718" cap="flat"/>
-<wire x1="1.649" y1="-2.411" x2="2.413" y2="-3.175" width="0.2032" layer="21"/>
-<wire x1="2.411" y1="-1.649" x2="3.175" y2="-2.413" width="0.2032" layer="21"/>
-<wire x1="2.413" y1="-3.175" x2="3.175" y2="-2.413" width="0.2032" layer="21"/>
-<wire x1="0.9692" y1="2.2098" x2="2.2098" y2="0.9692" width="0.0508" layer="21" curve="-42.636282" cap="flat"/>
-<circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="1" x="1.905" y="0" drill="0.8128" shape="octagon"/>
-<pad name="2" x="0" y="1.905" drill="0.8128" shape="octagon"/>
-<pad name="3" x="-1.905" y="0" drill="0.8128" shape="octagon"/>
-<text x="3.302" y="0.381" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="3.302" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="1.016" y="-1.143" size="1.27" layer="51" ratio="10">1</text>
-<text x="-0.508" y="0.635" size="1.27" layer="51" ratio="10">2</text>
-<text x="-1.905" y="-1.27" size="1.27" layer="51" ratio="10">3</text>
-</package>
 <package name="TO18">
-<description>&lt;b&gt;TO-18&lt;/b&gt;
-&lt;p&gt; TO 206AA Motorola</description>
-<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
-<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="21" curve="-135.281008" cap="flat"/>
-<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
-<wire x1="-3.937" y1="-0.508" x2="-2.877" y2="-0.508" width="0.2032" layer="21"/>
-<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
-<wire x1="-3.937" y1="0.508" x2="-2.877" y2="0.508" width="0.2032" layer="21"/>
-<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="21" curve="45.282836" cap="flat"/>
+<description>&lt;b&gt;TO-18 (2.54mm lead pitch, 3 leads)&lt;/b&gt;&lt;p&gt;
+Header family package. 2.54mm lead pitch, 3 leads, metal can.
+&lt;p/&gt;&lt;p&gt;
+JEDEC TO-18.
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="2.921" width="0.2032" layer="21"/>
-<pad name="1" x="-1.27" y="-1.27" drill="0.8128" shape="octagon"/>
-<pad name="2" x="1.27" y="-1.27" drill="0.8128" shape="octagon"/>
-<pad name="3" x="1.27" y="1.27" drill="0.8128" shape="octagon"/>
-<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<pad name="1" x="-1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="1.27" y="-1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="1.27" y="1.27" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <text x="3.175" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-1.905" y="-1.27" size="1.27" layer="51" ratio="10">1</text>
-<text x="0.635" y="-1.27" size="1.27" layer="51" ratio="10">2</text>
-<text x="0" y="0.635" size="1.27" layer="51" ratio="10">3</text>
+<text x="3.175" y="0" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.937" y1="-0.508" x2="-3.937" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="-0.508" x2="-2.8765" y2="-0.508" width="0.2032" layer="21"/>
+<wire x1="-3.937" y1="0.508" x2="-2.8765" y2="0.508" width="0.2032" layer="21"/>
+<wire x1="-2.227" y1="-0.9289" x2="0.929" y2="2.2271" width="0.0508" layer="51" curve="-135.281008" cap="flat"/>
+<wire x1="-2.227" y1="-0.9289" x2="-0.9289" y2="-2.227" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="-0.9289" y1="-2.227" x2="0.9289" y2="-2.227" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
+<wire x1="0.9289" y1="-2.227" x2="2.227" y2="-0.9289" width="0.0508" layer="51" curve="44.717164" cap="flat"/>
+<wire x1="0.9289" y1="2.227" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="-44.717164" cap="flat"/>
+<wire x1="2.227" y1="-0.9289" x2="2.227" y2="0.9289" width="0.0508" layer="51" curve="45.282836" cap="flat"/>
 </package>
 <package name="TO92-AB">
 <description>&lt;b&gt;TO-92 (1.27mm lead pitch, 3 leads, vertical, triangle pad arrangement)&lt;/b&gt;&lt;p&gt;
@@ -464,17 +412,19 @@ grid 5.45 mm, vertical</description>
 <rectangle x1="4.064" y1="-1.524" x2="6.858" y2="-1.143" layer="51"/>
 </package>
 <package name="TO5">
-<description>&lt;b&gt;TO-5&lt;/b&gt;</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-5 (3 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-5
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="3.8608" width="0.0508" layer="21"/>
-<pad name="1" x="0" y="-2.54" drill="0.8128" shape="octagon"/>
-<pad name="2" x="2.54" y="0" drill="0.8128" shape="octagon"/>
-<pad name="3" x="0" y="2.54" drill="0.8128" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
+<pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
 <package name="TO126">
 <description>&lt;b&gt;TO-126&lt;/b&gt;&lt;p&gt;
@@ -514,28 +464,27 @@ grid 2.3 mm, vertical</description>
 <hole x="0" y="5.08" drill="3.302"/>
 </package>
 <package name="TO66">
-<description>&lt;b&gt;TO-66&lt;/b&gt;</description>
-<wire x1="-3.501" y1="-7.895" x2="3.5012" y2="-7.895" width="0.254" layer="21" curve="47.833229" cap="flat"/>
-<wire x1="-3.501" y1="7.895" x2="3.5012" y2="7.895" width="0.254" layer="21" curve="-47.833229" cap="flat"/>
-<wire x1="-13.711" y1="3.3666" x2="-13.711" y2="-3.367" width="0.254" layer="21" curve="132.167583" cap="flat"/>
-<wire x1="-3.501" y1="-7.895" x2="-13.711" y2="-3.367" width="0.254" layer="21"/>
-<wire x1="-3.501" y1="7.895" x2="-13.711" y2="3.367" width="0.254" layer="21"/>
-<wire x1="13.711" y1="-3.367" x2="13.711" y2="3.3666" width="0.254" layer="21" curve="132.167583" cap="flat"/>
-<wire x1="3.501" y1="-7.895" x2="13.711" y2="-3.367" width="0.254" layer="21"/>
-<wire x1="3.501" y1="7.895" x2="13.711" y2="3.367" width="0.254" layer="21"/>
-<circle x="0" y="0" radius="7.874" width="0.254" layer="21"/>
-<circle x="0" y="0" radius="6.35" width="0.254" layer="21"/>
-<circle x="-12.192" y="0" radius="1.905" width="0.254" layer="51"/>
-<circle x="12.192" y="0" radius="1.905" width="0.254" layer="51"/>
-<pad name="TO66" x="-12.192" y="0" drill="3.302" diameter="6.35"/>
-<pad name="3" x="12.192" y="0" drill="3.302" diameter="6.35"/>
-<pad name="2" x="-2.54" y="2.54" drill="1.1176" diameter="2.54" shape="long"/>
+<description>&lt;b&gt;TO-66 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-66.
+&lt;/p&gt;</description>
+<circle x="-12.192" y="0" radius="1.905" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="7.874" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="6.35" width="0.2032" layer="51"/>
+<circle x="12.192" y="0" radius="1.905" width="0.2032" layer="51"/>
 <pad name="1" x="-2.54" y="-2.54" drill="1.1176" diameter="2.54" shape="long"/>
-<text x="8.89" y="-4.445" size="1.016" layer="21" ratio="18">3</text>
+<pad name="2" x="-2.54" y="2.54" drill="1.1176" diameter="2.54" shape="long"/>
+<pad name="3" x="12.192" y="0" drill="3.302" diameter="6.35"/>
+<pad name="4" x="-12.192" y="0" drill="3.302" diameter="6.35"/>
 <text x="1.27" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.175" y="-3.175" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<text x="-5.08" y="1.905" size="1.016" layer="21" ratio="18">2</text>
-<text x="-5.08" y="-3.175" size="1.016" layer="21" ratio="18">1</text>
+<wire x1="-13.711" y1="3.3666" x2="-13.711" y2="-3.367" width="0.2032" layer="21" curve="132.167583" cap="flat"/>
+<wire x1="-3.501" y1="-7.895" x2="3.5012" y2="-7.895" width="0.2032" layer="21" curve="47.833229" cap="flat"/>
+<wire x1="-3.501" y1="-7.895" x2="-13.711" y2="-3.367" width="0.2032" layer="21"/>
+<wire x1="-3.501" y1="7.895" x2="3.5012" y2="7.895" width="0.2032" layer="21" curve="-47.833229" cap="flat"/>
+<wire x1="-3.501" y1="7.895" x2="-13.711" y2="3.367" width="0.2032" layer="21"/>
+<wire x1="3.501" y1="-7.895" x2="13.711" y2="-3.367" width="0.2032" layer="21"/>
+<wire x1="3.501" y1="7.895" x2="13.711" y2="3.367" width="0.2032" layer="21"/>
+<wire x1="13.711" y1="-3.367" x2="13.711" y2="3.3666" width="0.2032" layer="21" curve="132.167583" cap="flat"/>
 </package>
 <package name="SOT93">
 <description>&lt;b&gt;SOT-93&lt;/b&gt;&lt;p&gt;
@@ -612,17 +561,19 @@ b-c-e, grid 5.45 mm, vertical</description>
 <rectangle x1="-7.62" y1="-2.032" x2="7.62" y2="0" layer="51"/>
 </package>
 <package name="TO39">
-<description>&lt;b&gt;TO-39&lt;/b&gt;</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<description>&lt;b&gt;TO-39&lt;/b&gt;&lt;p&gt;
+JEDEC TO-39
+&lt;p/&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="3.8608" width="0.0508" layer="21"/>
-<pad name="1" x="0" y="-2.54" drill="0.8128" shape="octagon"/>
-<pad name="2" x="2.54" y="0" drill="0.8128" shape="octagon"/>
-<pad name="3" x="0" y="2.54" drill="0.8128" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
+<pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
 <package name="TO202V">
 <description>&lt;b&gt;TO-202&lt;/b&gt;&lt;p&gt;
@@ -1703,10 +1654,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -1724,7 +1675,7 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
-<connect gate="A" pin="C@1" pad="TO66"/>
+<connect gate="A" pin="C@1" pad="4"/>
 <connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
@@ -2407,10 +2358,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2536,7 +2487,7 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
-<connect gate="A" pin="C@1" pad="TO66"/>
+<connect gate="A" pin="C@1" pad="4"/>
 <connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
@@ -2555,7 +2506,7 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
-<connect gate="A" pin="C@1" pad="TO66"/>
+<connect gate="A" pin="C@1" pad="4"/>
 <connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
@@ -2662,10 +2613,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2681,10 +2632,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2700,10 +2651,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2721,7 +2672,7 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
-<connect gate="A" pin="C@1" pad="TO66"/>
+<connect gate="A" pin="C@1" pad="4"/>
 <connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
@@ -2740,7 +2691,7 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
-<connect gate="A" pin="C@1" pad="TO66"/>
+<connect gate="A" pin="C@1" pad="4"/>
 <connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
@@ -2757,10 +2708,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2902,10 +2853,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2921,10 +2872,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -2940,10 +2891,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3013,10 +2964,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3032,10 +2983,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3051,10 +3002,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3106,10 +3057,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3125,10 +3076,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3144,10 +3095,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3163,10 +3114,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3182,10 +3133,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3201,10 +3152,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3220,10 +3171,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3239,10 +3190,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3258,10 +3209,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3277,10 +3228,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3332,10 +3283,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3351,10 +3302,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3370,10 +3321,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3389,10 +3340,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3408,10 +3359,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3445,10 +3396,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3482,10 +3433,10 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <devices>
 <device name="" package="TO3">
 <connects>
-<connect gate="A" pin="B" pad="B"/>
-<connect gate="A" pin="C" pad="C"/>
-<connect gate="A" pin="C@1" pad="C/"/>
-<connect gate="A" pin="E" pad="E"/>
+<connect gate="A" pin="B" pad="2"/>
+<connect gate="A" pin="C" pad="3"/>
+<connect gate="A" pin="C@1" pad="4"/>
+<connect gate="A" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3571,7 +3522,7 @@ Small outline package. Lead pitch 1.27mm, body width 3.90mm, 16 leads. JEDEC MS-
 <gate name="G$1" symbol="NPN" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO18-">
+<device name="" package="TO18">
 <connects>
 <connect gate="G$1" pin="B" pad="2"/>
 <connect gate="G$1" pin="C" pad="3"/>
@@ -3891,9 +3842,9 @@ common emitter</description>
 <devices>
 <device name="TO3/" package="TO3">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3928,16 +3879,6 @@ common emitter</description>
 <technology name="BSS72"/>
 <technology name="BSS73"/>
 <technology name="BSX20"/>
-</technologies>
-</device>
-<device name="TO18-" package="TO18-">
-<connects>
-<connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
-</connects>
-<technologies>
-<technology name=""/>
 </technologies>
 </device>
 <device name="TO202" package="TO202">
@@ -4377,9 +4318,9 @@ common emitter</description>
 <devices>
 <device name="TO3" package="TO3">
 <connects>
-<connect gate="G$1" pin="B" pad="B"/>
-<connect gate="G$1" pin="C" pad="C"/>
-<connect gate="G$1" pin="E" pad="E"/>
+<connect gate="G$1" pin="B" pad="2"/>
+<connect gate="G$1" pin="C" pad="3"/>
+<connect gate="G$1" pin="E" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4407,16 +4348,6 @@ common emitter</description>
 <technology name="BSS74"/>
 <technology name="BSS75"/>
 <technology name="BSS76"/>
-</technologies>
-</device>
-<device name="TO18-" package="TO18-">
-<connects>
-<connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="3"/>
-<connect gate="G$1" pin="E" pad="1"/>
-</connects>
-<technologies>
-<technology name=""/>
 </technologies>
 </device>
 <device name="TO18V" package="TO18V">

--- a/transistor.lbr
+++ b/transistor.lbr
@@ -942,36 +942,6 @@ Thin shrink small outline transistor package (also known as SOT323). 0.65mm pitc
 <wire x1="1" y1="0.425" x2="1" y2="-0.425" width="0.2032" layer="21"/>
 <wire x1="1" y1="0.625" x2="1" y2="0.425" width="0.2032" layer="51"/>
 </package>
-<package name="TO252">
-<description>&lt;b&gt;SMALL OUTLINE TRANSISTOR&lt;/b&gt;&lt;p&gt;
-TS-003</description>
-<wire x1="3.2766" y1="3.8354" x2="3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="3.277" y1="-2.159" x2="-3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="-2.159" x2="-3.2766" y2="3.8354" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="3.835" x2="3.2774" y2="3.8346" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="3.937" x2="-2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="4.6482" x2="-2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="-2.1082" y1="5.1054" x2="2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="2.1082" y1="5.1054" x2="2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="4.6482" x2="2.5654" y2="3.937" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="3.937" x2="-2.5654" y2="3.937" width="0.2032" layer="51"/>
-<smd name="3" x="0" y="2.5" dx="5.4" dy="6.2" layer="1"/>
-<smd name="1" x="-2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<smd name="2" x="2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<text x="-3.81" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-2.54" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<rectangle x1="-2.7178" y1="-5.1562" x2="-1.8542" y2="-2.2606" layer="51"/>
-<rectangle x1="1.8542" y1="-5.1562" x2="2.7178" y2="-2.2606" layer="51"/>
-<rectangle x1="-0.4318" y1="-3.0226" x2="0.4318" y2="-2.2606" layer="21"/>
-<polygon width="0.1998" layer="51">
-<vertex x="-2.5654" y="3.937"/>
-<vertex x="-2.5654" y="4.6482"/>
-<vertex x="-2.1082" y="5.1054"/>
-<vertex x="2.1082" y="5.1054"/>
-<vertex x="2.5654" y="4.6482"/>
-<vertex x="2.5654" y="3.937"/>
-</polygon>
-</package>
 <package name="SOT143">
 <description>&lt;b&gt;SMALL OUTLINE TRANSISTOR&lt;/b&gt;</description>
 <wire x1="-1.448" y1="0.635" x2="1.448" y2="0.635" width="0.2032" layer="51"/>
@@ -990,33 +960,12 @@ TS-003</description>
 <rectangle x1="-1.1938" y1="-1.3208" x2="-0.3048" y2="-0.635" layer="51"/>
 <rectangle x1="-0.4001" y1="-0.3" x2="0.4001" y2="0.5001" layer="35"/>
 </package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
-<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -1025,6 +974,28 @@ TS-003</description>
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
 <package name="PT100MX0MP">
 <description>Phototransistor&lt;p&gt;
@@ -1056,24 +1027,12 @@ Sharp PT100Mx0MP Series</description>
 <text x="-1.805" y="1.505" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-1.805" y="-2.275" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="3.175" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -1082,6 +1041,18 @@ Sharp PT100Mx0MP Series</description>
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
 <package name="SOT23">
 <description>&lt;b&gt;SOT23 (0.95mm pitch, 1.3mm body, 3 leads)&lt;/b&gt;&lt;p&gt;
@@ -4820,7 +4791,7 @@ common emitter</description>
 <gate name="G$1" symbol="NPN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
 <connect gate="G$1" pin="C" pad="4"/>
@@ -4839,7 +4810,7 @@ common emitter</description>
 <gate name="G$1" symbol="PNP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>
 <connect gate="G$1" pin="C" pad="4"/>

--- a/transistor.lbr
+++ b/transistor.lbr
@@ -4636,16 +4636,6 @@ common emitter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TO92/" package="TO92-AB">
-<connects>
-<connect gate="G$1" pin="B" pad="2"/>
-<connect gate="G$1" pin="C" pad="1"/>
-<connect gate="G$1" pin="E" pad="3"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
 <device name="TOP3" package="TOP3">
 <connects>
 <connect gate="G$1" pin="B" pad="1"/>

--- a/triac.lbr
+++ b/triac.lbr
@@ -114,27 +114,6 @@ Also known as SOT78.</description>
 <wire x1="5.207" y1="12.7" x2="5.207" y2="14.605" width="0.2032" layer="21"/>
 <wire x1="5.207" y1="14.605" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
 </package>
-<package name="TIC225S">
-<wire x1="4.826" y1="-4.318" x2="5.08" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="4.826" y1="-4.318" x2="-4.826" y2="-4.318" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="-4.064" x2="-4.826" y2="-4.318" width="0.2032" layer="21"/>
-<wire x1="5.08" y1="-1.143" x2="5.08" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="-4.064" x2="-5.08" y2="-1.143" width="0.2032" layer="21"/>
-<circle x="-4.6228" y="-3.7084" radius="0.254" width="0" layer="21"/>
-<pad name="A1" x="-2.54" y="-2.54" drill="1.016" shape="long" rot="R90"/>
-<pad name="A2" x="0" y="-2.54" drill="1.016" shape="long" rot="R90"/>
-<pad name="G" x="2.54" y="-2.54" drill="1.016" shape="long" rot="R90"/>
-<text x="-5.08" y="-5.9182" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-5.08" y="-7.493" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<rectangle x1="-5.334" y1="-0.635" x2="5.334" y2="0" layer="21"/>
-<rectangle x1="-5.334" y1="-1.27" x2="-3.429" y2="-0.635" layer="21"/>
-<rectangle x1="-1.651" y1="-1.27" x2="-0.889" y2="-0.635" layer="21"/>
-<rectangle x1="0.889" y1="-1.27" x2="1.651" y2="-0.635" layer="21"/>
-<rectangle x1="3.429" y1="-1.27" x2="5.334" y2="-0.635" layer="21"/>
-<rectangle x1="-3.429" y1="-1.27" x2="-1.651" y2="-0.635" layer="51"/>
-<rectangle x1="-0.889" y1="-1.27" x2="0.889" y2="-0.635" layer="51"/>
-<rectangle x1="1.651" y1="-1.27" x2="3.429" y2="-0.635" layer="51"/>
-</package>
 <package name="TO220-AB">
 <description>&lt;b&gt;TO-220 AB (2.54mm lead pitch, 3 leads, exposed pad, vertical)&lt;/b&gt;&lt;p&gt;
 Flange mounted header. 2.54mm lead pitch, 3 leads, exposed pad, vertical. JEDEC TO-220K, variation AB.

--- a/triac.lbr
+++ b/triac.lbr
@@ -632,24 +632,12 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <rectangle x1="-0.889" y1="-0.381" x2="0.889" y2="0" layer="51"/>
 <rectangle x1="1.397" y1="-0.381" x2="3.175" y2="0" layer="51"/>
 </package>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="3.175" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -658,34 +646,25 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270" thermals="no"/>
-<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -694,6 +673,28 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -1323,7 +1324,7 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <gate name="G$1" symbol="THYR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="DPAK">
+<device name="D" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="A" pad="4"/>
 <connect gate="G$1" pin="C" pad="1"/>
@@ -1360,7 +1361,7 @@ TRIAC 600V 10A</description>
 <gate name="G$1" symbol="TRIAC" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="4"/>
@@ -1379,10 +1380,10 @@ Three quadrant high commutation</description>
 <gate name="G$1" symbol="TRIAC" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="D2PAK">
+<device name="" package="TO263-AB">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
-<connect gate="G$1" pin="A2" pad="2"/>
+<connect gate="G$1" pin="A2" pad="4"/>
 <connect gate="G$1" pin="G" pad="3"/>
 </connects>
 <technologies>

--- a/v-reg.lbr
+++ b/v-reg.lbr
@@ -154,33 +154,32 @@ Also known as SOT78.</description>
 <wire x1="5.207" y1="12.7" x2="5.207" y2="14.605" width="0.2032" layer="21"/>
 <wire x1="5.207" y1="14.605" x2="-5.207" y2="14.605" width="0.2032" layer="21"/>
 </package>
-<package name="TO3-78">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="1" x="-1.778" y="-5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="2" x="-1.778" y="5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="3" x="15.113" y="0" drill="3.048" diameter="6.477"/>
-<pad name="3@" x="-15.113" y="0" drill="3.048" diameter="6.477"/>
-<text x="2.54" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-5.08" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<text x="12.7" y="-5.08" size="1.27" layer="51" ratio="10">GND</text>
-<text x="-3.81" y="4.572" size="1.27" layer="51" ratio="10" rot="R90">IN</text>
-<text x="-3.81" y="-6.223" size="1.27" layer="51" ratio="10" rot="R90">OUT</text>
+<package name="TO3">
+<description>&lt;b&gt;TO-3 (2 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-3.
+&lt;/p&gt;</description>
+<circle x="-15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="9.3726" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
+<circle x="15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
+<pad name="1" x="-1.778" y="-5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="2" x="-1.778" y="5.461" drill="1.1938" diameter="3.1496" shape="long"/>
+<pad name="3" x="15.113" y="0" drill="4.1148" diameter="6.477"/>
+<pad name="4" x="-15.113" y="0" drill="4.1148" diameter="6.477"/>
+<text x="2.54" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="5.08" y="-3.81" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.2032" layer="21" curve="-60.173068" cap="flat"/>
+<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.2032" layer="21" curve="59.404169" cap="flat"/>
+<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.2032" layer="21" curve="-30.113639" cap="flat"/>
+<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.2032" layer="21"/>
+<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.2032" layer="21" curve="28.0726" cap="flat"/>
+<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.2032" layer="21"/>
+<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.2032" layer="21" curve="30.113639" cap="flat"/>
+<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.2032" layer="21" curve="-28.0726" cap="flat"/>
+<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.2032" layer="21"/>
+<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.2032" layer="21"/>
+<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="57.148737" cap="flat"/>
+<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="-57.148737" cap="flat"/>
 </package>
 <package name="TO3/78">
 <description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
@@ -209,90 +208,6 @@ Also known as SOT78.</description>
 <text x="3.81" y="-13.335" size="1.27" layer="51" ratio="10">GND</text>
 <text x="-7.62" y="0" size="1.27" layer="51" ratio="10">OUT</text>
 <text x="5.08" y="4.445" size="1.27" layer="51" ratio="10">IN</text>
-</package>
-<package name="TO3-79">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="1" x="-1.778" y="-5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="2" x="-1.778" y="5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="3" x="15.113" y="0" drill="3.048" diameter="6.477"/>
-<pad name="3@" x="-15.113" y="0" drill="3.048" diameter="6.477"/>
-<text x="2.54" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-5.08" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<text x="-3.81" y="3.302" size="1.27" layer="51" ratio="10" rot="R90">GND</text>
-<text x="-3.81" y="-6.223" size="1.27" layer="51" ratio="10" rot="R90">OUT</text>
-<text x="12.7" y="-5.08" size="1.27" layer="51" ratio="10">IN</text>
-</package>
-<package name="TO3-ADA">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="IN" x="-1.778" y="-5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="ADJ" x="-1.778" y="5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="OUT" x="15.113" y="0" drill="3.048" diameter="6.477"/>
-<pad name="TO3A" x="-15.113" y="0" drill="3.048" diameter="6.477"/>
-<text x="2.54" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-5.08" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<text x="-4.445" y="3.302" size="1.27" layer="51" ratio="10" rot="R90">Adj</text>
-<text x="-4.445" y="-6.223" size="1.27" layer="51" ratio="10" rot="R90">IN</text>
-<text x="13.97" y="-5.08" size="1.27" layer="51" ratio="10" rot="R90">OUT</text>
-</package>
-<package name="TO3-ADB">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="1" x="-1.778" y="-5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="2" x="-1.778" y="5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="3" x="15.113" y="0" drill="3.048" diameter="6.477"/>
-<pad name="3@" x="-15.113" y="0" drill="3.048" diameter="6.477"/>
-<text x="2.54" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-5.08" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<text x="-4.445" y="-6.223" size="1.27" layer="51" ratio="10" rot="R90">Adj</text>
-<text x="13.97" y="-5.08" size="1.27" layer="51" ratio="10" rot="R90">IN</text>
-<text x="-4.445" y="3.937" size="1.27" layer="51" ratio="10" rot="R90">OUT</text>
 </package>
 <package name="78MXXL">
 <description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
@@ -489,68 +404,64 @@ Also known as SOT78.</description>
 <rectangle x1="2.159" y1="-5.08" x2="2.921" y2="-3.429" layer="51"/>
 <hole x="0" y="17.78" drill="3.048"/>
 </package>
-<package name="TO05">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.4798" y2="-2.9718" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5052" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<package name="TO5">
+<description>&lt;b&gt;TO-5 (3 leads)&lt;/b&gt;&lt;p&gt;
+JEDEC TO-5
+&lt;/p&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.191" width="0.0508" layer="51"/>
+<circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
 <pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
 <pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.81" y="-6.35" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-0.635" y="-3.175" size="1.27" layer="51" ratio="10">1</text>
-<text x="1.905" y="-0.635" size="1.27" layer="51" ratio="10">2</text>
-<text x="-0.635" y="1.905" size="1.27" layer="51" ratio="10">3</text>
-</package>
-<package name="LH0070">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.4798" y2="-2.9718" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5052" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
 <wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
+</package>
+<package name="TO39">
+<description>&lt;b&gt;TO-39&lt;/b&gt;&lt;p&gt;
+JEDEC TO-39
+&lt;p/&gt;</description>
 <circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.191" width="0.0508" layer="51"/>
-<pad name="1" x="0" y="-2.54" drill="0.8128" shape="octagon"/>
-<pad name="2" x="2.54" y="0" drill="0.8128" shape="octagon"/>
-<pad name="3" x="0" y="2.54" drill="0.8128" shape="octagon"/>
+<circle x="0" y="0" radius="3.8608" width="0.0508" layer="51"/>
+<pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="-3.175" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.81" y="-6.35" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-0.635" y="-3.175" size="1.27" layer="51" ratio="10">I</text>
-<text x="-1.905" y="1.905" size="1.27" layer="51" ratio="10">GND</text>
-<text x="1.905" y="-0.635" size="1.27" layer="51" ratio="10">O</text>
+<wire x1="-4.0386" y1="-3.5306" x2="-3.5052" y2="-2.9972" width="0.2032" layer="21"/>
+<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
+<wire x1="-2.9718" y1="-3.5306" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
 </package>
 <package name="TO3-4">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.2032" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.2032" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.2032" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.2032" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.2032" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.2032" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.2032" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.2032" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.2032" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.2032" layer="21" curve="-28.0726" cap="flat"/>
+<description>&lt;b&gt;TO-3 (4 leads)&lt;/b&gt;&lt;p&gt;
+Non-standard, based on JEDEC TO-3.
+&lt;/p&gt;</description>
+<circle x="-15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
 <circle x="0" y="0" radius="9.3726" width="0.2032" layer="51"/>
 <circle x="0" y="0" radius="11.684" width="0.2032" layer="51"/>
 <circle x="15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.2032" layer="51"/>
 <pad name="1" x="-2.159" y="-5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="4" x="-2.159" y="5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="5" x="15.113" y="0" drill="3.048" diameter="6.477"/>
-<pad name="TO3/5" x="-15.113" y="0" drill="3.048" diameter="6.477"/>
-<pad name="3" x="4.9022" y="3.5306" drill="1.1938" diameter="3.81" shape="octagon"/>
 <pad name="2" x="4.9022" y="-3.5306" drill="1.1938" diameter="3.81" shape="octagon"/>
-<text x="-6.35" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-7.62" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="2.54" y="-7.62" size="1.016" layer="21" ratio="18">2</text>
-<text x="2.54" y="6.223" size="1.016" layer="21" ratio="18">3</text>
-<text x="-5.842" y="5.08" size="1.016" layer="21" ratio="18">4</text>
-<text x="-5.842" y="-5.08" size="1.016" layer="21" ratio="18">1</text>
+<pad name="3" x="4.9022" y="3.5306" drill="1.1938" diameter="3.81" shape="octagon"/>
+<pad name="4" x="-2.159" y="5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
+<pad name="5" x="15.113" y="0" drill="4.1148" diameter="6.477"/>
+<pad name="6" x="-15.113" y="0" drill="4.1148" diameter="6.477"/>
+<text x="-3.81" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-3.81" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.2032" layer="21" curve="-60.173068" cap="flat"/>
+<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.2032" layer="21" curve="59.404169" cap="flat"/>
+<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.2032" layer="21" curve="-30.113639" cap="flat"/>
+<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.2032" layer="21"/>
+<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.2032" layer="21" curve="28.0726" cap="flat"/>
+<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.2032" layer="21"/>
+<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.2032" layer="21" curve="30.113639" cap="flat"/>
+<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.2032" layer="21" curve="-28.0726" cap="flat"/>
+<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.2032" layer="21"/>
+<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.2032" layer="21"/>
+<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="57.148737" cap="flat"/>
+<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.2032" layer="21" curve="-57.148737" cap="flat"/>
 </package>
 <package name="L200TO3">
 <description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;&lt;p&gt;
@@ -609,47 +520,6 @@ L200.pdf from www.st.com</description>
 <rectangle x1="-3.937" y1="-8.509" x2="-2.921" y2="-7.366" layer="51"/>
 <rectangle x1="-0.508" y1="-7.366" x2="0.508" y2="-4.826" layer="21"/>
 <rectangle x1="-3.937" y1="-7.366" x2="-2.921" y2="-4.826" layer="21"/>
-</package>
-<package name="TO3-K02">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="6.3754" y1="-10.9982" x2="17.3736" y2="-4.5212" width="0.254" layer="21"/>
-<wire x1="5.969" y1="11.2014" x2="17.3736" y2="4.5212" width="0.254" layer="21"/>
-<wire x1="-6.35" y1="10.9982" x2="-17.272" y2="4.572" width="0.254" layer="21"/>
-<wire x1="-5.9436" y1="-11.2268" x2="-17.2466" y2="-4.5974" width="0.254" layer="21"/>
-<wire x1="17.3366" y1="4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="-57.148737" cap="flat"/>
-<wire x1="17.3366" y1="-4.545" x2="19.812" y2="0" width="0.254" layer="21" curve="57.148737" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.0927" y2="4.6935" width="0.254" layer="21" curve="-60.173068" cap="flat"/>
-<wire x1="-19.812" y1="0" x2="-17.1555" y2="-4.657" width="0.254" layer="21" curve="59.404169" cap="flat"/>
-<wire x1="0" y1="-12.7" x2="6.3718" y2="-10.9859" width="0.254" layer="21" curve="30.113639" cap="flat"/>
-<wire x1="-5.9765" y1="-11.2059" x2="0" y2="-12.7" width="0.254" layer="21" curve="28.0726" cap="flat"/>
-<wire x1="-6.3718" y1="10.9859" x2="0" y2="12.7" width="0.254" layer="21" curve="-30.113639" cap="flat"/>
-<wire x1="0" y1="12.7" x2="5.9765" y2="11.2059" width="0.254" layer="21" curve="-28.0726" cap="flat"/>
-<circle x="0" y="0" radius="9.3726" width="0.254" layer="51"/>
-<circle x="0" y="0" radius="11.684" width="0.254" layer="51"/>
-<circle x="15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<circle x="-15.113" y="0" radius="2.159" width="0.254" layer="51"/>
-<pad name="1" x="-1.778" y="-5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="2" x="-1.778" y="5.461" drill="1.1938" diameter="3.81" shape="octagon"/>
-<pad name="3" x="15.113" y="0" drill="3.048" diameter="6.477"/>
-<pad name="3@" x="-15.113" y="0" drill="3.048" diameter="6.477"/>
-<text x="2.54" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-5.08" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-</package>
-<package name="TO39-H03">
-<description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
-<wire x1="-4.0386" y1="-3.5306" x2="-3.4798" y2="-2.9718" width="0.2032" layer="21"/>
-<wire x1="-2.9718" y1="-3.5052" x2="-3.5052" y2="-4.064" width="0.2032" layer="21"/>
-<wire x1="-3.5052" y1="-4.064" x2="-4.0386" y2="-3.5306" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.572" width="0.2032" layer="21"/>
-<circle x="0" y="0" radius="4.191" width="0.0508" layer="51"/>
-<pad name="1" x="0" y="-2.54" drill="0.8128" diameter="1.6764"/>
-<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<pad name="3" x="0" y="2.54" drill="0.8128" diameter="1.6764" shape="octagon"/>
-<text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-3.81" y="-6.35" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-0.635" y="-3.175" size="1.27" layer="51" ratio="10">1</text>
-<text x="1.905" y="-0.635" size="1.27" layer="51" ratio="10">2</text>
-<text x="-0.635" y="1.905" size="1.27" layer="51" ratio="10">3</text>
 </package>
 <package name="SOT89-4">
 <wire x1="2.2724" y1="1.6104" x2="2.2724" y2="-1.1104" width="0.1778" layer="51"/>
@@ -2985,7 +2855,7 @@ horizontal, no mount hole.</description>
 <gate name="1" symbol="78XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3-78">
+<device name="" package="TO3">
 <connects>
 <connect gate="1" pin="GND" pad="3"/>
 <connect gate="1" pin="IN" pad="2"/>
@@ -3003,7 +2873,7 @@ horizontal, no mount hole.</description>
 <gate name="1" symbol="79XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3-79">
+<device name="" package="TO3">
 <connects>
 <connect gate="1" pin="GND" pad="2"/>
 <connect gate="1" pin="IN" pad="3"/>
@@ -3039,7 +2909,7 @@ horizontal, no mount hole.</description>
 <gate name="1" symbol="LH0070" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LH0070">
+<device name="" package="TO39">
 <connects>
 <connect gate="1" pin="GND" pad="3"/>
 <connect gate="1" pin="IN" pad="1"/>
@@ -3099,7 +2969,7 @@ horizontal, no mount hole.</description>
 <gate name="1" symbol="78ADJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3-K02">
+<device name="" package="TO3">
 <connects>
 <connect gate="1" pin="ADJ" pad="2"/>
 <connect gate="1" pin="IN" pad="1"/>
@@ -3117,7 +2987,7 @@ horizontal, no mount hole.</description>
 <gate name="1" symbol="79ADJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3-K02">
+<device name="" package="TO3">
 <connects>
 <connect gate="1" pin="ADJ" pad="2"/>
 <connect gate="1" pin="IN" pad="3"/>
@@ -3181,10 +3051,10 @@ horizontal, no mount hole.</description>
 <gate name="1" symbol="78XXA" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3-78">
+<device name="" package="TO3">
 <connects>
 <connect gate="1" pin="GND" pad="3"/>
-<connect gate="1" pin="GND1" pad="3@"/>
+<connect gate="1" pin="GND1" pad="4"/>
 <connect gate="1" pin="IN" pad="2"/>
 <connect gate="1" pin="OUT" pad="1"/>
 </connects>
@@ -3218,7 +3088,7 @@ horizontal, no mount hole.</description>
 <gate name="G$1" symbol="78XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3-K02">
+<device name="" package="TO3">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="IN" pad="2"/>
@@ -3236,7 +3106,7 @@ horizontal, no mount hole.</description>
 <gate name="G$1" symbol="78ADJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO39-H03">
+<device name="" package="TO39">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="2"/>
 <connect gate="G$1" pin="IN" pad="1"/>
@@ -3254,7 +3124,7 @@ horizontal, no mount hole.</description>
 <gate name="G$1" symbol="79ADJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3-K02">
+<device name="" package="TO3">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="2"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -3272,7 +3142,7 @@ horizontal, no mount hole.</description>
 <gate name="G$1" symbol="78XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3-K02">
+<device name="" package="TO3">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="IN" pad="2"/>
@@ -3290,7 +3160,7 @@ horizontal, no mount hole.</description>
 <gate name="G$1" symbol="78XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3-K02">
+<device name="" package="TO3">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="IN" pad="2"/>
@@ -3308,7 +3178,7 @@ horizontal, no mount hole.</description>
 <gate name="G$1" symbol="79ADJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3-K02">
+<device name="" package="TO3">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="2"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -3326,7 +3196,7 @@ horizontal, no mount hole.</description>
 <gate name="G$1" symbol="78ADJ" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="TO3-K02">
+<device name="" package="TO3">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="2"/>
 <connect gate="G$1" pin="IN" pad="1"/>
@@ -3380,7 +3250,7 @@ horizontal, no mount hole.</description>
 <gate name="G$1" symbol="79XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO3-K02">
+<device name="" package="TO3">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="IN" pad="3"/>

--- a/v-reg.lbr
+++ b/v-reg.lbr
@@ -543,35 +543,6 @@ L200.pdf from www.st.com</description>
 <rectangle x1="1.25" y1="-2.15" x2="1.75" y2="-1.15" layer="51"/>
 <rectangle x1="-0.85" y1="1.65" x2="0.85" y2="2.2" layer="51"/>
 </package>
-<package name="TO263">
-<description>&lt;b&gt;TO-263 Package&lt;/b&gt;</description>
-<wire x1="-5.5" y1="-4.365" x2="-5.5" y2="4.635" width="0.2032" layer="21"/>
-<wire x1="5.5" y1="-4.365" x2="5.5" y2="4.635" width="0.2032" layer="21"/>
-<wire x1="5.5" y1="-4.365" x2="-5.5" y2="-4.365" width="0.2032" layer="21"/>
-<wire x1="-5.5" y1="4.635" x2="5.5" y2="4.635" width="0.2032" layer="51"/>
-<wire x1="-5.5" y1="4.635" x2="-4.4" y2="5.735" width="0.2032" layer="51"/>
-<wire x1="-4.4" y1="5.735" x2="4.4" y2="5.735" width="0.2032" layer="51"/>
-<wire x1="4.4" y1="5.735" x2="5.5" y2="4.635" width="0.2032" layer="51"/>
-<wire x1="-5.5" y1="3.935" x2="5.5" y2="3.935" width="0.2032" layer="51"/>
-<wire x1="-5.5" y1="-3.965" x2="5.5" y2="-3.965" width="0.2032" layer="51"/>
-<circle x="-3" y="-2.965" radius="0.4123" width="0" layer="51"/>
-<smd name="4" x="0" y="2.635" dx="10.25" dy="9" layer="1" rot="R180" thermals="no"/>
-<smd name="1" x="-2.54" y="-8.255" dx="3.81" dy="1.524" layer="1" rot="R90"/>
-<smd name="2" x="0" y="-8.255" dx="3.81" dy="1.524" layer="1" rot="R90"/>
-<smd name="3" x="2.54" y="-8.255" dx="3.81" dy="1.524" layer="1" rot="R90"/>
-<text x="-6.35" y="-4.445" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="7.3025" y="-4.445" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<text x="-3.2" y="-2.165" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.3" y="-2.165" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.4" y="-2.165" size="1.016" layer="51" ratio="10">2</text>
-<text x="-0.55" y="2.385" size="1.016" layer="51" ratio="10">4</text>
-<rectangle x1="-3.04" y1="-5.865" x2="-2" y2="-4.37" layer="21"/>
-<rectangle x1="-0.5" y1="-5.865" x2="0.5" y2="-4.37" layer="21"/>
-<rectangle x1="2.04" y1="-5.865" x2="3" y2="-4.37" layer="21"/>
-<rectangle x1="-3.04" y1="-8.64" x2="-2" y2="-5.865" layer="51"/>
-<rectangle x1="-0.5" y1="-8.64" x2="0.5" y2="-5.865" layer="51"/>
-<rectangle x1="2.04" y1="-8.64" x2="3" y2="-5.865" layer="51"/>
-</package>
 <package name="SC63-5">
 <description>&lt;b&gt;SO63-5&lt;/b&gt;&lt;p&gt;
 Sharp</description>
@@ -615,30 +586,6 @@ Sharp</description>
 <rectangle x1="0.9525" y1="-5.5562" x2="1.5875" y2="-4.2862" layer="51"/>
 <rectangle x1="2.2225" y1="-5.5562" x2="2.8575" y2="-4.2862" layer="51"/>
 <rectangle x1="-2.8575" y1="-4.3656" x2="-2.2" y2="-3.5" layer="21"/>
-</package>
-<package name="2-PFM">
-<wire x1="3.7" y1="-2.54" x2="3.7" y2="3.66" width="0.2032" layer="21"/>
-<wire x1="3.7" y1="3.66" x2="-3.7" y2="3.66" width="0.2032" layer="51"/>
-<wire x1="-3.7" y1="3.66" x2="-3.7" y2="-2.54" width="0.2032" layer="21"/>
-<wire x1="-3.7" y1="-2.54" x2="3.7" y2="-2.54" width="0.2032" layer="21"/>
-<smd name="1" x="-2.3" y="-4.84" dx="2.1844" dy="1.0668" layer="1" rot="R90"/>
-<smd name="3" x="2.3" y="-4.84" dx="2.1844" dy="1.0668" layer="1" rot="R90"/>
-<smd name="4" x="0" y="2.46" dx="6.8" dy="7" layer="1" thermals="no"/>
-<text x="-2.54" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-3.175" y="6.35" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<rectangle x1="-3.12" y1="-4.72" x2="-1.48" y2="-3.92" layer="51" rot="R90"/>
-<rectangle x1="1.48" y1="-4.72" x2="3.12" y2="-3.92" layer="51" rot="R90"/>
-<rectangle x1="-0.4" y1="-3.34" x2="0.4" y2="-2.54" layer="21"/>
-<rectangle x1="-2.78" y1="-3.42" x2="-1.82" y2="-2.62" layer="21" rot="R90"/>
-<rectangle x1="1.82" y1="-3.42" x2="2.78" y2="-2.62" layer="21" rot="R90"/>
-<polygon width="0.2032" layer="51">
-<vertex x="3.1" y="3.7"/>
-<vertex x="-3.1" y="3.7"/>
-<vertex x="-3.1" y="4.2825" curve="-90"/>
-<vertex x="-2.7825" y="4.6"/>
-<vertex x="2.7825" y="4.6" curve="-90"/>
-<vertex x="3.1" y="4.2825"/>
-</polygon>
 </package>
 <package name="TO-3P">
 <description>&lt;b&gt;Molded Package&lt;/b&gt;&lt;p&gt;
@@ -824,35 +771,12 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <wire x1="1" y1="-0.625" x2="-1" y2="-0.625" width="0.2032" layer="51"/>
 <wire x1="1" y1="0.625" x2="1" y2="-0.625" width="0.2032" layer="21"/>
 </package>
-<package name="DDPAK">
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="4" x="0" y="2.54" dx="9.652" dy="8.89" layer="1" rot="R270" thermals="no"/>
-<smd name="1" x="-2.54" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
-<smd name="2" x="0" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<text x="-0.3175" y="-3.81" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
-<rectangle x1="-0.635" y1="-7.62" x2="0.635" y2="-5.715" layer="51"/>
+<package name="TO263-AA">
+<description>&lt;b&gt;TO-263 AA (3 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 3 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AA, R-PSFM.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -861,36 +785,30 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
-</package>
-<package name="TO252">
-<description>&lt;b&gt;SMALL OUTLINE TRANSISTOR&lt;/b&gt;&lt;p&gt;
-TS-003</description>
-<wire x1="3.2766" y1="3.8354" x2="3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="3.277" y1="-2.159" x2="-3.277" y2="-2.159" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="-2.159" x2="-3.2766" y2="3.8354" width="0.2032" layer="21"/>
-<wire x1="-3.277" y1="3.835" x2="3.2774" y2="3.8346" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="3.937" x2="-2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="-2.5654" y1="4.6482" x2="-2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="-2.1082" y1="5.1054" x2="2.1082" y2="5.1054" width="0.2032" layer="51"/>
-<wire x1="2.1082" y1="5.1054" x2="2.5654" y2="4.6482" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="4.6482" x2="2.5654" y2="3.937" width="0.2032" layer="51"/>
-<wire x1="2.5654" y1="3.937" x2="-2.5654" y2="3.937" width="0.2032" layer="51"/>
-<smd name="3" x="0" y="2.5" dx="5.4" dy="6.2" layer="1" thermals="no"/>
-<smd name="1" x="-2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<smd name="2" x="2.28" y="-4.8" dx="1" dy="1.6" layer="1"/>
-<text x="-3.81" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="5.08" y="-2.54" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<rectangle x1="-2.7178" y1="-5.1562" x2="-1.8542" y2="-2.2606" layer="51"/>
-<rectangle x1="1.8542" y1="-5.1562" x2="2.7178" y2="-2.2606" layer="51"/>
-<rectangle x1="-0.4318" y1="-3.0226" x2="0.4318" y2="-2.2606" layer="21"/>
-<polygon width="0.1998" layer="51">
-<vertex x="-2.5654" y="3.937"/>
-<vertex x="-2.5654" y="4.6482"/>
-<vertex x="-2.1082" y="5.1054"/>
-<vertex x="2.1082" y="5.1054"/>
-<vertex x="2.5654" y="4.6482"/>
-<vertex x="2.5654" y="3.937"/>
-</polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-7.62" x2="0.635" y2="-5.715" layer="51"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="2" x="0" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="1.905" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
 <package name="MSOP08">
 <description>&lt;b&gt;Mini Small Outline Package&lt;/b&gt;</description>
@@ -919,24 +837,12 @@ TS-003</description>
 <rectangle x1="-0.45" y1="1.5" x2="-0.2" y2="2.5" layer="51"/>
 <rectangle x1="-1.1" y1="1.5" x2="-0.85" y2="2.5" layer="51"/>
 </package>
-<package name="DPAK">
-<description>&lt;b&gt;SMD D-PAK&lt;/b&gt;</description>
-<wire x1="3.3" y1="-3" x2="3.3" y2="3.2" width="0.2032" layer="21"/>
-<wire x1="-3.3" y1="3.2" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
-<wire x1="3.3" y1="-3" x2="-3.3" y2="-3" width="0.2032" layer="21"/>
-<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1" thermals="no"/>
-<smd name="3" x="2.2098" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<smd name="1" x="-2.2606" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
-<text x="3.175" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
-<text x="-2.54" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.413" y="-2.5273" size="0.6096" layer="51">1</text>
-<text x="-0.2032" y="-2.5273" size="0.6096" layer="51">2</text>
-<text x="1.9812" y="-2.5273" size="0.6096" layer="51">3</text>
-<text x="-0.3302" y="1.8415" size="0.6096" layer="51">4</text>
-<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
-<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
-<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<package name="TO252-AA">
+<description>&lt;b&gt;TO-252 AA (DPAK, 2 leads, 2.39mm max height, 2.67mm lead length)&lt;/b&gt;&lt;p&gt;
+Flange mounted family surface mount. 2 leads, 2.39mm max height, 2.67mm lead length.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-2.5" y="3.2"/>
 <vertex x="-2.5" y="3.95"/>
@@ -945,34 +851,25 @@ TS-003</description>
 <vertex x="2.5" y="3.95"/>
 <vertex x="2.5" y="3.2"/>
 </polygon>
+<rectangle x1="-2.6416" y1="-5.7404" x2="-1.8796" y2="-3.0734" layer="51"/>
+<rectangle x1="-0.381" y1="-3.8354" x2="0.381" y2="-3.0734" layer="51"/>
+<rectangle x1="1.8288" y1="-5.7404" x2="2.5908" y2="-3.0734" layer="51"/>
+<smd name="1" x="-2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="3" x="2.286" y="-4.9276" dx="1.6002" dy="2.9972" layer="1"/>
+<smd name="4" x="0" y="1.8528" dx="5.4516" dy="7" layer="1"/>
+<text x="3.81" y="1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<text x="3.81" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<wire x1="-3.302" y1="3.2" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="3.2" x2="-3.3" y2="3.2" width="0.2032" layer="51"/>
+<wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
-<package name="D2PAK">
-<description>&lt;b&gt;SMD D2PAK&lt;/b&gt;</description>
-<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
-<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
-<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
-<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
-<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
-<smd name="2" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270" thermals="no"/>
-<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
-<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
-<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
-<text x="-2.8575" y="-3.81" size="1.016" layer="51" ratio="10">1</text>
-<text x="2.2225" y="-3.81" size="1.016" layer="51" ratio="10">3</text>
-<text x="-0.3175" y="2.2225" size="1.016" layer="51" ratio="10">2</text>
-<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
-<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
-<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
-<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
-<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<package name="TO263-AB">
+<description>&lt;b&gt;TO-263 AB (D2PAK, 2 leads, 2.54mm pitch, 4.83mm max height)&lt;/b&gt;&lt;p&gt;
+Plastic surface mounted header family. 2 leads, 2.54mm pitch, 4.83mm max height.
+&lt;/p&gt;&lt;p&gt;
+JEDEC TO-263E, variation AB, R-PSFM. Also known as D2PAK.
+&lt;/p&gt;</description>
 <polygon width="0.2032" layer="51">
 <vertex x="-5.3975" y="4.445"/>
 <vertex x="-5.3975" y="5.08"/>
@@ -981,6 +878,28 @@ TS-003</description>
 <vertex x="5.3975" y="5.08"/>
 <vertex x="5.3975" y="4.445"/>
 </polygon>
+<rectangle x1="-3.175" y1="-7.62" x2="-1.905" y2="-5.715" layer="51"/>
+<rectangle x1="-3.175" y1="-5.715" x2="-1.905" y2="-4.7625" layer="21"/>
+<rectangle x1="-0.635" y1="-5.715" x2="0.635" y2="-4.7624" layer="21"/>
+<rectangle x1="1.905" y1="-7.62" x2="3.175" y2="-5.715" layer="51"/>
+<rectangle x1="1.905" y1="-5.715" x2="3.175" y2="-4.7625" layer="21"/>
+<smd name="1" x="-2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="3" x="2.54" y="-8.255" dx="2.08" dy="3.81" layer="1" rot="R180"/>
+<smd name="4" x="0" y="2.54" dx="10.16" dy="9.652" layer="1" rot="R270"/>
+<text x="-6.0325" y="-4.7625" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
+<text x="-2.2225" y="-1.5875" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+<wire x1="-5.3975" y1="-4.7625" x2="-5.3975" y2="4.445" width="0.2032" layer="21"/>
+<wire x1="-5.3975" y1="4.445" x2="5.3975" y2="4.445" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.08" y2="4.1274" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="-4.445" x2="-5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="5.0799" y2="4.1275" width="0.0508" layer="51"/>
+<wire x1="-5.08" y1="4.1274" x2="-5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.08" y2="-4.445" width="0.0508" layer="51"/>
+<wire x1="5.0799" y1="4.1275" x2="5.3975" y2="4.445" width="0.0508" layer="51"/>
+<wire x1="5.08" y1="-4.445" x2="5.3975" y2="-4.7625" width="0.0508" layer="51"/>
+<wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
+<wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
 <package name="TO263-3">
 <description>&lt;b&gt;TO-263 Package&lt;/b&gt;</description>
@@ -3288,9 +3207,9 @@ horizontal, no mount hole.</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D2T" package="D2PAK">
+<device name="D2T" package="TO263-AB">
 <connects>
-<connect gate="G$1" pin="GND" pad="2"/>
+<connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="IN" pad="1"/>
 <connect gate="G$1" pin="OUT" pad="3"/>
 </connects>
@@ -3308,7 +3227,7 @@ horizontal, no mount hole.</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DT" package="DPAK">
+<device name="DT" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="IN" pad="1"/>
@@ -3465,7 +3384,7 @@ horizontal, no mount hole.</description>
 <gate name="G$1" symbol="LMADJ-2OUT" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO263">
+<device name="" package="TO263-AA">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -3657,7 +3576,7 @@ Texas Instruments</description>
 <gate name="G$1" symbol="78XX-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="2-PFM">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="IN" pad="1"/>
@@ -3773,7 +3692,7 @@ Texas Instruments</description>
 <gate name="G$1" symbol="LM1117-4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TO263">
+<device name="" package="TO263-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -3813,11 +3732,11 @@ Texas Instruments</description>
 <gate name="G$1" symbol="78ADJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D2T" package="D2PAK">
+<device name="D2T" package="TO263-AB">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
-<connect gate="G$1" pin="OUT" pad="2"/>
+<connect gate="G$1" pin="OUT" pad="4"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -3843,7 +3762,7 @@ Texas Instruments</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="MDT" package="DPAK">
+<device name="MDT" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -3962,7 +3881,7 @@ ST Micro, 3 pin, TO-220</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="DPAK">
+<device name="D" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="IN" pad="1"/>
@@ -4014,7 +3933,7 @@ DPAK, fixed voltage</description>
 <gate name="G$1" symbol="LM2931" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DT" package="DPAK">
+<device name="DT" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="IN" pad="1"/>
@@ -4307,10 +4226,10 @@ AD1582/AD1583/AD1584/AD1585</description>
 <gate name="G$1" symbol="79XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D2T" package="D2PAK">
+<device name="D2T" package="TO263-AB">
 <connects>
 <connect gate="G$1" pin="GND" pad="1"/>
-<connect gate="G$1" pin="IN" pad="2"/>
+<connect gate="G$1" pin="IN" pad="4"/>
 <connect gate="G$1" pin="OUT" pad="3"/>
 </connects>
 <technologies>
@@ -4372,7 +4291,7 @@ Fixed 2.85V, 3.3V, 5V</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-M" package="DDPAK">
+<device name="-M" package="TO263-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -4403,7 +4322,7 @@ Adjustable</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-M" package="DDPAK">
+<device name="-M" package="TO263-AA">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -4463,7 +4382,7 @@ Adjustable</description>
 <gate name="G$1" symbol="LM2937" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="ES-X.X" package="TO263">
+<device name="ES-X.X" package="TO263-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="GND1" pad="4"/>
@@ -4575,7 +4494,7 @@ CMOS Micropower, Ultra Low-Dropout, Low-Noise, 300mA</description>
 <gate name="G$1" symbol="LMLADJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -4615,7 +4534,7 @@ LD1086 series</description>
 <gate name="G$1" symbol="LDXXXX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DTXX" package="DPAK">
+<device name="DTXX" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -4625,11 +4544,11 @@ LD1086 series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D2XX" package="D2PAK">
+<device name="D2XX" package="TO263-AB">
 <connects>
 <connect gate="G$1" pin="GND" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
-<connect gate="G$1" pin="OUT" pad="2"/>
+<connect gate="G$1" pin="OUT" pad="4"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4664,7 +4583,7 @@ LD1117 series</description>
 <gate name="G$1" symbol="LDXXXX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DTXX" package="DPAK">
+<device name="DTXX" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -4724,7 +4643,7 @@ ULTRALOW-NOISE, HIGH PSRR, FAST RF 250-mA</description>
 <gate name="G$1" symbol="REG-3PIN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="CD" package="DPAK">
+<device name="CD" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -4876,7 +4795,7 @@ Adjustable Micropower, 100mA</description>
 <gate name="G$1" symbol="MIC2940A-XXBU/WU" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="TO263">
+<device name="" package="TO263-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="GND1" pad="4"/>
@@ -4916,17 +4835,17 @@ LD1086 adjustable series</description>
 <gate name="G$1" symbol="LDXXXX-ADJ" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="D2XX" package="D2PAK">
+<device name="D2XX" package="TO263-AB">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
-<connect gate="G$1" pin="OUT" pad="2"/>
+<connect gate="G$1" pin="OUT" pad="4"/>
 </connects>
 <technologies>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DTXX" package="DPAK">
+<device name="DTXX" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -5143,7 +5062,7 @@ LD29150 series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="DPAK">
+<device name="T" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="IN" pad="1"/>
@@ -5251,7 +5170,7 @@ LD29150 series</description>
 <gate name="G$1" symbol="LD39150DT" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DPAK">
+<device name="" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="IN" pad="1"/>
@@ -5290,7 +5209,7 @@ LD29150 series</description>
 <gate name="G$1" symbol="LT1086" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DDPAK">
+<device name="" package="TO263-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -5380,7 +5299,7 @@ Fixed 150mA Low-Noise</description>
 <gate name="G$1" symbol="LM340S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="TO263">
+<device name="S" package="TO263-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="GND@4" pad="4"/>
@@ -5505,10 +5424,10 @@ Fixed 150mA Low-Noise</description>
 <gate name="G$1" symbol="79ADJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D2T" package="D2PAK">
+<device name="D2T" package="TO263-AB">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="1"/>
-<connect gate="G$1" pin="IN" pad="2"/>
+<connect gate="G$1" pin="IN" pad="4"/>
 <connect gate="G$1" pin="OUT" pad="3"/>
 </connects>
 <technologies>
@@ -5553,7 +5472,7 @@ Fixed 150mA Low-Noise</description>
 <gate name="G$1" symbol="AP1117" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="DPAK">
+<device name="D" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="GND" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -5643,7 +5562,7 @@ Fixed 150mA Low-Noise</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="K4" package="DPAK">
+<device name="K4" package="TO252-AA">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="3"/>
 <connect gate="G$1" pin="IN" pad="1"/>
@@ -5689,7 +5608,7 @@ Fixed 150mA Low-Noise</description>
 <gate name="G$1" symbol="TL783" x="0" y="0"/>
 </gates>
 <devices>
-<device name="KTT" package="TO263">
+<device name="KTT" package="TO263-AA">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>

--- a/v-reg.lbr
+++ b/v-reg.lbr
@@ -3487,8 +3487,8 @@ horizontal, no mount hole.</description>
 <device name="" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
-<connect gate="G$1" pin="IN" pad="1"/>
-<connect gate="G$1" pin="OUT" pad="3"/>
+<connect gate="G$1" pin="IN" pad="3"/>
+<connect gate="G$1" pin="OUT" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4157,8 +4157,8 @@ DPAK, fixed voltage</description>
 <device name="Z" package="TO92-AB">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
-<connect gate="G$1" pin="IN" pad="1"/>
-<connect gate="G$1" pin="OUT" pad="3"/>
+<connect gate="G$1" pin="IN" pad="3"/>
+<connect gate="G$1" pin="OUT" pad="1"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -4354,7 +4354,7 @@ PRECISION MICROPOWER SHUNT</description>
 </device>
 <device name="LP" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="A" pad="1"/>
+<connect gate="G$1" pin="A" pad="3"/>
 <connect gate="G$1" pin="C" pad="2"/>
 </connects>
 <technologies>
@@ -5734,9 +5734,9 @@ Fixed 150mA Low-Noise</description>
 </device>
 <device name="Z" package="TO92-AB">
 <connects>
-<connect gate="G$1" pin="GND" pad="3"/>
+<connect gate="G$1" pin="GND" pad="1"/>
 <connect gate="G$1" pin="IN" pad="2"/>
-<connect gate="G$1" pin="OUT" pad="1"/>
+<connect gate="G$1" pin="OUT" pad="3"/>
 </connects>
 <technologies>
 <technology name="AB"/>


### PR DESCRIPTION
 - Fixed an error in previous PR: due to a bug in my scripts 13 devices using TO-92 got incorrect device<->footprint connections. The bug occurs in very specific circumstances, so only those devices were affected. To make sure I've inspected all my cleanup work done so far and found no other erroneous changes. 
 - Added reference packages for TO-3, TO-5, TO-18, TO-39, TO-66, TO-72, TO-78, TO252-AA, TO253-AA and TO263-AB (D2PAK). The footprints were copied from other libraries and were verified with JEDEC for correctness.
 - Synchronized libraries with the new reference packages.
 - Removed versions of the packages that differ only by pin naming.