### PR TITLE
Change format of names of ref packages to be more convenient

### DIFF
--- a/40xx.lbr
+++ b/40xx.lbr
@@ -81,7 +81,7 @@ Based on the following sources:
 &lt;/ul&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="SOP-127P-530W-1030L-210H-125F-16">
+<package name="SOP-16-127P-530W-1030L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -130,7 +130,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="5.125" y1="-2.625" x2="-5.125" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="2.625" x2="-5.125" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-16">
+<package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -175,7 +175,7 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-14">
+<package name="SSOP-14-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
@@ -216,7 +216,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -242,7 +242,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -270,7 +270,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -310,7 +310,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -346,7 +346,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -386,7 +386,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -432,7 +432,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -497,7 +497,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -2086,7 +2086,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="3"/>
 <connect gate="A" pin="D1" pad="1"/>
@@ -2106,7 +2106,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="3"/>
 <connect gate="A" pin="D1" pad="1"/>
@@ -2134,7 +2134,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="4007" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="1A" pad="3"/>
 <connect gate="A" pin="1DN" pad="5"/>
@@ -2155,7 +2155,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="1A" pad="3"/>
 <connect gate="A" pin="1DN" pad="5"/>
@@ -2185,7 +2185,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="7"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -2208,7 +2208,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="7"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -2245,7 +2245,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-2.54" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -2266,7 +2266,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -2301,7 +2301,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-2.54" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -2322,7 +2322,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -2353,7 +2353,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="2"/>
 <connect gate="A" pin="CLK" pad="3"/>
@@ -2374,7 +2374,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="2"/>
 <connect gate="A" pin="CLK" pad="3"/>
@@ -2404,7 +2404,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="10"/>
 <connect gate="A" pin="P/!S" pad="9"/>
@@ -2427,7 +2427,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="10"/>
 <connect gate="A" pin="P/!S" pad="9"/>
@@ -2460,7 +2460,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="D" pad="15"/>
@@ -2483,7 +2483,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="D" pad="15"/>
@@ -2518,7 +2518,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-2.54" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -2539,7 +2539,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -2569,7 +2569,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="14"/>
 <connect gate="A" pin="CO" pad="12"/>
@@ -2592,7 +2592,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="14"/>
 <connect gate="A" pin="CO" pad="12"/>
@@ -2624,7 +2624,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="14"/>
 <connect gate="A" pin="D" pad="1"/>
@@ -2647,7 +2647,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="14"/>
 <connect gate="A" pin="D" pad="1"/>
@@ -2679,7 +2679,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="6"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -2702,7 +2702,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="6"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -2734,7 +2734,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="P1" pad="10"/>
 <connect gate="A" pin="Q1" pad="9"/>
@@ -2757,7 +2757,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="P1" pad="10"/>
 <connect gate="A" pin="Q1" pad="9"/>
@@ -2789,7 +2789,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="14"/>
 <connect gate="A" pin="CLR" pad="13"/>
@@ -2810,7 +2810,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="14"/>
 <connect gate="A" pin="CLR" pad="13"/>
@@ -2840,7 +2840,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="Q1" pad="12"/>
@@ -2858,7 +2858,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="Q1" pad="12"/>
@@ -2885,7 +2885,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -2908,7 +2908,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -2941,7 +2941,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="2"/>
 <connect gate="A" pin="CLK" pad="3"/>
@@ -2964,7 +2964,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="2"/>
 <connect gate="A" pin="CLK" pad="3"/>
@@ -2996,7 +2996,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="13"/>
@@ -3019,7 +3019,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="13"/>
@@ -3051,7 +3051,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="B/!D" pad="9"/>
 <connect gate="A" pin="CI" pad="5"/>
@@ -3074,7 +3074,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B/!D" pad="9"/>
 <connect gate="A" pin="CI" pad="5"/>
@@ -3106,7 +3106,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="7"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -3122,7 +3122,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="7"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -3147,7 +3147,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="10"/>
 <connect gate="A" pin="A2" pad="13"/>
@@ -3170,7 +3170,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="10"/>
 <connect gate="A" pin="A2" pad="13"/>
@@ -3202,7 +3202,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -3225,7 +3225,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -3257,7 +3257,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A/!B" pad="11"/>
 <connect gate="A" pin="A/!S" pad="14"/>
@@ -3288,7 +3288,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A/!B" pad="11"/>
 <connect gate="A" pin="A/!S" pad="14"/>
@@ -3328,7 +3328,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="6"/>
 <connect gate="A" pin="J" pad="4"/>
@@ -3351,7 +3351,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="6"/>
 <connect gate="A" pin="J" pad="4"/>
@@ -3383,7 +3383,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="10"/>
 <connect gate="A" pin="A2" pad="13"/>
@@ -3406,7 +3406,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="10"/>
 <connect gate="A" pin="A2" pad="13"/>
@@ -3438,7 +3438,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="P1" pad="10"/>
 <connect gate="A" pin="Q1" pad="9"/>
@@ -3461,7 +3461,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="P1" pad="10"/>
 <connect gate="A" pin="Q1" pad="9"/>
@@ -3493,7 +3493,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-10.16" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!QA" pad="2"/>
 <connect gate="A" pin="!QB" pad="5"/>
@@ -3514,7 +3514,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!QA" pad="2"/>
 <connect gate="A" pin="!QB" pad="5"/>
@@ -3544,7 +3544,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q0" pad="3"/>
 <connect gate="A" pin="!Q1" pad="9"/>
@@ -3567,7 +3567,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q0" pad="3"/>
 <connect gate="A" pin="!Q1" pad="9"/>
@@ -3599,7 +3599,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="EN" pad="5"/>
 <connect gate="A" pin="Q0" pad="2"/>
@@ -3621,7 +3621,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="EN" pad="5"/>
 <connect gate="A" pin="Q0" pad="2"/>
@@ -3652,7 +3652,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="EN" pad="5"/>
 <connect gate="A" pin="Q0" pad="13"/>
@@ -3674,7 +3674,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="EN" pad="5"/>
 <connect gate="A" pin="Q0" pad="13"/>
@@ -3705,7 +3705,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CIN" pad="3"/>
 <connect gate="A" pin="CX@1" pad="6"/>
@@ -3728,7 +3728,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CIN" pad="3"/>
 <connect gate="A" pin="CX@1" pad="6"/>
@@ -3760,7 +3760,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!AST" pad="4"/>
 <connect gate="A" pin="!Q" pad="11"/>
@@ -3781,7 +3781,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!AST" pad="4"/>
 <connect gate="A" pin="!Q" pad="11"/>
@@ -3811,7 +3811,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="14"/>
 <connect gate="A" pin="B" pad="13"/>
@@ -3834,7 +3834,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="14"/>
 <connect gate="A" pin="B" pad="13"/>
@@ -3866,7 +3866,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+VEE" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -3889,7 +3889,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -3912,7 +3912,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="MTC" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="MTC" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -3935,7 +3935,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SJ" package="SOP-127P-530W-1030L-210H-125F-16">
+<device name="SJ" package="SOP-16-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -3967,7 +3967,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+VEE" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -3990,7 +3990,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -4022,7 +4022,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+VEE" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -4045,7 +4045,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -4077,7 +4077,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+VEE" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -4100,7 +4100,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -4132,7 +4132,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+VEE" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -4155,7 +4155,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -4187,7 +4187,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!P0" pad="10"/>
 <connect gate="A" pin="P0" pad="9"/>
@@ -4210,7 +4210,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!P0" pad="10"/>
 <connect gate="A" pin="P0" pad="9"/>
@@ -4242,7 +4242,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="10"/>
 <connect gate="A" pin="A1" pad="12"/>
@@ -4265,7 +4265,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="10"/>
 <connect gate="A" pin="A1" pad="12"/>
@@ -4297,7 +4297,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="4068" x="12.7" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -4315,7 +4315,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -4347,7 +4347,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-2.54" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4368,7 +4368,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4389,7 +4389,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4419,7 +4419,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="CLR" pad="15"/>
@@ -4442,7 +4442,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="CLR" pad="15"/>
@@ -4474,7 +4474,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!OUT" pad="5"/>
 <connect gate="A" pin="15" pad="1"/>
@@ -4497,7 +4497,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!OUT" pad="5"/>
 <connect gate="A" pin="15" pad="1"/>
@@ -4529,7 +4529,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="3"/>
 <connect gate="A" pin="D" pad="2"/>
@@ -4552,7 +4552,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="3"/>
 <connect gate="A" pin="D" pad="2"/>
@@ -4584,7 +4584,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -4604,7 +4604,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -4633,7 +4633,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -4653,7 +4653,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -4682,7 +4682,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="5"/>
 <connect gate="A" pin="A1" pad="6"/>
@@ -4705,7 +4705,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="5"/>
 <connect gate="A" pin="A1" pad="6"/>
@@ -4737,7 +4737,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="10"/>
 <connect gate="A" pin="P/!S" pad="9"/>
@@ -4760,7 +4760,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="10"/>
 <connect gate="A" pin="P/!S" pad="9"/>
@@ -4797,7 +4797,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-10.16" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4818,7 +4818,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4839,7 +4839,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4874,7 +4874,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4895,7 +4895,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4916,7 +4916,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4949,7 +4949,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -4970,7 +4970,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -5000,7 +5000,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -5031,7 +5031,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -5071,7 +5071,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -5102,7 +5102,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -5145,7 +5145,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="0" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5166,7 +5166,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5197,7 +5197,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="0" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5216,7 +5216,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5247,7 +5247,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-2.54" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5268,7 +5268,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5299,7 +5299,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5318,7 +5318,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5348,7 +5348,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="5.08" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5369,7 +5369,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5401,7 +5401,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5422,7 +5422,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5455,7 +5455,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5476,7 +5476,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5509,7 +5509,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5530,7 +5530,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5561,7 +5561,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5580,7 +5580,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5610,7 +5610,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5631,7 +5631,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5663,7 +5663,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5684,7 +5684,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5717,7 +5717,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5738,7 +5738,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5768,7 +5768,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5786,7 +5786,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5816,7 +5816,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5837,7 +5837,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5868,7 +5868,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5887,7 +5887,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5918,7 +5918,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5939,7 +5939,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5972,7 +5972,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="5.08" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5993,7 +5993,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -6028,7 +6028,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-2.54" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -6049,7 +6049,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -6081,7 +6081,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-17.78" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="3"/>
 <connect gate="A" pin="I1" pad="4"/>
@@ -6100,7 +6100,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="3"/>
 <connect gate="A" pin="I1" pad="4"/>
@@ -6128,7 +6128,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLEAR#" pad="1"/>
 <connect gate="G$1" pin="CLK" pad="2"/>
@@ -6151,7 +6151,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLEAR#" pad="1"/>
 <connect gate="G$1" pin="CLK" pad="2"/>
@@ -6183,7 +6183,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLEAR#" pad="1"/>
 <connect gate="G$1" pin="CLK" pad="2"/>
@@ -6206,7 +6206,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLEAR#" pad="1"/>
 <connect gate="G$1" pin="CLK" pad="2"/>
@@ -6238,7 +6238,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLEAR#" pad="1"/>
 <connect gate="G$1" pin="CLK" pad="2"/>
@@ -6261,7 +6261,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLEAR#" pad="1"/>
 <connect gate="G$1" pin="CLK" pad="2"/>
@@ -6293,7 +6293,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLEAR#" pad="1"/>
 <connect gate="G$1" pin="CLK" pad="2"/>
@@ -6316,7 +6316,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLEAR#" pad="1"/>
 <connect gate="G$1" pin="CLK" pad="2"/>
@@ -6348,7 +6348,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="9"/>
 <connect gate="G$1" pin="D0" pad="3"/>
@@ -6371,7 +6371,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="9"/>
 <connect gate="G$1" pin="D0" pad="3"/>
@@ -6403,7 +6403,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!Q0" pad="3"/>
 <connect gate="G$1" pin="!Q01" pad="6"/>
@@ -6426,7 +6426,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!Q0" pad="3"/>
 <connect gate="G$1" pin="!Q01" pad="6"/>
@@ -6458,7 +6458,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="4194" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="11"/>
 <connect gate="G$1" pin="DP0" pad="3"/>
@@ -6481,7 +6481,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="11"/>
 <connect gate="G$1" pin="DP0" pad="3"/>
@@ -6513,7 +6513,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="22.86" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="1"/>
 <connect gate="G$1" pin="DIS#" pad="10"/>
@@ -6536,7 +6536,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="1"/>
 <connect gate="G$1" pin="DIS#" pad="10"/>
@@ -6568,7 +6568,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="4490" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="AIN" pad="1"/>
 <connect gate="G$1" pin="AO" pad="15"/>
@@ -6591,7 +6591,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="AIN" pad="1"/>
 <connect gate="G$1" pin="AO" pad="15"/>
@@ -6623,7 +6623,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="15"/>
 <connect gate="G$1" pin="B" pad="1"/>
@@ -6646,7 +6646,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="15"/>
 <connect gate="G$1" pin="B" pad="1"/>
@@ -6682,7 +6682,7 @@ Low-to-High, Quad</description>
 <gate name="D" symbol="40109" x="38.1" y="-20.32"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="EN" pad="2"/>
 <connect gate="A" pin="I" pad="3"/>
@@ -6704,7 +6704,7 @@ Low-to-High, Quad</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="SOP-127P-530W-1030L-210H-125F-16">
+<device name="NS" package="SOP-16-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="A" pin="EN" pad="2"/>
 <connect gate="A" pin="I" pad="3"/>
@@ -6726,7 +6726,7 @@ Low-to-High, Quad</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="EN" pad="2"/>
 <connect gate="A" pin="I" pad="3"/>
@@ -6758,7 +6758,7 @@ Source: www.standardics.nxp.com/products/hc/datasheet/74hc4059.pdf</description>
 <gate name="G$1" symbol="4059" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CP" pad="1"/>
 <connect gate="G$1" pin="EL" pad="2"/>
@@ -6789,7 +6789,7 @@ Source: www.standardics.nxp.com/products/hc/datasheet/74hc4059.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N3" package="DIP-300-28">
+<device name="N3" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CP" pad="1"/>
 <connect gate="G$1" pin="EL" pad="2"/>
@@ -6820,7 +6820,7 @@ Source: www.standardics.nxp.com/products/hc/datasheet/74hc4059.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CP" pad="1"/>
 <connect gate="G$1" pin="EL" pad="2"/>

--- a/41xx.lbr
+++ b/41xx.lbr
@@ -74,7 +74,7 @@
 <description>&lt;b&gt;41xx Series Devices&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -102,7 +102,7 @@
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -258,7 +258,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CL!" pad="1"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -281,7 +281,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!CL!" pad="1"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -313,7 +313,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="D0" pad="3"/>
@@ -336,7 +336,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="D0" pad="3"/>
@@ -368,7 +368,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q0!" pad="3"/>
 <connect gate="A" pin="!Q1!" pad="6"/>
@@ -391,7 +391,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q0!" pad="3"/>
 <connect gate="A" pin="!Q1!" pad="6"/>
@@ -423,7 +423,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="D0" pad="3"/>
@@ -446,7 +446,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="D0" pad="3"/>
@@ -478,7 +478,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CL!" pad="1"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -501,7 +501,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!CL!" pad="1"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -533,7 +533,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CL!" pad="1"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -556,7 +556,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!CL!" pad="1"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -588,7 +588,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CL!" pad="1"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -611,7 +611,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!CL!" pad="1"/>
 <connect gate="A" pin="CLK" pad="2"/>

--- a/45xx.lbr
+++ b/45xx.lbr
@@ -80,7 +80,7 @@ Based on the following sources:
 &lt;/ul&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -106,7 +106,7 @@ Based on the following sources:
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -134,7 +134,7 @@ Based on the following sources:
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -164,7 +164,7 @@ Based on the following sources:
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -200,7 +200,7 @@ Based on the following sources:
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -246,7 +246,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -296,7 +296,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -1650,7 +1650,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <gate name="P" symbol="PWRN" x="-5.08" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -1673,7 +1673,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -1705,7 +1705,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D1" pad="3"/>
 <connect gate="A" pin="D2" pad="6"/>
@@ -1728,7 +1728,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="3"/>
 <connect gate="A" pin="D2" pad="6"/>
@@ -1760,7 +1760,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="DA" pad="1"/>
 <connect gate="A" pin="DB" pad="15"/>
@@ -1783,7 +1783,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="DA" pad="1"/>
 <connect gate="A" pin="DB" pad="15"/>
@@ -1815,7 +1815,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <gate name="P" symbol="PWR+VCC" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="AI" pad="3"/>
 <connect gate="A" pin="AO" pad="2"/>
@@ -1838,7 +1838,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="AI" pad="3"/>
 <connect gate="A" pin="AO" pad="2"/>
@@ -1870,7 +1870,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="AA" pad="1"/>
 <connect gate="A" pin="AB" pad="9"/>
@@ -1893,7 +1893,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="AA" pad="1"/>
 <connect gate="A" pin="AB" pad="9"/>
@@ -1926,7 +1926,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="D0" pad="4"/>
 <connect gate="A" pin="D1" pad="6"/>
@@ -1957,7 +1957,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="D0" pad="4"/>
 <connect gate="A" pin="D1" pad="6"/>
@@ -1997,7 +1997,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CIN" pad="5"/>
 <connect gate="A" pin="CLK" pad="15"/>
@@ -2020,7 +2020,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CIN" pad="5"/>
 <connect gate="A" pin="CLK" pad="15"/>
@@ -2052,7 +2052,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -2075,7 +2075,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -2108,7 +2108,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -2131,7 +2131,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -2163,7 +2163,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-18">
+<device name="N" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -2197,7 +2197,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="D1" pad="2"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -2228,7 +2228,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="2"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -2268,7 +2268,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="D1" pad="2"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -2299,7 +2299,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="2"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -2339,7 +2339,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CIN" pad="5"/>
 <connect gate="A" pin="CLK" pad="15"/>
@@ -2362,7 +2362,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CIN" pad="5"/>
 <connect gate="A" pin="CLK" pad="15"/>
@@ -2395,7 +2395,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <gate name="P" symbol="PWRN" x="-2.54" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="4"/>
 <connect gate="A" pin="D" pad="7"/>
@@ -2418,7 +2418,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="4"/>
 <connect gate="A" pin="D" pad="7"/>
@@ -2451,7 +2451,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <gate name="P" symbol="PWRN" x="-5.08" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="EN" pad="2"/>
@@ -2474,7 +2474,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="EN" pad="2"/>
@@ -2506,7 +2506,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -2529,7 +2529,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -2563,7 +2563,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN2" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="01" pad="7"/>
 <connect gate="A" pin="02" pad="4"/>
@@ -2586,7 +2586,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="01" pad="7"/>
 <connect gate="A" pin="02" pad="4"/>
@@ -2618,7 +2618,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="&quot;0&quot;" pad="12"/>
 <connect gate="A" pin="CF" pad="13"/>
@@ -2641,7 +2641,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="&quot;0&quot;" pad="12"/>
 <connect gate="A" pin="CF" pad="13"/>
@@ -2673,7 +2673,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!OUT" pad="5"/>
 <connect gate="A" pin="&quot;9&quot;" pad="1"/>
@@ -2696,7 +2696,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!OUT" pad="5"/>
 <connect gate="A" pin="&quot;9&quot;" pad="1"/>
@@ -2728,7 +2728,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="6"/>
 <connect gate="A" pin="B" pad="7"/>
@@ -2751,7 +2751,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="6"/>
 <connect gate="A" pin="B" pad="7"/>
@@ -2784,7 +2784,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -2807,7 +2807,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -2839,7 +2839,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D0" pad="7"/>
 <connect gate="A" pin="D1" pad="6"/>
@@ -2862,7 +2862,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D0" pad="7"/>
 <connect gate="A" pin="D1" pad="6"/>
@@ -2894,7 +2894,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D0" pad="10"/>
 <connect gate="A" pin="D1" pad="11"/>
@@ -2917,7 +2917,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D0" pad="10"/>
 <connect gate="A" pin="D1" pad="11"/>
@@ -2949,7 +2949,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="3SC" pad="21"/>
 <connect gate="A" pin="3SDC" pad="15"/>
@@ -2980,7 +2980,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="3SC" pad="21"/>
 <connect gate="A" pin="3SDC" pad="15"/>
@@ -3020,7 +3020,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="8BYP" pad="6"/>
 <connect gate="A" pin="A" pad="9"/>
@@ -3043,7 +3043,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="8BYP" pad="6"/>
 <connect gate="A" pin="A" pad="9"/>
@@ -3075,7 +3075,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="14"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -3098,7 +3098,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="14"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -3130,7 +3130,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="12"/>
 <connect gate="A" pin="AR" pad="5"/>
@@ -3149,7 +3149,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="12"/>
 <connect gate="A" pin="AR" pad="5"/>
@@ -3177,7 +3177,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -3200,7 +3200,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -3232,7 +3232,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-18">
+<device name="N" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -3266,7 +3266,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -3287,7 +3287,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -3317,7 +3317,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="D" pad="6"/>
@@ -3340,7 +3340,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="D" pad="6"/>
@@ -3372,7 +3372,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWR+VEE" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CTL" pad="9"/>
 <connect gate="A" pin="W" pad="14"/>
@@ -3395,7 +3395,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CTL" pad="9"/>
 <connect gate="A" pin="W" pad="14"/>
@@ -3427,7 +3427,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CIA" pad="4"/>
 <connect gate="A" pin="CIB" pad="3"/>
@@ -3450,7 +3450,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CIA" pad="4"/>
 <connect gate="A" pin="CIB" pad="3"/>
@@ -3482,7 +3482,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CO" pad="4"/>
 <connect gate="A" pin="K0" pad="12"/>
@@ -3505,7 +3505,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CO" pad="4"/>
 <connect gate="A" pin="K0" pad="12"/>
@@ -3538,7 +3538,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -3561,7 +3561,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -3594,7 +3594,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -3617,7 +3617,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -3649,7 +3649,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CE" pad="5"/>
 <connect gate="A" pin="!Q" pad="11"/>
@@ -3672,7 +3672,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!CE" pad="5"/>
 <connect gate="A" pin="!Q" pad="11"/>
@@ -3704,7 +3704,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -3727,7 +3727,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -3759,7 +3759,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="D" pad="6"/>
@@ -3782,7 +3782,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="D" pad="6"/>
@@ -3814,7 +3814,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="15"/>
 <connect gate="A" pin="A2" pad="1"/>
@@ -3837,7 +3837,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="15"/>
 <connect gate="A" pin="A2" pad="1"/>
@@ -3869,7 +3869,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!COM" pad="6"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -3889,7 +3889,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!COM" pad="6"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -3918,7 +3918,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="5"/>
 <connect gate="A" pin="D" pad="12"/>
@@ -3937,7 +3937,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="5"/>
 <connect gate="A" pin="D" pad="12"/>
@@ -3965,7 +3965,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="5/!6" pad="11"/>
 <connect gate="A" pin="A" pad="9"/>
@@ -3988,7 +3988,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="5/!6" pad="11"/>
 <connect gate="A" pin="A" pad="9"/>
@@ -4020,7 +4020,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="&quot;0&quot;" pad="3"/>
 <connect gate="A" pin="C1" pad="9"/>
@@ -4043,7 +4043,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="&quot;0&quot;" pad="3"/>
 <connect gate="A" pin="C1" pad="9"/>
@@ -4075,7 +4075,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CF" pad="7"/>
 <connect gate="A" pin="CLK" pad="9"/>
@@ -4098,7 +4098,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CF" pad="7"/>
 <connect gate="A" pin="CLK" pad="9"/>
@@ -4135,7 +4135,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="F" symbol="4572/B" x="48.26" y="-15.24"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="1"/>
@@ -4158,7 +4158,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="1"/>
@@ -4190,7 +4190,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="3SA" pad="3"/>
 <connect gate="A" pin="3SB" pad="21"/>
@@ -4221,7 +4221,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="3SA" pad="3"/>
 <connect gate="A" pin="3SB" pad="21"/>
@@ -4261,7 +4261,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="2"/>
 <connect gate="A" pin="A1" pad="23"/>
@@ -4292,7 +4292,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="2"/>
 <connect gate="A" pin="A1" pad="23"/>
@@ -4332,7 +4332,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CIN" pad="13"/>
 <connect gate="A" pin="CN+X" pad="12"/>
@@ -4355,7 +4355,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CIN" pad="13"/>
 <connect gate="A" pin="CN+X" pad="12"/>
@@ -4387,7 +4387,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!A0" pad="11"/>
 <connect gate="A" pin="!B0" pad="12"/>
@@ -4410,7 +4410,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A0" pad="11"/>
 <connect gate="A" pin="!B0" pad="12"/>
@@ -4442,7 +4442,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="10"/>
 <connect gate="A" pin="A1" pad="7"/>
@@ -4465,7 +4465,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="10"/>
 <connect gate="A" pin="A1" pad="7"/>
@@ -4497,7 +4497,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="3"/>
 <connect gate="A" pin="D0" pad="1"/>
@@ -4520,7 +4520,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="3"/>
 <connect gate="A" pin="D0" pad="1"/>
@@ -4552,7 +4552,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-18">
+<device name="N" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="7"/>
 <connect gate="A" pin="A1" pad="8"/>
@@ -4585,7 +4585,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-18">
+<device name="N" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="5"/>
 <connect gate="A" pin="A1" pad="6"/>
@@ -4620,7 +4620,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="EN" pad="2"/>
@@ -4643,7 +4643,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="EN" pad="2"/>
@@ -4675,7 +4675,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="&quot;0&quot;" pad="12"/>
 <connect gate="A" pin="CF" pad="13"/>
@@ -4698,7 +4698,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="&quot;0&quot;" pad="12"/>
 <connect gate="A" pin="CF" pad="13"/>
@@ -4731,7 +4731,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <gate name="P" symbol="PWRN" x="-5.08" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="7"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -4754,7 +4754,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="7"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -4788,7 +4788,7 @@ Dual precision monostable</description>
 <gate name="P" symbol="PWRN" x="-12.7" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="7"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -4811,7 +4811,7 @@ Dual precision monostable</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="7"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -4848,7 +4848,7 @@ Dual precision monostable</description>
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4869,7 +4869,7 @@ Dual precision monostable</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4899,7 +4899,7 @@ Dual precision monostable</description>
 <gate name="P" symbol="PWRN" x="30.48" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="DATA" pad="3"/>
 <connect gate="G$1" pin="FLAGF" pad="9"/>
@@ -4922,7 +4922,7 @@ Dual precision monostable</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="DATA" pad="3"/>
 <connect gate="G$1" pin="FLAGF" pad="9"/>

--- a/65LV.lbr
+++ b/65LV.lbr
@@ -237,7 +237,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <text x="1.5" y="-0.75" size="0.4064" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 <rectangle x1="-1" y1="-0.75" x2="-0.75" y2="-0.5" layer="21" rot="R90"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -326,7 +326,7 @@ HIGH-SPEED</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="D" pad="2"/>
 <connect gate="G$1" pin="GND" pad="4"/>

--- a/74AVC.lbr
+++ b/74AVC.lbr
@@ -79,7 +79,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2015, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SSOP-65P-440W-500L-120H-100F-16">
+<package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -159,7 +159,7 @@ Configurable Voltage Translation and 3-State Outputs</description>
 <gate name="G$1" symbol="SN74AVC4T774" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="9"/>
 <connect gate="G$1" pin="A1" pad="3"/>

--- a/74CB.lbr
+++ b/74CB.lbr
@@ -79,7 +79,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2013, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -192,7 +192,7 @@ pitch 0.635 mm, body 4.0 x 8.75 mm</description>
 <rectangle x1="-2.3236" y1="-3.1" x2="-2.1204" y2="-2" layer="51"/>
 <rectangle x1="-2.9586" y1="-3.1" x2="-2.7554" y2="-2" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-650L-120H-100F-20">
+<package name="SSOP-20-65P-440W-650L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
@@ -245,7 +245,7 @@ JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.15" y1="-2.1" x2="3.15" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.1" x2="-3.15" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-440W-500L-120H-100F-24">
+<package name="SSOP-24-40P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation CA, R-PDSO-G.&lt;/p&gt;
@@ -306,7 +306,7 @@ JEDEC MO-153F, variation CA, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-16">
+<package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -351,7 +351,7 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -466,7 +466,7 @@ Source: &lt;href&gt;http://www.ti.com/lit/ds/symlink/sn74cb3t3245.pdf</descripti
 <gate name="A" symbol="74CB3T3245" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!OE!" pad="19"/>
 <connect gate="A" pin="A1" pad="2"/>
@@ -520,7 +520,7 @@ Source: &lt;href&gt;http://www.ti.com/lit/ds/symlink/sn74cb3t3245.pdf</descripti
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="PW" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="A" pin="!OE!" pad="19"/>
 <connect gate="A" pin="A1" pad="2"/>
@@ -547,7 +547,7 @@ Source: &lt;href&gt;http://www.ti.com/lit/ds/symlink/sn74cb3t3245.pdf</descripti
 <technology name=""/>
 </technologies>
 </device>
-<device name="DGV" package="SSOP-40P-440W-500L-120H-100F-24">
+<device name="DGV" package="SSOP-24-40P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="!OE!" pad="19"/>
 <connect gate="A" pin="A1" pad="2"/>
@@ -582,7 +582,7 @@ Source: &lt;href&gt;http://www.ti.com/lit/ds/symlink/sn74cb3t3245.pdf</descripti
 <gate name="G$1" symbol="74CBTLV3257" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="15"/>
 <connect gate="G$1" pin="1A" pad="4"/>
@@ -605,7 +605,7 @@ Source: &lt;href&gt;http://www.ti.com/lit/ds/symlink/sn74cb3t3245.pdf</descripti
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="15"/>
 <connect gate="G$1" pin="1A" pad="4"/>

--- a/74LV.lbr
+++ b/74LV.lbr
@@ -239,7 +239,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <text x="1.5" y="-0.75" size="0.4064" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 <rectangle x1="-1" y1="-0.75" x2="-0.75" y2="-0.5" layer="21" rot="R90"/>
 </package>
-<package name="SSOP-65P-280W-295L-135H-60F-8">
+<package name="SSOP-8-65P-280W-295L-135H-60F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.60mm lead length, 3.0mm length, 2.8mm width, 1.35mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.60mm lead length 3.0mm length, 2.8mm width, 1.35mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation DA, LSR-PDSO.&lt;/p&gt;
@@ -272,7 +272,7 @@ JEDEC MO-187F, variation DA, LSR-PDSO.&lt;/p&gt;
 <wire x1="1.45" y1="-1.375" x2="-1.45" y2="-1.375" width="0.0508" layer="51"/>
 <wire x1="1.45" y1="1.375" x2="-1.45" y2="1.375" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-50P-230W-200L-100H-40F-8">
+<package name="SSOP-8-50P-230W-200L-100H-40F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.40mm lead length, 2.0mm length, 2.3mm width, 1.00mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.50mm pitch, 0.40mm lead length 2.0mm length, 2.3mm width, 1.00mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation CA, VSR-PDSO.&lt;/p&gt;
@@ -374,7 +374,7 @@ Also known as SOT-753.</description>
 <wire x1="1.45" y1="-0.6" x2="1.45" y2="0.6" width="0.2032" layer="21"/>
 <wire x1="1.45" y1="0.75" x2="1.45" y2="-0.75" width="0.2032" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-650L-120H-100F-20">
+<package name="SSOP-20-65P-440W-650L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
@@ -1609,7 +1609,7 @@ OPEN-DRAIN OUTPUTS</description>
 <gate name="G$1" symbol="NAND2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DCT" package="SSOP-65P-280W-295L-135H-60F-8">
+<device name="DCT" package="SSOP-8-65P-280W-295L-135H-60F">
 <connects>
 <connect gate="G$1" pin="1A" pad="1"/>
 <connect gate="G$1" pin="1B" pad="2"/>
@@ -1624,7 +1624,7 @@ OPEN-DRAIN OUTPUTS</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DCU" package="SSOP-50P-230W-200L-100H-40F-8">
+<device name="DCU" package="SSOP-8-50P-230W-200L-100H-40F">
 <connects>
 <connect gate="G$1" pin="1A" pad="1"/>
 <connect gate="G$1" pin="1B" pad="2"/>
@@ -1850,7 +1850,7 @@ SINGLE-POLE, DOUBLE-THROW</description>
 <gate name="G$1" symbol="74LV8154" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="PW" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!CCLR!" pad="11"/>
 <connect gate="G$1" pin="!CLKBEN!" pad="9"/>
@@ -1885,7 +1885,7 @@ SINGLE-POLE, DOUBLE-THROW</description>
 <gate name="G$1" symbol="74LVC3G34" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DCT" package="SSOP-65P-280W-295L-135H-60F-8">
+<device name="DCT" package="SSOP-8-65P-280W-295L-135H-60F">
 <connects>
 <connect gate="G$1" pin="1A" pad="1"/>
 <connect gate="G$1" pin="1Y" pad="7"/>
@@ -1900,7 +1900,7 @@ SINGLE-POLE, DOUBLE-THROW</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DCU" package="SSOP-50P-230W-200L-100H-40F-8">
+<device name="DCU" package="SSOP-8-50P-230W-200L-100H-40F">
 <connects>
 <connect gate="G$1" pin="1A" pad="1"/>
 <connect gate="G$1" pin="1Y" pad="7"/>
@@ -1923,7 +1923,7 @@ SINGLE-POLE, DOUBLE-THROW</description>
 <gate name="G$1" symbol="74LVC3G17" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DCT" package="SSOP-65P-280W-295L-135H-60F-8">
+<device name="DCT" package="SSOP-8-65P-280W-295L-135H-60F">
 <connects>
 <connect gate="G$1" pin="1A" pad="1"/>
 <connect gate="G$1" pin="1Y" pad="7"/>
@@ -1938,7 +1938,7 @@ SINGLE-POLE, DOUBLE-THROW</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DCU" package="SSOP-50P-230W-200L-100H-40F-8">
+<device name="DCU" package="SSOP-8-50P-230W-200L-100H-40F">
 <connects>
 <connect gate="G$1" pin="1A" pad="1"/>
 <connect gate="G$1" pin="1Y" pad="7"/>
@@ -2036,7 +2036,7 @@ With Configurable Voltage Translation and 3-State Outputs</description>
 <gate name="G$1" symbol="74LVC2T45" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="DCU" package="SSOP-50P-230W-200L-100H-40F-8">
+<device name="DCU" package="SSOP-8-50P-230W-200L-100H-40F">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -2051,7 +2051,7 @@ With Configurable Voltage Translation and 3-State Outputs</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SM8" package="SSOP-65P-280W-295L-135H-60F-8">
+<device name="SM8" package="SSOP-8-65P-280W-295L-135H-60F">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>

--- a/74VHCT.lbr
+++ b/74VHCT.lbr
@@ -76,7 +76,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2014, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -122,7 +122,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-14">
+<package name="SSOP-14-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
@@ -211,7 +211,7 @@ LSTTL−Compatible Inputs</description>
 <gate name="P" symbol="PWRN" x="-25.4" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -232,7 +232,7 @@ LSTTL−Compatible Inputs</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DT" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="DT" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -267,7 +267,7 @@ LSTTL−Compatible Inputs</description>
 <gate name="P" symbol="PWRN" x="-25.4" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="M" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="M" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -288,7 +288,7 @@ LSTTL−Compatible Inputs</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="MTC" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="MTC" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>

--- a/74ac-logic.lbr
+++ b/74ac-logic.lbr
@@ -188,7 +188,7 @@ Based on the following source:
 <rectangle x1="6.858" y1="3.8894" x2="7.112" y2="5.134" layer="51"/>
 <rectangle x1="7.493" y1="3.8894" x2="7.747" y2="5.134" layer="51"/>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -214,7 +214,7 @@ Based on the following source:
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -242,7 +242,7 @@ Based on the following source:
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -274,7 +274,7 @@ Based on the following source:
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -314,7 +314,7 @@ Based on the following source:
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -350,7 +350,7 @@ Based on the following source:
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -390,7 +390,7 @@ Based on the following source:
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -436,7 +436,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -493,7 +493,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -558,7 +558,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -631,7 +631,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -2492,7 +2492,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR2GND" x="33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2515,7 +2515,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2550,7 +2550,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR2GND" x="33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2573,7 +2573,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2610,7 +2610,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="20"/>
 <connect gate="A" pin="O" pad="1"/>
@@ -2635,7 +2635,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="I" pad="20"/>
 <connect gate="A" pin="O" pad="1"/>
@@ -2672,7 +2672,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR2GND" x="27.94" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2695,7 +2695,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2729,7 +2729,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR2GND" x="27.94" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2752,7 +2752,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2786,7 +2786,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR2GND" x="27.94" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2809,7 +2809,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2842,7 +2842,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="1"/>
@@ -2861,7 +2861,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="1"/>
@@ -2890,7 +2890,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="B" symbol="7411021" x="20.32" y="-10.16" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="1"/>
@@ -2909,7 +2909,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="1"/>
@@ -2939,7 +2939,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR2GND" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2962,7 +2962,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2994,7 +2994,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="3"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -3012,7 +3012,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="3"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -3042,7 +3042,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR2GND" x="-48.26" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I1" pad="1"/>
 <connect gate="A" pin="I2" pad="16"/>
@@ -3065,7 +3065,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I1" pad="1"/>
 <connect gate="A" pin="I2" pad="16"/>
@@ -3102,7 +3102,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="20"/>
 <connect gate="A" pin="O" pad="1"/>
@@ -3127,7 +3127,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="I" pad="20"/>
 <connect gate="A" pin="O" pad="1"/>
@@ -3162,7 +3162,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="3"/>
 <connect gate="A" pin="CL" pad="12"/>
@@ -3183,7 +3183,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="3"/>
 <connect gate="A" pin="CL" pad="12"/>
@@ -3214,7 +3214,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="3"/>
 <connect gate="A" pin="CL" pad="13"/>
@@ -3237,7 +3237,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="3"/>
 <connect gate="A" pin="CL" pad="13"/>
@@ -3270,7 +3270,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-10.16" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="3"/>
 <connect gate="A" pin="CL" pad="13"/>
@@ -3291,7 +3291,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="3"/>
 <connect gate="A" pin="CL" pad="13"/>
@@ -3321,7 +3321,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-22.86" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -3344,7 +3344,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -3377,7 +3377,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -3400,7 +3400,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -3432,7 +3432,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="6"/>
 <connect gate="A" pin="B" pad="7"/>
@@ -3455,7 +3455,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="6"/>
 <connect gate="A" pin="B" pad="7"/>
@@ -3487,7 +3487,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C0" pad="16"/>
 <connect gate="A" pin="1C1" pad="15"/>
@@ -3510,7 +3510,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="16"/>
 <connect gate="A" pin="1C1" pad="15"/>
@@ -3542,7 +3542,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="20"/>
@@ -3569,7 +3569,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="20"/>
@@ -3605,7 +3605,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="20"/>
@@ -3632,7 +3632,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="20"/>
@@ -3668,7 +3668,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="18"/>
 <connect gate="A" pin="B" pad="17"/>
@@ -3695,7 +3695,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="18"/>
 <connect gate="A" pin="B" pad="17"/>
@@ -3731,7 +3731,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="CLR" pad="20"/>
@@ -3758,7 +3758,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="CLR" pad="20"/>
@@ -3794,7 +3794,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!Q1!" pad="1"/>
 <connect gate="A" pin="!Q2!" pad="3"/>
@@ -3821,7 +3821,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!Q1!" pad="1"/>
 <connect gate="A" pin="!Q2!" pad="3"/>
@@ -3857,7 +3857,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="28"/>
 <connect gate="A" pin="A1" pad="27"/>
@@ -3891,7 +3891,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="28"/>
 <connect gate="A" pin="A1" pad="27"/>
@@ -3934,7 +3934,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="18"/>
 <connect gate="A" pin="B" pad="17"/>
@@ -3961,7 +3961,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="18"/>
 <connect gate="A" pin="B" pad="17"/>
@@ -3997,7 +3997,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="18"/>
 <connect gate="A" pin="B" pad="17"/>
@@ -4024,7 +4024,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="18"/>
 <connect gate="A" pin="B" pad="17"/>
@@ -4060,7 +4060,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="18"/>
 <connect gate="A" pin="B" pad="17"/>
@@ -4087,7 +4087,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="18"/>
 <connect gate="A" pin="B" pad="17"/>
@@ -4123,7 +4123,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -4146,7 +4146,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -4179,7 +4179,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -4202,7 +4202,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -4235,7 +4235,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-12.7" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="23"/>
 <connect gate="A" pin="A2" pad="22"/>
@@ -4266,7 +4266,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="23"/>
 <connect gate="A" pin="A2" pad="22"/>
@@ -4306,7 +4306,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1A1" pad="23"/>
 <connect gate="A" pin="1A2" pad="22"/>
@@ -4333,7 +4333,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="1A1" pad="23"/>
 <connect gate="A" pin="1A2" pad="22"/>
@@ -4369,7 +4369,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1A1" pad="23"/>
 <connect gate="A" pin="1A2" pad="22"/>
@@ -4400,7 +4400,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="1A1" pad="23"/>
 <connect gate="A" pin="1A2" pad="22"/>
@@ -4440,7 +4440,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A2" pad="2"/>
@@ -4471,7 +4471,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A2" pad="2"/>
@@ -4511,7 +4511,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="6"/>
 <connect gate="A" pin="B" pad="7"/>
@@ -4534,7 +4534,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="6"/>
 <connect gate="A" pin="B" pad="7"/>
@@ -4566,7 +4566,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C0" pad="16"/>
 <connect gate="A" pin="1C1" pad="15"/>
@@ -4589,7 +4589,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="16"/>
 <connect gate="A" pin="1C1" pad="15"/>
@@ -4621,7 +4621,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="20"/>
@@ -4648,7 +4648,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="20"/>
@@ -4684,7 +4684,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="20"/>
@@ -4711,7 +4711,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="20"/>
@@ -4747,7 +4747,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P1" symbol="7411280" x="20.32" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="P" pin="GND" pad="4"/>
 <connect gate="P" pin="VCC" pad="11"/>
@@ -4767,7 +4767,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="P" pin="GND" pad="4"/>
 <connect gate="P" pin="VCC" pad="11"/>
@@ -4796,7 +4796,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -4817,7 +4817,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -4847,7 +4847,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A/QA" pad="1"/>
 <connect gate="A" pin="B/QB" pad="2"/>
@@ -4878,7 +4878,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A/QA" pad="1"/>
 <connect gate="A" pin="B/QB" pad="2"/>
@@ -4918,7 +4918,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C0" pad="16"/>
 <connect gate="A" pin="1C1" pad="15"/>
@@ -4941,7 +4941,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="16"/>
 <connect gate="A" pin="1C1" pad="15"/>
@@ -4973,7 +4973,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C0" pad="16"/>
 <connect gate="A" pin="1C1" pad="15"/>
@@ -4996,7 +4996,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="16"/>
 <connect gate="A" pin="1C1" pad="15"/>
@@ -5028,7 +5028,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="D0" pad="23"/>
 <connect gate="A" pin="D1" pad="22"/>
@@ -5059,7 +5059,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="D0" pad="23"/>
 <connect gate="A" pin="D1" pad="22"/>
@@ -5099,7 +5099,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="13"/>
 <connect gate="A" pin="D0" pad="23"/>
@@ -5130,7 +5130,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="13"/>
 <connect gate="A" pin="D0" pad="23"/>
@@ -5170,7 +5170,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!Q1!" pad="1"/>
 <connect gate="A" pin="!Q2!" pad="3"/>
@@ -5197,7 +5197,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!Q1!" pad="1"/>
 <connect gate="A" pin="!Q2!" pad="3"/>
@@ -5233,7 +5233,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G" pad="20"/>
 <connect gate="A" pin="P0" pad="4"/>
@@ -5260,7 +5260,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="G" pad="20"/>
 <connect gate="A" pin="P0" pad="4"/>
@@ -5296,7 +5296,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="C" pad="13"/>
 <connect gate="A" pin="D1" pad="23"/>
@@ -5327,7 +5327,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="C" pad="13"/>
 <connect gate="A" pin="D1" pad="23"/>
@@ -5367,7 +5367,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="13"/>
 <connect gate="A" pin="D1" pad="23"/>
@@ -5398,7 +5398,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="13"/>
 <connect gate="A" pin="D1" pad="23"/>
@@ -5438,7 +5438,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A2" pad="2"/>
@@ -5469,7 +5469,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A2" pad="2"/>
@@ -5509,7 +5509,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -5544,7 +5544,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -5588,7 +5588,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -5623,7 +5623,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -5667,7 +5667,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="15"/>
 <connect gate="A" pin="CLKEN" pad="16"/>
@@ -5702,7 +5702,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="15"/>
 <connect gate="A" pin="CLKEN" pad="16"/>
@@ -5746,7 +5746,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="15"/>
 <connect gate="A" pin="CLKEN" pad="16"/>
@@ -5781,7 +5781,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="15"/>
 <connect gate="A" pin="CLKEN" pad="16"/>
@@ -5825,7 +5825,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="15"/>
 <connect gate="A" pin="CLKEN" pad="16"/>
@@ -5860,7 +5860,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="15"/>
 <connect gate="A" pin="CLKEN" pad="16"/>
@@ -5904,7 +5904,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="27"/>
 <connect gate="A" pin="A10" pad="16"/>
@@ -5939,7 +5939,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="27"/>
 <connect gate="A" pin="A10" pad="16"/>
@@ -5983,7 +5983,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -6018,7 +6018,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -6062,7 +6062,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A10" pad="14"/>
@@ -6097,7 +6097,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A10" pad="14"/>
@@ -6141,7 +6141,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="CN" pad="3"/>
 <connect gate="A" pin="CN+16" pad="5"/>
@@ -6175,7 +6175,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="CN" pad="3"/>
 <connect gate="A" pin="CN+16" pad="5"/>
@@ -6218,7 +6218,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-30.48" y="-2.54" addlevel="request" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="P" pin="GND@1" pad="6"/>
 <connect gate="P" pin="GND@2" pad="7"/>
@@ -6253,7 +6253,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="P" pin="GND@1" pad="6"/>
 <connect gate="P" pin="GND@2" pad="7"/>
@@ -6297,7 +6297,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -6332,7 +6332,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -6376,7 +6376,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-33.02" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -6411,7 +6411,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -6456,7 +6456,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-5.08" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="A" pin="C" pad="1"/>
 <connect gate="A" pin="CLR" pad="27"/>
@@ -6491,7 +6491,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="C" pad="1"/>
 <connect gate="A" pin="CLR" pad="27"/>
@@ -6536,7 +6536,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-15.24" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="CLR" pad="27"/>
@@ -6571,7 +6571,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="CLR" pad="27"/>
@@ -6615,7 +6615,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-38.1" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="28"/>
 <connect gate="G$1" pin="A1" pad="27"/>
@@ -6650,7 +6650,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="28"/>
 <connect gate="G$1" pin="A1" pad="27"/>

--- a/74ttl-din.lbr
+++ b/74ttl-din.lbr
@@ -74,7 +74,7 @@ CadSoft and the author do not warrant that this library is free from error
 or will meet your specific requirements.&lt;p&gt;
 &lt;author&gt;Created by Holger Bettenbühl, hol.bet.@rhein-main.net&lt;/author&gt;</description>
 <packages>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -100,7 +100,7 @@ or will meet your specific requirements.&lt;p&gt;
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -128,7 +128,7 @@ or will meet your specific requirements.&lt;p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -160,7 +160,7 @@ or will meet your specific requirements.&lt;p&gt;
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -200,7 +200,7 @@ or will meet your specific requirements.&lt;p&gt;
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -20638,7 +20638,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="00" x="-22.86" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -20675,7 +20675,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="02" x="-22.86" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -20711,7 +20711,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/6" symbol="04" x="-25.4" y="35.56" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -20745,7 +20745,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="08" x="-22.86" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -20778,7 +20778,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/3" symbol="10" x="-22.86" y="10.16" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -20812,7 +20812,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="01" x="-25.4" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -20846,7 +20846,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="03" x="-22.86" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -20882,7 +20882,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/6" symbol="05" x="-25.4" y="35.56" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -20916,7 +20916,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="09" x="-22.86" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -20949,7 +20949,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/3" symbol="11" x="-20.32" y="10.16" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -20985,7 +20985,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/6" symbol="14" x="-25.4" y="35.56" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21017,7 +21017,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="20" x="-22.86" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21047,7 +21047,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="21" x="-22.86" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21078,7 +21078,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/3" symbol="27" x="-20.32" y="10.16" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21109,7 +21109,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="30" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21140,7 +21140,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="32" x="-7.62" y="10.16" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21174,7 +21174,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="36" x="-25.4" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21205,7 +21205,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="42" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -21239,7 +21239,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="51_1" x="-17.78" y="17.78"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21271,7 +21271,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="73" x="-25.4" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="4"/>
 <connect gate="/-UB" pin="-UB" pad="11"/>
@@ -21303,7 +21303,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="74" x="-25.4" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21335,7 +21335,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="75" x="-25.4" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="5"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -21369,7 +21369,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="76" x="-25.4" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="5"/>
 <connect gate="/-UB" pin="-UB" pad="13"/>
@@ -21403,7 +21403,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="77" x="-25.4" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="4"/>
 <connect gate="/-UB" pin="-UB" pad="11"/>
@@ -21432,7 +21432,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="78" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="4"/>
 <connect gate="/-UB" pin="-UB" pad="11"/>
@@ -21463,7 +21463,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="85A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -21499,7 +21499,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="86" x="-25.4" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21531,7 +21531,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="107" x="-22.86" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21563,7 +21563,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="109" x="-25.4" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -21597,7 +21597,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="112" x="-25.4" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -21631,7 +21631,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="113" x="-25.4" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21662,7 +21662,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="114" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21696,7 +21696,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="125" x="-25.4" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21730,7 +21730,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="126" x="-25.4" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21764,7 +21764,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="132" x="-25.4" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -21795,7 +21795,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="133" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -21828,7 +21828,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="137" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -21861,7 +21861,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="138" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -21895,7 +21895,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="139" x="-35.56" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -21928,7 +21928,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="147" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -21960,7 +21960,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="148" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -21993,7 +21993,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="151" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22026,7 +22026,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="152" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -22057,7 +22057,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="153" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22090,7 +22090,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="154" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -22131,7 +22131,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="157" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22164,7 +22164,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="158" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22197,7 +22197,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="160" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22230,7 +22230,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="162" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22263,7 +22263,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="161" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22296,7 +22296,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="163" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22329,7 +22329,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="164" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -22360,7 +22360,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="165" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22393,7 +22393,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="166" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22426,7 +22426,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="173" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22459,7 +22459,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="174" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22492,7 +22492,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="175" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22525,7 +22525,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="180" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -22556,7 +22556,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="190" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22589,7 +22589,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="191" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22622,7 +22622,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="192" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22655,7 +22655,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="193" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22688,7 +22688,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="194" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22721,7 +22721,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="195" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22754,7 +22754,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="237" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22787,7 +22787,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="238" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22821,7 +22821,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="239" x="-35.56" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -22855,7 +22855,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="240" x="-30.48" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -22893,7 +22893,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="241_2" x="-30.48" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -22930,7 +22930,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="242" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -22959,7 +22959,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="243" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -22989,7 +22989,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="244" x="-30.48" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -23026,7 +23026,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="245" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -23063,7 +23063,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="251" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23096,7 +23096,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="253" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23129,7 +23129,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="257" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23162,7 +23162,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="258" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23195,7 +23195,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="259" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23231,7 +23231,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="266" x="-25.4" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -23262,7 +23262,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="273" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -23299,7 +23299,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="280" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -23329,7 +23329,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="283" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23362,7 +23362,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="298" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23395,7 +23395,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="299" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -23432,7 +23432,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="352" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23465,7 +23465,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="353" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23498,7 +23498,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="354" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -23535,7 +23535,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="356" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -23572,7 +23572,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="365" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23605,7 +23605,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="366" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23639,7 +23639,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="367_1" x="-30.48" y="5.08"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23673,7 +23673,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="368_1" x="-30.48" y="5.08"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23706,7 +23706,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="373" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -23743,7 +23743,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="374" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -23781,7 +23781,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="375" x="-25.4" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23814,7 +23814,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="377" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -23851,7 +23851,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="378" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23884,7 +23884,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="379" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23920,7 +23920,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="386" x="-25.4" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -23952,7 +23952,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="390" x="-35.56" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -23986,7 +23986,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="393" x="-35.56" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -24018,7 +24018,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="490" x="-35.56" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -24051,7 +24051,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="533" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -24088,7 +24088,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="534" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -24125,7 +24125,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="540" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -24162,7 +24162,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="541" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -24199,7 +24199,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="563" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -24236,7 +24236,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="564" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -24273,7 +24273,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="573" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -24310,7 +24310,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="574" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -24347,7 +24347,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="590A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -24380,7 +24380,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="594" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -24413,7 +24413,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="595" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -24447,7 +24447,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/2" symbol="4002" x="-22.86" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -24479,7 +24479,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="4016" x="-27.94" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -24510,7 +24510,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="4017" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -24543,7 +24543,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="4020" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -24576,7 +24576,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="4024" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -24604,7 +24604,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="4040" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -24637,7 +24637,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="4060" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -24669,7 +24669,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="4061" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -24705,7 +24705,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="4066" x="-27.94" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -24738,7 +24738,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/3" symbol="4075" x="-22.86" y="10.16" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -24769,7 +24769,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="4078" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -24798,7 +24798,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="4514" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -24839,7 +24839,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="4515" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -24879,7 +24879,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="4724" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -24912,7 +24912,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="604" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-28">
+<device name="N" package="DIP-28-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="28"/>
 <connect gate="/-UB" pin="-UB" pad="14"/>
@@ -24957,7 +24957,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="620" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -24994,7 +24994,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="623" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -25031,7 +25031,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="640" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -25068,7 +25068,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="643" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -25105,7 +25105,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="645" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -25142,7 +25142,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="646" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -25183,7 +25183,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="648" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -25224,7 +25224,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="651" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -25265,7 +25265,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="652" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -25306,7 +25306,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="658" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -25347,7 +25347,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="659" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -25388,7 +25388,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="664" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -25429,7 +25429,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="665" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -25470,7 +25470,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="677" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -25511,7 +25511,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="678" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -25552,7 +25552,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="679" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -25589,7 +25589,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="680" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -25626,7 +25626,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="682" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -25663,7 +25663,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="684" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -25700,7 +25700,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="688" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -25740,7 +25740,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="7001" x="-22.86" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -25774,7 +25774,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="7002" x="-22.86" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -25810,7 +25810,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/6" symbol="7006_1" x="-48.26" y="25.4"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -25858,7 +25858,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/8" symbol="7008_1" x="-50.8" y="35.56" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -25898,7 +25898,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="1" symbol="7022" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="16"/>
 <connect gate="/-UB" pin="-UB" pad="8"/>
@@ -25934,7 +25934,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="7032" x="-22.86" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -25970,7 +25970,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/6" symbol="7074_1" x="-45.72" y="27.94" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -26016,7 +26016,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/6" symbol="7075_1" x="-45.72" y="27.94" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -26062,7 +26062,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/6" symbol="7076_1" x="-45.72" y="22.86" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="24"/>
 <connect gate="/-UB" pin="-UB" pad="12"/>
@@ -26106,7 +26106,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/4" symbol="7266" x="-22.86" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="14"/>
 <connect gate="/-UB" pin="-UB" pad="7"/>
@@ -26142,7 +26142,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/6" symbol="804" x="-45.72" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -26184,7 +26184,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/6" symbol="805" x="-45.72" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -26226,7 +26226,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/6" symbol="808" x="-45.72" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -26268,7 +26268,7 @@ or will meet your specific requirements.&lt;p&gt;
 <gate name="/6" symbol="832" x="-45.72" y="17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="/+UB" pin="+UB" pad="20"/>
 <connect gate="/-UB" pin="-UB" pad="10"/>
@@ -26331,7 +26331,7 @@ Philips Semiconductor</description>
 <gate name="P1" symbol="PWRVCCGNDVEE" x="33.02" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!G" pad="6"/>
 <connect gate="G$1" pin="1" pad="1"/>

--- a/74xx-eu.lbr
+++ b/74xx-eu.lbr
@@ -82,7 +82,7 @@ Based on the following sources:
 &lt;/ul&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="PLCC-127P-896W-896L-457H-20">
+<package name="PLCC-20-127P-896W-896L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 8.97mm length, 8.97mm width, 4.57mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 8.97mm body length, 8.97mm body width, 4.57mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AA.&lt;/p&gt;
@@ -144,7 +144,7 @@ JEDEC MS-018A, variation AA.&lt;/p&gt;
 <wire x1="4.4831" y1="3.205" x2="4.4831" y2="4.4831" width="0.2032" layer="21"/>
 <wire x1="4.4831" y1="4.4831" x2="3.205" y2="4.4831" width="0.2032" layer="21"/>
 </package>
-<package name="LCC-127P-888W-888L-254H-20">
+<package name="LCC-20-127P-888W-888L-254H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 8.89mm length, 8.89mm width, 2.54mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 8.89mm body length, 8.89mm body width, 2.54mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CB.&lt;/p&gt;
@@ -225,7 +225,7 @@ Leadless chip carrier. 1.27mm pitch, 8.89mm body length, 8.89mm body width, 2.54
 <wire x1="4.545" y1="1.67" x2="4.545" y2="0.87" width="0.2032" layer="51" curve="180" cap="flat"/>
 <wire x1="4.545" y1="2.94" x2="4.545" y2="2.14" width="0.2032" layer="51" curve="180" cap="flat"/>
 </package>
-<package name="LCC-127P-1143W-1143L-254H-28">
+<package name="LCC-28-127P-1143W-1143L-254H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 11.43mm length, 11.43mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 11.43mm body length, 11.43mm body width, 2.54mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CC.&lt;/p&gt;
@@ -357,7 +357,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <wire x1="1.45" y1="-0.65" x2="1.45" y2="0.65" width="0.2032" layer="21"/>
 <wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -377,7 +377,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -403,7 +403,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -431,7 +431,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -463,7 +463,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-48">
+<package name="DIP-48-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-29.845" y1="-5.715" x2="29.845" y2="-5.715" width="0.2032" layer="21"/>
@@ -523,7 +523,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <text x="-30.48" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -563,7 +563,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -599,7 +599,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -639,7 +639,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -675,7 +675,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -721,7 +721,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -778,7 +778,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -843,7 +843,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -8443,7 +8443,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -8472,7 +8472,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -8501,7 +8501,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -8542,7 +8542,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -8567,7 +8567,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -8592,7 +8592,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -8631,7 +8631,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -8653,7 +8653,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -8684,7 +8684,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -8711,7 +8711,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -8738,7 +8738,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="19"/>
 <connect gate="A" pin="B" pad="18"/>
@@ -8774,7 +8774,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -8797,7 +8797,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -8829,7 +8829,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -8861,7 +8861,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -8893,7 +8893,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -8923,7 +8923,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!1X" pad="12"/>
 <connect gate="A" pin="1A" pad="1"/>
@@ -8953,7 +8953,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="1A" pad="1"/>
 <connect gate="A" pin="1B" pad="12"/>
@@ -8975,7 +8975,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="1A" pad="1"/>
 <connect gate="A" pin="1B" pad="12"/>
@@ -8997,7 +8997,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="PLCC-127P-896W-896L-457H-20">
+<device name="FK" package="PLCC-20-127P-896W-896L-457H">
 <connects>
 <connect gate="A" pin="1A" pad="2"/>
 <connect gate="A" pin="1B" pad="18"/>
@@ -9028,7 +9028,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -9048,7 +9048,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -9068,7 +9068,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -9097,7 +9097,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -9124,7 +9124,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="CKA" pad="5"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -9153,7 +9153,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -9183,7 +9183,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="11"/>
@@ -9204,7 +9204,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="11"/>
@@ -9225,7 +9225,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -9255,7 +9255,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1CLKA" pad="1"/>
 <connect gate="A" pin="1CLKB" pad="15"/>
@@ -9286,7 +9286,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -9315,7 +9315,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -9345,7 +9345,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="13"/>
 <connect gate="A" pin="CL" pad="2"/>
@@ -9366,7 +9366,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="13"/>
 <connect gate="A" pin="CL" pad="2"/>
@@ -9397,7 +9397,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="3"/>
@@ -9423,7 +9423,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="3"/>
@@ -9449,7 +9449,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!Q" pad="9"/>
 <connect gate="A" pin="CLK" pad="4"/>
@@ -9484,7 +9484,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q1" pad="1"/>
 <connect gate="A" pin="!Q2" pad="14"/>
@@ -9510,7 +9510,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q1" pad="1"/>
 <connect gate="A" pin="!Q2" pad="14"/>
@@ -9546,7 +9546,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="14"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -9570,7 +9570,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="14"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -9603,7 +9603,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="12C" pad="12"/>
 <connect gate="A" pin="1D" pad="1"/>
@@ -9623,7 +9623,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="12C" pad="12"/>
 <connect gate="A" pin="1D" pad="1"/>
@@ -9652,7 +9652,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q1" pad="12"/>
 <connect gate="A" pin="!Q2" pad="9"/>
@@ -9682,7 +9682,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="14"/>
@@ -9708,7 +9708,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="10"/>
 <connect gate="A" pin="A2" pad="8"/>
@@ -9741,7 +9741,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="10"/>
 <connect gate="A" pin="A1" pad="12"/>
@@ -9768,7 +9768,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="10"/>
 <connect gate="A" pin="A1" pad="12"/>
@@ -9794,7 +9794,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A0" pad="13"/>
 <connect gate="A" pin="A1" pad="15"/>
@@ -9829,7 +9829,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -9849,7 +9849,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -9878,7 +9878,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!QH" pad="14"/>
 <connect gate="A" pin="A" pad="12"/>
@@ -9901,7 +9901,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -9918,7 +9918,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -9944,7 +9944,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -9963,7 +9963,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -9991,7 +9991,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -10022,7 +10022,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -10045,7 +10045,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -10077,7 +10077,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="B0" pad="4"/>
 <connect gate="A" pin="B1" pad="1"/>
@@ -10100,7 +10100,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B0" pad="4"/>
 <connect gate="A" pin="B1" pad="1"/>
@@ -10133,7 +10133,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="D1" pad="2"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -10170,7 +10170,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="2"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -10194,7 +10194,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="2"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -10228,7 +10228,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="7"/>
 <connect gate="A" pin="CLK" pad="4"/>
@@ -10255,7 +10255,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="7"/>
 <connect gate="A" pin="CLK" pad="4"/>
@@ -10282,7 +10282,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!Q" pad="9"/>
 <connect gate="A" pin="CLK" pad="5"/>
@@ -10319,7 +10319,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="5"/>
@@ -10352,7 +10352,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -10380,7 +10380,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -10408,7 +10408,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!Q" pad="8"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -10446,7 +10446,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -10470,7 +10470,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -10503,7 +10503,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="7478" x="20.32" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="!Q1" pad="6"/>
 <connect gate="G$1" pin="!Q2" pad="8"/>
@@ -10535,7 +10535,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLR" pad="1"/>
 <connect gate="A" pin="D1" pad="4"/>
@@ -10576,7 +10576,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Y" pad="7"/>
 <connect gate="A" pin="C" pad="5"/>
@@ -10608,7 +10608,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="1"/>
 <connect gate="A" pin="A1" pad="3"/>
@@ -10625,7 +10625,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="1"/>
 <connect gate="A" pin="A1" pad="3"/>
@@ -10651,7 +10651,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -10670,7 +10670,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -10699,7 +10699,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="4"/>
 <connect gate="A" pin="A" pad="1"/>
@@ -10723,7 +10723,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="4"/>
 <connect gate="A" pin="A" pad="1"/>
@@ -10747,7 +10747,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!Q" pad="5"/>
 <connect gate="A" pin="A" pad="2"/>
@@ -10781,7 +10781,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CX@1" pad="4"/>
 <connect gate="A" pin="CX@2" pad="5"/>
@@ -10804,7 +10804,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CX@1" pad="4"/>
 <connect gate="A" pin="CX@2" pad="5"/>
@@ -10827,7 +10827,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="CX@1" pad="5"/>
 <connect gate="A" pin="CX@2" pad="7"/>
@@ -10859,7 +10859,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -10883,7 +10883,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -10915,7 +10915,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -10940,7 +10940,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -10965,7 +10965,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -10999,7 +10999,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -11027,7 +11027,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -11055,7 +11055,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -11093,7 +11093,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -11121,7 +11121,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -11149,7 +11149,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -11186,7 +11186,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="16"/>
@@ -11226,7 +11226,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -11250,7 +11250,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -11274,7 +11274,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="0" pad="2"/>
 <connect gate="A" pin="1" pad="3"/>
@@ -11307,7 +11307,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1" pad="11"/>
 <connect gate="A" pin="2" pad="12"/>
@@ -11331,7 +11331,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1" pad="11"/>
 <connect gate="A" pin="2" pad="12"/>
@@ -11363,7 +11363,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="11"/>
@@ -11388,7 +11388,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="11"/>
@@ -11413,7 +11413,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="0" pad="13"/>
 <connect gate="A" pin="1" pad="14"/>
@@ -11447,7 +11447,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -11487,7 +11487,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -11516,7 +11516,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -11545,7 +11545,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="14"/>
 <connect gate="A" pin="B" pad="13"/>
@@ -11583,7 +11583,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -11613,7 +11613,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -11641,7 +11641,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -11669,7 +11669,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1C0" pad="8"/>
 <connect gate="A" pin="1C1" pad="7"/>
@@ -11706,7 +11706,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -11739,7 +11739,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -11781,7 +11781,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C" pad="1"/>
 <connect gate="A" pin="1G" pad="2"/>
@@ -11806,7 +11806,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C" pad="1"/>
 <connect gate="A" pin="1G" pad="2"/>
@@ -11831,7 +11831,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1C" pad="2"/>
 <connect gate="A" pin="1G" pad="3"/>
@@ -11865,7 +11865,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C" pad="1"/>
 <connect gate="A" pin="1G" pad="2"/>
@@ -11889,7 +11889,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C" pad="1"/>
 <connect gate="A" pin="1G" pad="2"/>
@@ -11913,7 +11913,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1C" pad="2"/>
 <connect gate="A" pin="1G" pad="3"/>
@@ -11945,7 +11945,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -11974,7 +11974,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -12003,7 +12003,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!A!/B" pad="2"/>
 <connect gate="A" pin="1A" pad="3"/>
@@ -12040,7 +12040,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -12069,7 +12069,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -12097,7 +12097,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!A!/B" pad="2"/>
 <connect gate="A" pin="1A" pad="3"/>
@@ -12134,7 +12134,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -12174,7 +12174,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -12201,7 +12201,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -12235,7 +12235,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -12261,7 +12261,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -12287,7 +12287,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -12322,7 +12322,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH" pad="7"/>
 <connect gate="A" pin="A" pad="11"/>
@@ -12348,7 +12348,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH" pad="7"/>
 <connect gate="A" pin="A" pad="11"/>
@@ -12374,7 +12374,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QH" pad="9"/>
 <connect gate="A" pin="A" pad="14"/>
@@ -12409,7 +12409,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -12435,7 +12435,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -12461,7 +12461,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -12495,7 +12495,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="B0" pad="14"/>
 <connect gate="A" pin="B1" pad="15"/>
@@ -12526,7 +12526,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -12558,7 +12558,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D1" pad="15"/>
 <connect gate="A" pin="D2" pad="1"/>
@@ -12582,7 +12582,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="15"/>
 <connect gate="A" pin="D2" pad="1"/>
@@ -12606,7 +12606,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="D1" pad="19"/>
 <connect gate="A" pin="D2" pad="2"/>
@@ -12638,7 +12638,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q1" pad="1"/>
 <connect gate="A" pin="!Q2" pad="2"/>
@@ -12670,7 +12670,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="CLR" pad="15"/>
@@ -12695,7 +12695,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="CLR" pad="15"/>
@@ -12720,7 +12720,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="CLR" pad="19"/>
@@ -12754,7 +12754,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -12783,7 +12783,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -12812,7 +12812,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="CLK" pad="12"/>
 <connect gate="A" pin="CLR" pad="2"/>
@@ -12850,7 +12850,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q1" pad="3"/>
 <connect gate="A" pin="!Q2" pad="6"/>
@@ -12879,7 +12879,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q1" pad="3"/>
 <connect gate="A" pin="!Q2" pad="6"/>
@@ -12908,7 +12908,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!Q1" pad="4"/>
 <connect gate="A" pin="!Q2" pad="8"/>
@@ -12945,7 +12945,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="4"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -12975,7 +12975,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -13005,7 +13005,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QD" pad="12"/>
 <connect gate="A" pin="A" pad="3"/>
@@ -13037,7 +13037,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="8"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -13067,7 +13067,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="2"/>
 <connect gate="A" pin="A1" pad="23"/>
@@ -13101,7 +13101,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="2"/>
 <connect gate="A" pin="A1" pad="23"/>
@@ -13135,7 +13135,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-1143W-1143L-254H-28">
+<device name="FK" package="LCC-28-127P-1143W-1143L-254H">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="27"/>
@@ -13178,7 +13178,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CN" pad="13"/>
 <connect gate="A" pin="CN+X" pad="12"/>
@@ -13203,7 +13203,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CN" pad="13"/>
 <connect gate="A" pin="CN+X" pad="12"/>
@@ -13228,7 +13228,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="CN" pad="17"/>
 <connect gate="A" pin="CN+X" pad="15"/>
@@ -13263,7 +13263,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -13282,7 +13282,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -13310,7 +13310,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -13342,7 +13342,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -13368,7 +13368,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -13401,7 +13401,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -13427,7 +13427,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -13460,7 +13460,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -13488,7 +13488,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -13516,7 +13516,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="4"/>
 <connect gate="A" pin="B" pad="5"/>
@@ -13553,7 +13553,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QD" pad="11"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -13579,7 +13579,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QD" pad="11"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -13603,7 +13603,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QD" pad="14"/>
 <connect gate="A" pin="A" pad="5"/>
@@ -13638,7 +13638,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="5"/>
@@ -13678,7 +13678,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="5"/>
@@ -13719,7 +13719,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -13751,7 +13751,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -13783,7 +13783,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -13825,7 +13825,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="B" symbol="74241A" x="20.32" y="-15.24"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -13857,7 +13857,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -13889,7 +13889,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -13930,7 +13930,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -13951,7 +13951,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -13981,7 +13981,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14013,7 +14013,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14045,7 +14045,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14086,7 +14086,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -14117,7 +14117,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -14148,7 +14148,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -14188,7 +14188,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -14228,7 +14228,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -14256,7 +14256,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -14284,7 +14284,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="14"/>
 <connect gate="A" pin="B" pad="13"/>
@@ -14321,7 +14321,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -14349,7 +14349,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -14377,7 +14377,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1C0" pad="8"/>
 <connect gate="A" pin="1C1" pad="7"/>
@@ -14413,7 +14413,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -14441,7 +14441,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -14469,7 +14469,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!A!/B" pad="2"/>
 <connect gate="A" pin="1A" pad="3"/>
@@ -14506,7 +14506,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -14534,7 +14534,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -14562,7 +14562,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!A!/B" pad="2"/>
 <connect gate="A" pin="1A" pad="3"/>
@@ -14599,7 +14599,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLR" pad="15"/>
 <connect gate="A" pin="D" pad="13"/>
@@ -14627,7 +14627,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLR" pad="15"/>
 <connect gate="A" pin="D" pad="13"/>
@@ -14663,7 +14663,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="B0" pad="13"/>
 <connect gate="A" pin="B1" pad="14"/>
@@ -14695,7 +14695,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -14726,7 +14726,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -14757,7 +14757,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -14797,7 +14797,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1CK" pad="3"/>
 <connect gate="A" pin="1J" pad="2"/>
@@ -14833,7 +14833,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="D1" pad="12"/>
 <connect gate="A" pin="D2" pad="13"/>
@@ -14865,7 +14865,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="Q" pad="4"/>
 <connect gate="A" pin="R" pad="1"/>
@@ -14889,7 +14889,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="Q" pad="4"/>
 <connect gate="A" pin="R" pad="1"/>
@@ -14913,7 +14913,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="Q" pad="5"/>
 <connect gate="A" pin="R" pad="2"/>
@@ -14945,7 +14945,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="8"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -14970,7 +14970,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="8"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -14995,7 +14995,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="12"/>
 <connect gate="A" pin="B" pad="13"/>
@@ -15029,7 +15029,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="5"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -15057,7 +15057,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="5"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -15084,7 +15084,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="7"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -15121,7 +15121,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1A" pad="5"/>
 <connect gate="A" pin="1B" pad="6"/>
@@ -15153,7 +15153,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1A" pad="5"/>
 <connect gate="A" pin="1B" pad="6"/>
@@ -15185,7 +15185,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="8"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -15215,7 +15215,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -15243,7 +15243,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -15264,7 +15264,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -15294,7 +15294,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -15311,7 +15311,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -15337,7 +15337,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -15355,7 +15355,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -15382,7 +15382,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -15412,7 +15412,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="2"/>
@@ -15436,7 +15436,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="2"/>
@@ -15460,7 +15460,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -15492,7 +15492,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!QA!" pad="8"/>
 <connect gate="A" pin="!QH!" pad="17"/>
@@ -15524,7 +15524,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!QA!" pad="8"/>
 <connect gate="A" pin="!QH!" pad="17"/>
@@ -15556,7 +15556,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QA!" pad="8"/>
 <connect gate="A" pin="!QH!" pad="17"/>
@@ -15597,7 +15597,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!!F!" pad="9"/>
 <connect gate="A" pin="!F" pad="12"/>
@@ -15625,7 +15625,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!!F!" pad="9"/>
 <connect gate="A" pin="!F" pad="12"/>
@@ -15655,7 +15655,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="12"/>
 <connect gate="A" pin="A/QA" pad="4"/>
@@ -15691,7 +15691,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="11"/>
@@ -15714,7 +15714,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="11"/>
@@ -15737,7 +15737,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="0" pad="13"/>
 <connect gate="A" pin="1" pad="14"/>
@@ -15769,7 +15769,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -15795,7 +15795,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -15830,7 +15830,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -15855,7 +15855,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -15889,7 +15889,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="D0" pad="8"/>
 <connect gate="A" pin="D1" pad="7"/>
@@ -15918,7 +15918,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="D0" pad="8"/>
 <connect gate="A" pin="D1" pad="7"/>
@@ -15955,7 +15955,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="D0" pad="8"/>
 <connect gate="A" pin="D1" pad="7"/>
@@ -15991,7 +15991,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="D0" pad="8"/>
@@ -16019,7 +16019,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="D0" pad="8"/>
@@ -16056,7 +16056,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="D0" pad="8"/>
@@ -16092,7 +16092,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -16117,7 +16117,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -16142,7 +16142,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -16176,7 +16176,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -16201,7 +16201,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -16226,7 +16226,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -16260,7 +16260,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1A1" pad="2"/>
 <connect gate="A" pin="1A2" pad="4"/>
@@ -16285,7 +16285,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1A1" pad="2"/>
 <connect gate="A" pin="1A2" pad="4"/>
@@ -16310,7 +16310,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1A1" pad="3"/>
 <connect gate="A" pin="1A2" pad="5"/>
@@ -16344,7 +16344,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1A1" pad="2"/>
 <connect gate="A" pin="1A2" pad="4"/>
@@ -16369,7 +16369,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1A1" pad="2"/>
 <connect gate="A" pin="1A2" pad="4"/>
@@ -16394,7 +16394,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1A1" pad="3"/>
 <connect gate="A" pin="1A2" pad="5"/>
@@ -16428,7 +16428,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16460,7 +16460,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16490,7 +16490,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16531,7 +16531,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16563,7 +16563,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16595,7 +16595,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16636,7 +16636,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!1Q" pad="2"/>
 <connect gate="A" pin="!2Q" pad="6"/>
@@ -16659,7 +16659,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!1Q" pad="2"/>
 <connect gate="A" pin="!2Q" pad="6"/>
@@ -16682,7 +16682,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!1Q" pad="4"/>
 <connect gate="A" pin="!2Q" pad="8"/>
@@ -16714,7 +16714,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1J" pad="2"/>
 <connect gate="A" pin="1K" pad="3"/>
@@ -16737,7 +16737,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1J" pad="2"/>
 <connect gate="A" pin="1K" pad="3"/>
@@ -16769,7 +16769,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16800,7 +16800,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16830,7 +16830,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16870,7 +16870,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16895,7 +16895,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16919,7 +16919,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="ACT"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1D" pad="4"/>
 <connect gate="A" pin="1Q" pad="3"/>
@@ -16953,7 +16953,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!1Q" pad="3"/>
 <connect gate="A" pin="!2Q" pad="6"/>
@@ -16976,7 +16976,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!1Q" pad="3"/>
 <connect gate="A" pin="!2Q" pad="6"/>
@@ -16999,7 +16999,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!1Q" pad="4"/>
 <connect gate="A" pin="!2Q" pad="8"/>
@@ -17031,7 +17031,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17059,7 +17059,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17087,7 +17087,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17123,7 +17123,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17150,7 +17150,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17186,7 +17186,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -17218,7 +17218,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1A" pad="5"/>
 <connect gate="A" pin="1B" pad="4"/>
@@ -17255,7 +17255,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -17281,7 +17281,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -17306,7 +17306,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="5"/>
@@ -17341,7 +17341,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="CLR" pad="2"/>
@@ -17366,7 +17366,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="CLR" pad="2"/>
@@ -17389,7 +17389,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="CLR" pad="3"/>
@@ -17421,7 +17421,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QD!" pad="11"/>
 <connect gate="A" pin="A" pad="3"/>
@@ -17444,7 +17444,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QD!" pad="11"/>
 <connect gate="A" pin="A" pad="3"/>
@@ -17467,7 +17467,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QD!" pad="14"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -17499,7 +17499,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1Q1" pad="2"/>
 <connect gate="A" pin="1Q2" pad="5"/>
@@ -17522,7 +17522,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1Q1" pad="2"/>
 <connect gate="A" pin="1Q2" pad="5"/>
@@ -17545,7 +17545,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1Q1" pad="3"/>
 <connect gate="A" pin="1Q2" pad="7"/>
@@ -17577,7 +17577,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!QA" pad="3"/>
 <connect gate="A" pin="!QB" pad="8"/>
@@ -17613,7 +17613,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -17636,7 +17636,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -17659,7 +17659,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -17691,7 +17691,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLR" pad="14"/>
 <connect gate="A" pin="DI1" pad="3"/>
@@ -17731,7 +17731,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17759,7 +17759,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -17795,7 +17795,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -17827,7 +17827,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -17859,7 +17859,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -17891,7 +17891,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -17927,7 +17927,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -17954,7 +17954,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -17991,7 +17991,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18028,7 +18028,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18065,7 +18065,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="CLR" pad="2"/>
@@ -18097,7 +18097,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18124,7 +18124,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18160,7 +18160,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18187,7 +18187,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18223,7 +18223,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18250,7 +18250,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18286,7 +18286,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18322,7 +18322,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18358,7 +18358,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-2.54" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18379,7 +18379,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18400,7 +18400,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="6"/>
@@ -18435,7 +18435,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -18459,7 +18459,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -18483,7 +18483,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -18515,7 +18515,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CN!" pad="13"/>
 <connect gate="A" pin="CN+X" pad="15"/>
@@ -18554,7 +18554,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="5.08" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -18583,7 +18583,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -18612,7 +18612,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -18653,7 +18653,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -18678,7 +18678,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -18703,7 +18703,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="3"/>
 <connect gate="A" pin="I1" pad="4"/>
@@ -18740,7 +18740,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -18769,7 +18769,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -18798,7 +18798,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="3"/>
 <connect gate="A" pin="I1" pad="4"/>
@@ -18839,7 +18839,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -18864,7 +18864,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -18889,7 +18889,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -18926,7 +18926,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="2.54" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -18954,7 +18954,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -18982,7 +18982,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19022,7 +19022,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19045,7 +19045,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19068,7 +19068,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19100,7 +19100,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19129,7 +19129,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19158,7 +19158,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19198,7 +19198,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19226,7 +19226,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19254,7 +19254,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19293,7 +19293,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19325,7 +19325,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19347,7 +19347,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19379,7 +19379,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19410,7 +19410,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="2.54" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19435,7 +19435,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19460,7 +19460,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19495,7 +19495,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19516,7 +19516,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19546,7 +19546,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="G" pad="3"/>
 <connect gate="A" pin="I0" pad="1"/>
@@ -19569,7 +19569,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="G" pad="3"/>
 <connect gate="A" pin="I0" pad="1"/>
@@ -19603,7 +19603,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="0" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19630,7 +19630,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19657,7 +19657,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19693,7 +19693,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19719,7 +19719,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19745,7 +19745,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19782,7 +19782,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19809,7 +19809,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19836,7 +19836,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19875,7 +19875,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19896,7 +19896,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19917,7 +19917,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="3"/>
 <connect gate="A" pin="I1" pad="4"/>
@@ -19950,7 +19950,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19980,7 +19980,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="11"/>
@@ -20013,7 +20013,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20040,7 +20040,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20066,7 +20066,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20104,7 +20104,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -20130,7 +20130,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -20167,7 +20167,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -20193,7 +20193,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -20218,7 +20218,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="4"/>
@@ -20252,7 +20252,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20276,7 +20276,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20300,7 +20300,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20333,7 +20333,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20366,7 +20366,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1A" pad="1"/>
 <connect gate="A" pin="1B" pad="2"/>
@@ -20389,7 +20389,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1A" pad="1"/>
 <connect gate="A" pin="1B" pad="2"/>
@@ -20412,7 +20412,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1A" pad="2"/>
 <connect gate="A" pin="1B" pad="3"/>
@@ -20447,7 +20447,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20468,7 +20468,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="DIP-300-14">
+<device name="D" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20489,7 +20489,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20520,7 +20520,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20541,7 +20541,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20562,7 +20562,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20595,7 +20595,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20617,7 +20617,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20639,7 +20639,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20673,7 +20673,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20695,7 +20695,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20730,7 +20730,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-17.78" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="13"/>
 <connect gate="A" pin="O" pad="12"/>
@@ -20756,7 +20756,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="13"/>
 <connect gate="A" pin="O" pad="12"/>
@@ -20782,7 +20782,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -20820,7 +20820,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="2.54" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20843,7 +20843,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20866,7 +20866,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20901,7 +20901,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20928,7 +20928,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20955,7 +20955,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20991,7 +20991,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21027,7 +21027,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G1" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21056,7 +21056,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="ALS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="G1" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21093,7 +21093,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G1" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21129,7 +21129,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21165,7 +21165,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21201,7 +21201,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="G1" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21233,7 +21233,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21264,7 +21264,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21294,7 +21294,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21334,7 +21334,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21365,7 +21365,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21396,7 +21396,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21436,7 +21436,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="ACL" pad="8"/>
@@ -21472,7 +21472,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="ACLR" pad="8"/>
@@ -21508,7 +21508,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="A" pad="15"/>
@@ -21532,7 +21532,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="A" pad="15"/>
@@ -21564,7 +21564,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CCKEN" pad="12"/>
 <connect gate="A" pin="CCLR" pad="10"/>
@@ -21590,7 +21590,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CCKEN" pad="12"/>
 <connect gate="A" pin="CCLR" pad="10"/>
@@ -21615,7 +21615,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="CCKEN" pad="15"/>
 <connect gate="A" pin="CCLR" pad="13"/>
@@ -21649,7 +21649,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CCKEN" pad="12"/>
 <connect gate="A" pin="CCLR" pad="10"/>
@@ -21681,7 +21681,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -21705,7 +21705,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -21729,7 +21729,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="19"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -21762,7 +21762,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CCKEN" pad="14"/>
 <connect gate="A" pin="!G" pad="18"/>
@@ -21791,7 +21791,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!CCKEN" pad="14"/>
 <connect gate="A" pin="!G" pad="18"/>
@@ -21819,7 +21819,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!CCKEN" pad="14"/>
 <connect gate="A" pin="!G" pad="18"/>
@@ -21856,7 +21856,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="QA" pad="15"/>
@@ -21881,7 +21881,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="QA" pad="15"/>
@@ -21915,7 +21915,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="G" pad="13"/>
@@ -21940,7 +21940,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="G" pad="13"/>
@@ -21964,7 +21964,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QH!" pad="12"/>
 <connect gate="A" pin="G" pad="17"/>
@@ -21998,7 +21998,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="G" pad="13"/>
@@ -22021,7 +22021,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="G" pad="13"/>
@@ -22053,7 +22053,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="A" pad="15"/>
@@ -22078,7 +22078,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="A" pad="15"/>
@@ -22102,7 +22102,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QH!" pad="12"/>
 <connect gate="A" pin="A" pad="19"/>
@@ -22135,7 +22135,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="11"/>
 <connect gate="A" pin="A/QA" pad="1"/>
@@ -22162,7 +22162,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="11"/>
 <connect gate="A" pin="A/QA" pad="1"/>
@@ -22189,7 +22189,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QH!" pad="11"/>
 <connect gate="A" pin="A/QA" pad="1"/>
@@ -22225,7 +22225,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="QA" pad="15"/>
@@ -22248,7 +22248,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="QA" pad="15"/>
@@ -22280,7 +22280,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="A/!B" pad="2"/>
 <connect gate="A" pin="A1" pad="3"/>
@@ -22324,7 +22324,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="A/!B" pad="2"/>
 <connect gate="A" pin="A1" pad="3"/>
@@ -22368,7 +22368,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CAS" pad="9"/>
 <connect gate="A" pin="!RAS" pad="7"/>
@@ -22400,7 +22400,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -22429,7 +22429,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -22466,7 +22466,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -22502,7 +22502,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -22543,7 +22543,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -22575,7 +22575,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D1" pad="15"/>
 <connect gate="A" pin="D2" pad="1"/>
@@ -22600,7 +22600,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="15"/>
 <connect gate="A" pin="D2" pad="1"/>
@@ -22624,7 +22624,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="D1" pad="19"/>
 <connect gate="A" pin="D2" pad="2"/>
@@ -22657,7 +22657,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -22693,7 +22693,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CS" pad="1"/>
 <connect gate="A" pin="M/SCLK" pad="5"/>
@@ -22724,7 +22724,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="CS" pad="1"/>
 <connect gate="A" pin="M/SCLK" pad="5"/>
@@ -22755,7 +22755,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-1143W-1143L-254H-28">
+<device name="FK" package="LCC-28-127P-1143W-1143L-254H">
 <connects>
 <connect gate="A" pin="CS" pad="2"/>
 <connect gate="A" pin="M/SCLK" pad="6"/>
@@ -22795,7 +22795,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="2"/>
 <connect gate="A" pin="CS" pad="1"/>
@@ -22825,7 +22825,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="2"/>
 <connect gate="A" pin="CS" pad="1"/>
@@ -22855,7 +22855,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-1143W-1143L-254H-28">
+<device name="FK" package="LCC-28-127P-1143W-1143L-254H">
 <connects>
 <connect gate="A" pin="CLK" pad="3"/>
 <connect gate="A" pin="CS" pad="2"/>
@@ -22894,7 +22894,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A10" pad="10"/>
@@ -22934,7 +22934,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A10" pad="11"/>
@@ -22970,7 +22970,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A10" pad="11"/>
@@ -23006,7 +23006,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="AS0" pad="18"/>
 <connect gate="A" pin="AS1" pad="17"/>
@@ -23042,7 +23042,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="P0" pad="2"/>
 <connect gate="A" pin="P1" pad="4"/>
@@ -23070,7 +23070,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="P0" pad="2"/>
 <connect gate="A" pin="P1" pad="4"/>
@@ -23097,7 +23097,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="P0" pad="2"/>
 <connect gate="A" pin="P1" pad="4"/>
@@ -23134,7 +23134,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="P0" pad="2"/>
 <connect gate="A" pin="P1" pad="4"/>
@@ -23170,7 +23170,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="G1" pad="2"/>
 <connect gate="A" pin="G2" pad="23"/>
@@ -23199,7 +23199,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="G1" pad="2"/>
 <connect gate="A" pin="G2" pad="23"/>
@@ -23228,7 +23228,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-1143W-1143L-254H-28">
+<device name="FK" package="LCC-28-127P-1143W-1143L-254H">
 <connects>
 <connect gate="A" pin="G1" pad="3"/>
 <connect gate="A" pin="G2" pad="27"/>
@@ -23266,7 +23266,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="G1" pad="2"/>
 <connect gate="A" pin="G2" pad="23"/>
@@ -23304,7 +23304,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -23333,7 +23333,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -23362,7 +23362,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -23400,7 +23400,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -23436,7 +23436,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -23472,7 +23472,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -23508,7 +23508,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -23544,7 +23544,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -23581,7 +23581,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -23618,7 +23618,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -23655,7 +23655,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -23696,7 +23696,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -23738,7 +23738,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -23780,7 +23780,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -23820,7 +23820,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -23855,7 +23855,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -23892,7 +23892,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="12"/>
 <connect gate="A" pin="D0" pad="8"/>
@@ -23936,7 +23936,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="D0" pad="8"/>
 <connect gate="A" pin="D1" pad="7"/>
@@ -23980,7 +23980,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -24020,7 +24020,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -24060,7 +24060,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1A" pad="2"/>
 <connect gate="A" pin="1B" pad="3"/>
@@ -24101,7 +24101,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="CLRQ" pad="27"/>
 <connect gate="A" pin="L/!A" pad="2"/>
@@ -24145,7 +24145,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -24186,7 +24186,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="C" pad="23"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -24228,7 +24228,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="23"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -24270,7 +24270,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="23"/>
 <connect gate="A" pin="D1" pad="3"/>
@@ -24311,7 +24311,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -24352,7 +24352,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="23"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -24394,7 +24394,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="C" pad="23"/>
 <connect gate="A" pin="D1" pad="3"/>
@@ -24435,7 +24435,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CN" pad="1"/>
 <connect gate="A" pin="CN+16" pad="11"/>
@@ -24474,7 +24474,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="L/!A" pad="1"/>
 <connect gate="A" pin="P0" pad="15"/>
@@ -24515,7 +24515,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -24552,7 +24552,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -24588,7 +24588,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -24624,7 +24624,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -24651,7 +24651,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -24678,7 +24678,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -24714,7 +24714,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -24745,7 +24745,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -24784,7 +24784,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -24815,7 +24815,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -24854,7 +24854,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -24885,7 +24885,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -24924,7 +24924,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -24955,7 +24955,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -24994,7 +24994,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25025,7 +25025,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25064,7 +25064,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25095,7 +25095,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25134,7 +25134,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="22"/>
@@ -25171,7 +25171,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25207,7 +25207,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="22"/>
@@ -25244,7 +25244,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25281,7 +25281,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="10D" pad="11"/>
 <connect gate="A" pin="10Q" pad="14"/>
@@ -25323,7 +25323,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="10D" pad="11"/>
 <connect gate="A" pin="10Q" pad="14"/>
@@ -25363,7 +25363,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="23"/>
@@ -25405,7 +25405,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="23"/>
@@ -25445,7 +25445,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="22"/>
@@ -25487,7 +25487,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="22"/>
@@ -25527,7 +25527,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-12.7" y="0"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-28">
+<device name="NT" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="10D" pad="16"/>
 <connect gate="A" pin="10Q" pad="14"/>
@@ -25574,7 +25574,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-28">
+<device name="NT" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="10D" pad="16"/>
 <connect gate="A" pin="10Q" pad="14"/>
@@ -25619,7 +25619,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-28">
+<device name="NT" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="27"/>
 <connect gate="A" pin="1Q" pad="1"/>
@@ -25664,7 +25664,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-28">
+<device name="NT" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="27"/>
 <connect gate="A" pin="1Q" pad="1"/>
@@ -25709,7 +25709,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-28">
+<device name="NT" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="26"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -25754,7 +25754,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR4GND" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-28">
+<device name="NT" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="26"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -25800,7 +25800,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="PO" symbol="PWRN" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="8"/>
 <connect gate="A" pin="EN" pad="5"/>
@@ -25818,7 +25818,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="8"/>
 <connect gate="A" pin="EN" pad="5"/>
@@ -25846,7 +25846,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -25872,7 +25872,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -25898,7 +25898,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -25936,7 +25936,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -25957,7 +25957,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -25990,7 +25990,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -26014,7 +26014,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -26038,7 +26038,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -26071,7 +26071,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR3GND" x="-27.94" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="11"/>
 <connect gate="G$1" pin="CLR" pad="14"/>
@@ -26103,7 +26103,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWR3GND" x="-30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="11"/>
 <connect gate="G$1" pin="CLR" pad="14"/>
@@ -26135,7 +26135,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="74305" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="PRE" pad="10"/>
@@ -26168,7 +26168,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="-1.27" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!X" pad="12"/>
 <connect gate="A" pin="A" pad="1"/>
@@ -26198,7 +26198,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!A!" pad="10"/>
 <connect gate="A" pin="!B!" pad="1"/>
@@ -26228,7 +26228,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="8"/>
 <connect gate="A" pin="CLR" pad="10"/>
@@ -26251,7 +26251,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="8"/>
 <connect gate="A" pin="CLR" pad="10"/>
@@ -26283,7 +26283,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="8"/>
 <connect gate="A" pin="CLK" pad="9"/>
@@ -26313,7 +26313,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="0" pad="16"/>
 <connect gate="A" pin="1" pad="15"/>
@@ -26345,7 +26345,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="9"/>
@@ -26368,7 +26368,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="9"/>
@@ -26400,7 +26400,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-8.89" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1DA" pad="22"/>
 <connect gate="A" pin="1DB" pad="4"/>
@@ -26440,7 +26440,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -26463,7 +26463,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -26495,7 +26495,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="AN" pad="1"/>
 <connect gate="A" pin="AN1" pad="2"/>
@@ -26526,7 +26526,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="AN" pad="1"/>
 <connect gate="A" pin="AN1" pad="2"/>
@@ -26566,7 +26566,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="2N+0" pad="9"/>
 <connect gate="A" pin="2N+1" pad="11"/>
@@ -26589,7 +26589,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="2N+0" pad="9"/>
 <connect gate="A" pin="2N+1" pad="11"/>
@@ -26621,7 +26621,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="74428" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="BUSEN" pad="22"/>
 <connect gate="A" pin="D0" pad="15"/>
@@ -26665,7 +26665,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -26688,7 +26688,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -26720,7 +26720,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-27.94" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A1" pad="3"/>
 <connect gate="G$1" pin="A2" pad="4"/>
@@ -26760,7 +26760,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR2GND" x="-35.56" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="JD" package="DIP-600-48">
+<device name="JD" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="A" pin="CB0" pad="28"/>
 <connect gate="A" pin="CB1" pad="27"/>
@@ -26824,7 +26824,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR2GND" x="-35.56" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="JD" package="DIP-600-48">
+<device name="JD" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="A" pin="CB0" pad="28"/>
 <connect gate="A" pin="CB1" pad="27"/>
@@ -26888,7 +26888,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-33.02" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-300-24">
+<device name="NT" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="1A0" pad="2"/>
 <connect gate="A" pin="1A1" pad="3"/>
@@ -26928,7 +26928,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-32.1818" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-28">
+<device name="N" package="DIP-28-254P-762W">
 <connects>
 <connect gate="A" pin="1A0" pad="4"/>
 <connect gate="A" pin="1A1" pad="5"/>
@@ -26977,7 +26977,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -26998,7 +26998,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -27033,7 +27033,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="F" symbol="7407" x="40.64" y="-25.4"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -27054,7 +27054,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -27089,7 +27089,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-17.78" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="13"/>
 <connect gate="A" pin="O" pad="12"/>
@@ -27112,7 +27112,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="13"/>
 <connect gate="A" pin="O" pad="12"/>
@@ -27144,7 +27144,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="74S51" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="G$1" pin="1A" pad="2"/>
 <connect gate="G$1" pin="1B" pad="19"/>
@@ -27163,7 +27163,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="1A" pad="1"/>
 <connect gate="G$1" pin="1B" pad="13"/>
@@ -27182,7 +27182,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1A" pad="1"/>
 <connect gate="G$1" pin="1B" pad="13"/>
@@ -27211,7 +27211,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="20.32" y="-2.54"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="4"/>
 <connect gate="A" pin="A" pad="1"/>
@@ -27237,7 +27237,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="4"/>
 <connect gate="A" pin="A" pad="1"/>
@@ -27263,7 +27263,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="JK" package="PLCC-127P-896W-896L-457H-20">
+<device name="JK" package="PLCC-20-127P-896W-896L-457H">
 <connects>
 <connect gate="A" pin="!Q" pad="5"/>
 <connect gate="A" pin="A" pad="2"/>
@@ -27299,7 +27299,7 @@ Philips Semiconductor</description>
 <gate name="P" symbol="PWRVCCGNDVEE" x="20.32" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="1Y0" pad="12"/>
 <connect gate="G$1" pin="1Y1" pad="13"/>
@@ -27323,7 +27323,7 @@ Philips Semiconductor</description>
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1Y0" pad="12"/>
 <connect gate="G$1" pin="1Y1" pad="13"/>
@@ -27356,7 +27356,7 @@ Philips Semiconductor</description>
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="13"/>
 <connect gate="A" pin="CP" pad="1"/>
@@ -27378,7 +27378,7 @@ Philips Semiconductor</description>
 <technology name="T"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="13"/>
 <connect gate="A" pin="CP" pad="1"/>

--- a/74xx-little-us.lbr
+++ b/74xx-little-us.lbr
@@ -261,7 +261,7 @@ Source: http://focus.ti.com/lit/ds/symlink/sn74lvc1g3157</description>
 <rectangle x1="-0.675" y1="-0.4" x2="-0.225" y2="-0.175" layer="51"/>
 <rectangle x1="-0.3" y1="-0.375" x2="-0.225" y2="-0.175" layer="21"/>
 </package>
-<package name="SSOP-65P-280W-295L-135H-60F-8">
+<package name="SSOP-8-65P-280W-295L-135H-60F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.60mm lead length, 3.0mm length, 2.8mm width, 1.35mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.60mm lead length 3.0mm length, 2.8mm width, 1.35mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation DA, LSR-PDSO.&lt;/p&gt;
@@ -294,7 +294,7 @@ JEDEC MO-187F, variation DA, LSR-PDSO.&lt;/p&gt;
 <wire x1="1.45" y1="-1.375" x2="-1.45" y2="-1.375" width="0.0508" layer="51"/>
 <wire x1="1.45" y1="1.375" x2="-1.45" y2="1.375" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-50P-230W-200L-100H-40F-8">
+<package name="SSOP-8-50P-230W-200L-100H-40F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.40mm lead length, 2.0mm length, 2.3mm width, 1.00mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.50mm pitch, 0.40mm lead length 2.0mm length, 2.3mm width, 1.00mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation CA, VSR-PDSO.&lt;/p&gt;
@@ -1142,7 +1142,7 @@ Source: http://focus.ti.com/lit/ds/symlink/sn74lvc1g66.pdf</description>
 <gate name="P" symbol="PWRN" x="15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="DCT" package="SSOP-65P-280W-295L-135H-60F-8">
+<device name="DCT" package="SSOP-8-65P-280W-295L-135H-60F">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="6"/>
@@ -1267,7 +1267,7 @@ Source: http://focus.ti.com/lit/ds/symlink/sn74lvc2g79.pdf</description>
 <gate name="B" symbol="7479" x="0" y="-10.16"/>
 </gates>
 <devices>
-<device name="DCT" package="SSOP-65P-280W-295L-135H-60F-8">
+<device name="DCT" package="SSOP-8-65P-280W-295L-135H-60F">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="D" pad="2"/>
@@ -1282,7 +1282,7 @@ Source: http://focus.ti.com/lit/ds/symlink/sn74lvc2g79.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DCU" package="SSOP-50P-230W-200L-100H-40F-8">
+<device name="DCU" package="SSOP-8-50P-230W-200L-100H-40F">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="D" pad="2"/>
@@ -1468,7 +1468,7 @@ Source: http://focus.ti.com/lit/ds/symlink/sn74lvc2g53.pdf</description>
 <gate name="P" symbol="PWRN2" x="17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="DCT" package="SSOP-65P-280W-295L-135H-60F-8">
+<device name="DCT" package="SSOP-8-65P-280W-295L-135H-60F">
 <connects>
 <connect gate="G$1" pin="A" pad="5"/>
 <connect gate="G$1" pin="COM" pad="1"/>
@@ -1483,7 +1483,7 @@ Source: http://focus.ti.com/lit/ds/symlink/sn74lvc2g53.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DCU" package="SSOP-50P-230W-200L-100H-40F-8">
+<device name="DCU" package="SSOP-8-50P-230W-200L-100H-40F">
 <connects>
 <connect gate="G$1" pin="A" pad="5"/>
 <connect gate="G$1" pin="COM" pad="1"/>

--- a/74xx-us.lbr
+++ b/74xx-us.lbr
@@ -82,7 +82,7 @@ Based on the following sources:
 &lt;/ul&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="PLCC-127P-896W-896L-457H-20">
+<package name="PLCC-20-127P-896W-896L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 8.97mm length, 8.97mm width, 4.57mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 8.97mm body length, 8.97mm body width, 4.57mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AA.&lt;/p&gt;
@@ -144,7 +144,7 @@ JEDEC MS-018A, variation AA.&lt;/p&gt;
 <wire x1="4.4831" y1="3.205" x2="4.4831" y2="4.4831" width="0.2032" layer="21"/>
 <wire x1="4.4831" y1="4.4831" x2="3.205" y2="4.4831" width="0.2032" layer="21"/>
 </package>
-<package name="LCC-127P-888W-888L-254H-20">
+<package name="LCC-20-127P-888W-888L-254H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 8.89mm length, 8.89mm width, 2.54mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 8.89mm body length, 8.89mm body width, 2.54mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CB.&lt;/p&gt;
@@ -225,7 +225,7 @@ Leadless chip carrier. 1.27mm pitch, 8.89mm body length, 8.89mm body width, 2.54
 <wire x1="4.545" y1="1.67" x2="4.545" y2="0.87" width="0.2032" layer="51" curve="180" cap="flat"/>
 <wire x1="4.545" y1="2.94" x2="4.545" y2="2.14" width="0.2032" layer="51" curve="180" cap="flat"/>
 </package>
-<package name="LCC-127P-1143W-1143L-254H-28">
+<package name="LCC-28-127P-1143W-1143L-254H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 11.43mm length, 11.43mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 11.43mm body length, 11.43mm body width, 2.54mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CC.&lt;/p&gt;
@@ -330,7 +330,7 @@ Leadless chip carrier. 1.27mm pitch, 11.43mm body length, 11.43mm body width, 2.
 <wire x1="5.815" y1="2.94" x2="5.815" y2="2.14" width="0.2032" layer="51" curve="180" cap="flat"/>
 <wire x1="5.815" y1="4.21" x2="5.815" y2="3.41" width="0.2032" layer="51" curve="180" cap="flat"/>
 </package>
-<package name="SSOP-065-530-14">
+<package name="SSOP-14-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 14 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 14 leads. JEDEC MO-150B. Variation AB.</description>
 <circle x="-1.935" y="-1.8988" radius="0.3175" width="0" layer="21"/>
@@ -369,7 +369,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 14 leads. JED
 <wire x1="2.5" y1="-2.6" x2="2.5" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="2.5" y1="2.6" x2="-2.5" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-16">
+<package name="SSOP-16-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 16 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 16 leads. JEDEC MO-150B. Variation AC.</description>
 <circle x="-2.235" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -412,7 +412,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 16 leads. JED
 <wire x1="3.15" y1="-2.6" x2="3.15" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.6" x2="-3.1" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-14">
+<package name="SSOP-14-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
@@ -453,7 +453,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-650L-120H-100F-20">
+<package name="SSOP-20-65P-440W-650L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
@@ -506,7 +506,7 @@ JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.15" y1="-2.1" x2="3.15" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.1" x2="-3.15" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-16">
+<package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -551,7 +551,7 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-780L-120H-100F-24">
+<package name="SSOP-24-65P-440W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
@@ -612,7 +612,7 @@ JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.1" x2="3.8" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.1" x2="-3.8" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-1250L-120H-100F-48">
+<package name="SSOP-48-50P-610W-1250L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 12.5mm length, 6.1mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 12.5mm length, 6.1mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation ED, R-PDSO-G.&lt;/p&gt;
@@ -721,7 +721,7 @@ JEDEC MO-153F, variation ED, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-2.95" x2="6.15" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="2.95" x2="-6.15" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -741,7 +741,7 @@ JEDEC MO-153F, variation ED, R-PDSO-G.&lt;/p&gt;
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -767,7 +767,7 @@ JEDEC MO-153F, variation ED, R-PDSO-G.&lt;/p&gt;
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -795,7 +795,7 @@ JEDEC MO-153F, variation ED, R-PDSO-G.&lt;/p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -827,7 +827,7 @@ JEDEC MO-153F, variation ED, R-PDSO-G.&lt;/p&gt;
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-48">
+<package name="DIP-48-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-29.845" y1="-5.715" x2="29.845" y2="-5.715" width="0.2032" layer="21"/>
@@ -887,7 +887,7 @@ JEDEC MO-153F, variation ED, R-PDSO-G.&lt;/p&gt;
 <text x="-30.48" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -927,7 +927,7 @@ JEDEC MO-153F, variation ED, R-PDSO-G.&lt;/p&gt;
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -963,7 +963,7 @@ JEDEC MO-153F, variation ED, R-PDSO-G.&lt;/p&gt;
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -1003,7 +1003,7 @@ JEDEC MO-153F, variation ED, R-PDSO-G.&lt;/p&gt;
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -1039,7 +1039,7 @@ JEDEC MO-153F, variation ED, R-PDSO-G.&lt;/p&gt;
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -1085,7 +1085,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -1142,7 +1142,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -1207,7 +1207,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -1257,7 +1257,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-530W-1030L-210H-125F-16">
+<package name="SOP-16-127P-530W-1030L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -1306,7 +1306,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="5.125" y1="-2.625" x2="-5.125" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="2.625" x2="-5.125" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-065-530-24">
+<package name="SSOP-24-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 24 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JEDEC MO-150B. Variation AG.</description>
 <circle x="-3.535" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -1365,7 +1365,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <wire x1="4.45" y1="-2.6" x2="4.45" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="4.45" y1="2.6" x2="-4.4" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-530W-1280L-210H-125F-20">
+<package name="SOP-20-127P-530W-1280L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 12.80mm length, 5.30mm width, 2.10mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 12.80mm length, 5.30mm width, 2.10mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -1422,7 +1422,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="6.375" y1="-2.625" x2="-6.375" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="2.625" x2="-6.375" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-065-530-20">
+<package name="SSOP-20-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 20 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JEDEC MO-150B. Variation AE.</description>
 <circle x="-2.885" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -9541,7 +9541,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -9567,7 +9567,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -9593,7 +9593,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -9616,7 +9616,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -9652,7 +9652,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -9676,7 +9676,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -9700,7 +9700,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -9738,7 +9738,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -9761,7 +9761,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LVC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -9784,7 +9784,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LVC"/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -9815,7 +9815,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -9838,7 +9838,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -9861,7 +9861,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="19"/>
 <connect gate="A" pin="B" pad="18"/>
@@ -9893,7 +9893,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -9916,7 +9916,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -9948,7 +9948,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -9980,7 +9980,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -10012,7 +10012,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -10042,7 +10042,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!1X!" pad="12"/>
 <connect gate="A" pin="1A" pad="1"/>
@@ -10072,7 +10072,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="1A" pad="1"/>
 <connect gate="A" pin="1B" pad="12"/>
@@ -10093,7 +10093,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="1A" pad="1"/>
 <connect gate="A" pin="1B" pad="12"/>
@@ -10114,7 +10114,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="PLCC-127P-896W-896L-457H-20">
+<device name="FK" package="PLCC-20-127P-896W-896L-457H">
 <connects>
 <connect gate="A" pin="1A" pad="2"/>
 <connect gate="A" pin="1B" pad="18"/>
@@ -10144,7 +10144,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -10164,7 +10164,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -10184,7 +10184,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -10213,7 +10213,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -10240,7 +10240,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="CKA" pad="5"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -10269,7 +10269,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -10299,7 +10299,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="11"/>
@@ -10320,7 +10320,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="11"/>
@@ -10341,7 +10341,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -10371,7 +10371,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1CLKA" pad="1"/>
 <connect gate="A" pin="1CLKB" pad="15"/>
@@ -10402,7 +10402,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -10431,7 +10431,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -10461,7 +10461,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="13"/>
 <connect gate="A" pin="CL" pad="2"/>
@@ -10482,7 +10482,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="13"/>
 <connect gate="A" pin="CL" pad="2"/>
@@ -10513,7 +10513,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="CLK" pad="3"/>
@@ -10535,7 +10535,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="CLK" pad="3"/>
@@ -10557,7 +10557,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!Q!" pad="9"/>
 <connect gate="A" pin="CLK" pad="4"/>
@@ -10588,7 +10588,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q1!" pad="1"/>
 <connect gate="A" pin="!Q2!" pad="14"/>
@@ -10612,7 +10612,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q1!" pad="1"/>
 <connect gate="A" pin="!Q2!" pad="14"/>
@@ -10646,7 +10646,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="14"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -10669,7 +10669,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="14"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -10701,7 +10701,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="12C" pad="12"/>
 <connect gate="A" pin="1D" pad="1"/>
@@ -10729,7 +10729,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q1!" pad="12"/>
 <connect gate="A" pin="!Q2!" pad="9"/>
@@ -10759,7 +10759,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="14"/>
@@ -10785,7 +10785,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="10"/>
 <connect gate="A" pin="A2" pad="8"/>
@@ -10818,7 +10818,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="10"/>
 <connect gate="A" pin="A1" pad="12"/>
@@ -10843,7 +10843,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="10"/>
 <connect gate="A" pin="A1" pad="12"/>
@@ -10867,7 +10867,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A0" pad="13"/>
 <connect gate="A" pin="A1" pad="15"/>
@@ -10900,7 +10900,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -10920,7 +10920,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -10949,7 +10949,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="14"/>
 <connect gate="A" pin="A" pad="12"/>
@@ -10972,7 +10972,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -10989,7 +10989,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -11015,7 +11015,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -11032,7 +11032,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -11058,7 +11058,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -11089,7 +11089,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -11112,7 +11112,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -11144,7 +11144,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="B0" pad="4"/>
 <connect gate="A" pin="B1" pad="1"/>
@@ -11167,7 +11167,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B0" pad="4"/>
 <connect gate="A" pin="B1" pad="1"/>
@@ -11200,7 +11200,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="D1" pad="2"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -11237,7 +11237,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="2"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -11259,7 +11259,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="2"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -11291,7 +11291,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="7"/>
 <connect gate="A" pin="CLK" pad="4"/>
@@ -11314,7 +11314,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="7"/>
 <connect gate="A" pin="CLK" pad="4"/>
@@ -11337,7 +11337,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!Q!" pad="9"/>
 <connect gate="A" pin="CLK" pad="5"/>
@@ -11370,7 +11370,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="CLK" pad="5"/>
@@ -11403,7 +11403,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -11427,7 +11427,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -11451,7 +11451,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!Q!" pad="8"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -11485,7 +11485,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -11516,7 +11516,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="G$1" symbol="7478" x="20.32" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="!Q1!" pad="6"/>
 <connect gate="G$1" pin="!Q2!" pad="8"/>
@@ -11548,7 +11548,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLR" pad="1"/>
 <connect gate="A" pin="D1" pad="4"/>
@@ -11589,7 +11589,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Y!" pad="7"/>
 <connect gate="A" pin="C" pad="5"/>
@@ -11621,7 +11621,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="1"/>
 <connect gate="A" pin="A1" pad="3"/>
@@ -11638,7 +11638,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="1"/>
 <connect gate="A" pin="A1" pad="3"/>
@@ -11664,7 +11664,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -11683,7 +11683,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -11712,7 +11712,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="4"/>
 <connect gate="A" pin="A" pad="1"/>
@@ -11736,7 +11736,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="4"/>
 <connect gate="A" pin="A" pad="1"/>
@@ -11760,7 +11760,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!Q!" pad="5"/>
 <connect gate="A" pin="A" pad="2"/>
@@ -11794,7 +11794,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CX@1" pad="4"/>
 <connect gate="A" pin="CX@2" pad="5"/>
@@ -11817,7 +11817,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CX@1" pad="4"/>
 <connect gate="A" pin="CX@2" pad="5"/>
@@ -11840,7 +11840,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="CX@1" pad="5"/>
 <connect gate="A" pin="CX@2" pad="7"/>
@@ -11872,7 +11872,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -11904,7 +11904,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -11927,7 +11927,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -11950,7 +11950,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -11982,7 +11982,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -12006,7 +12006,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -12030,7 +12030,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -12054,7 +12054,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -12078,7 +12078,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="AHC"/>
 </technologies>
 </device>
-<device name="DB" package="SSOP-065-530-16">
+<device name="DB" package="SSOP-16-65P-530W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -12101,7 +12101,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="SOP-127P-530W-1030L-210H-125F-16">
+<device name="NS" package="SOP-16-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -12134,7 +12134,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -12161,7 +12161,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -12188,7 +12188,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -12222,7 +12222,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="16"/>
@@ -12262,7 +12262,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -12286,7 +12286,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -12310,7 +12310,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="0" pad="2"/>
 <connect gate="A" pin="1" pad="3"/>
@@ -12343,7 +12343,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1" pad="11"/>
 <connect gate="A" pin="2" pad="12"/>
@@ -12374,7 +12374,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="11"/>
@@ -12398,7 +12398,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="11"/>
@@ -12422,7 +12422,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="0" pad="13"/>
 <connect gate="A" pin="1" pad="14"/>
@@ -12455,7 +12455,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -12495,7 +12495,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -12520,7 +12520,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -12545,7 +12545,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="14"/>
 <connect gate="A" pin="B" pad="13"/>
@@ -12579,7 +12579,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -12609,7 +12609,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -12633,7 +12633,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -12657,7 +12657,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1C0" pad="8"/>
 <connect gate="A" pin="1C1" pad="7"/>
@@ -12690,7 +12690,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -12721,7 +12721,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -12761,7 +12761,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C" pad="1"/>
 <connect gate="A" pin="1G" pad="2"/>
@@ -12785,7 +12785,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C" pad="1"/>
 <connect gate="A" pin="1G" pad="2"/>
@@ -12809,7 +12809,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1C" pad="2"/>
 <connect gate="A" pin="1G" pad="3"/>
@@ -12842,7 +12842,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C" pad="1"/>
 <connect gate="A" pin="1G" pad="2"/>
@@ -12866,7 +12866,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C" pad="1"/>
 <connect gate="A" pin="1G" pad="2"/>
@@ -12890,7 +12890,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1C" pad="2"/>
 <connect gate="A" pin="1G" pad="3"/>
@@ -12922,7 +12922,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -12947,7 +12947,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -12972,7 +12972,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!A!/B" pad="2"/>
 <connect gate="A" pin="1A" pad="3"/>
@@ -13005,7 +13005,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -13030,7 +13030,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -13054,7 +13054,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!A!/B" pad="2"/>
 <connect gate="A" pin="1A" pad="3"/>
@@ -13087,7 +13087,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -13127,7 +13127,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -13159,7 +13159,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -13181,7 +13181,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -13203,7 +13203,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -13234,7 +13234,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="7"/>
 <connect gate="A" pin="A" pad="11"/>
@@ -13258,7 +13258,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="7"/>
 <connect gate="A" pin="A" pad="11"/>
@@ -13281,7 +13281,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="A" pad="14"/>
@@ -13313,7 +13313,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -13337,7 +13337,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -13361,7 +13361,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -13393,7 +13393,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="B0" pad="14"/>
 <connect gate="A" pin="B1" pad="15"/>
@@ -13424,7 +13424,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -13456,7 +13456,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D1" pad="15"/>
 <connect gate="A" pin="D2" pad="1"/>
@@ -13480,7 +13480,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="15"/>
 <connect gate="A" pin="D2" pad="1"/>
@@ -13504,7 +13504,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="D1" pad="19"/>
 <connect gate="A" pin="D2" pad="2"/>
@@ -13536,7 +13536,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q1!" pad="1"/>
 <connect gate="A" pin="!Q2!" pad="2"/>
@@ -13568,7 +13568,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="CLR" pad="15"/>
@@ -13591,7 +13591,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="CLR" pad="15"/>
@@ -13614,7 +13614,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="CLR" pad="19"/>
@@ -13646,7 +13646,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -13671,7 +13671,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -13696,7 +13696,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="CLK" pad="12"/>
 <connect gate="A" pin="CLR" pad="2"/>
@@ -13730,7 +13730,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q1!" pad="3"/>
 <connect gate="A" pin="!Q2!" pad="6"/>
@@ -13755,7 +13755,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q1!" pad="3"/>
 <connect gate="A" pin="!Q2!" pad="6"/>
@@ -13780,7 +13780,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!Q1!" pad="4"/>
 <connect gate="A" pin="!Q2!" pad="8"/>
@@ -13813,7 +13813,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="4"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -13843,7 +13843,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -13873,7 +13873,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QD!" pad="12"/>
 <connect gate="A" pin="A" pad="3"/>
@@ -13905,7 +13905,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="8"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -13935,7 +13935,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="2"/>
 <connect gate="A" pin="A1" pad="23"/>
@@ -13967,7 +13967,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="2"/>
 <connect gate="A" pin="A1" pad="23"/>
@@ -13999,7 +13999,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-1143W-1143L-254H-28">
+<device name="FK" package="LCC-28-127P-1143W-1143L-254H">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="27"/>
@@ -14040,7 +14040,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CN" pad="13"/>
 <connect gate="A" pin="CN+X" pad="12"/>
@@ -14063,7 +14063,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CN" pad="13"/>
 <connect gate="A" pin="CN+X" pad="12"/>
@@ -14086,7 +14086,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="CN" pad="17"/>
 <connect gate="A" pin="CN+X" pad="15"/>
@@ -14119,7 +14119,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -14138,7 +14138,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -14166,7 +14166,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -14198,7 +14198,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -14231,7 +14231,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -14264,7 +14264,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -14288,7 +14288,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -14312,7 +14312,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="4"/>
 <connect gate="A" pin="B" pad="5"/>
@@ -14345,7 +14345,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QD!" pad="11"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -14369,7 +14369,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QD!" pad="11"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -14393,7 +14393,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QD!" pad="14"/>
 <connect gate="A" pin="A" pad="5"/>
@@ -14426,7 +14426,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="5"/>
@@ -14466,7 +14466,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="5"/>
@@ -14507,7 +14507,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14535,7 +14535,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14564,7 +14564,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14592,7 +14592,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="PW" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14630,7 +14630,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="B" symbol="74241A" x="20.32" y="-15.24"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14658,7 +14658,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14686,7 +14686,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14723,7 +14723,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14752,7 +14752,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14780,7 +14780,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14808,7 +14808,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14836,7 +14836,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="PW" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14873,7 +14873,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -14900,7 +14900,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -14927,7 +14927,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -14954,7 +14954,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="PW" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -14990,7 +14990,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -15030,7 +15030,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -15054,7 +15054,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -15078,7 +15078,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="14"/>
 <connect gate="A" pin="B" pad="13"/>
@@ -15111,7 +15111,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -15135,7 +15135,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -15159,7 +15159,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1C0" pad="8"/>
 <connect gate="A" pin="1C1" pad="7"/>
@@ -15191,7 +15191,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -15215,7 +15215,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -15239,7 +15239,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!A!/B" pad="2"/>
 <connect gate="A" pin="1A" pad="3"/>
@@ -15263,7 +15263,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -15286,7 +15286,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="SSOP-065-530-16">
+<device name="NS" package="SSOP-16-65P-530W">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -15318,7 +15318,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -15342,7 +15342,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -15366,7 +15366,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!A!/B" pad="2"/>
 <connect gate="A" pin="1A" pad="3"/>
@@ -15399,7 +15399,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="13"/>
 <connect gate="A" pin="LE" pad="14"/>
@@ -15425,7 +15425,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="13"/>
 <connect gate="A" pin="LE" pad="14"/>
@@ -15459,7 +15459,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="B0" pad="13"/>
 <connect gate="A" pin="B1" pad="14"/>
@@ -15491,7 +15491,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -15518,7 +15518,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -15545,7 +15545,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -15581,7 +15581,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1CK" pad="3"/>
 <connect gate="A" pin="1J" pad="2"/>
@@ -15617,7 +15617,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="D1" pad="12"/>
 <connect gate="A" pin="D2" pad="13"/>
@@ -15649,7 +15649,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="Q" pad="4"/>
 <connect gate="A" pin="R" pad="1"/>
@@ -15673,7 +15673,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="Q" pad="4"/>
 <connect gate="A" pin="R" pad="1"/>
@@ -15697,7 +15697,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="Q" pad="5"/>
 <connect gate="A" pin="R" pad="2"/>
@@ -15729,7 +15729,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="8"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -15750,7 +15750,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="8"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -15771,7 +15771,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="12"/>
 <connect gate="A" pin="B" pad="13"/>
@@ -15801,7 +15801,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="5"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -15825,7 +15825,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="5"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -15848,7 +15848,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="7"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -15881,7 +15881,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1A" pad="5"/>
 <connect gate="A" pin="1B" pad="6"/>
@@ -15913,7 +15913,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1A" pad="5"/>
 <connect gate="A" pin="1B" pad="6"/>
@@ -15945,7 +15945,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="8"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -15975,7 +15975,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -16003,7 +16003,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -16024,7 +16024,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -16054,7 +16054,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -16071,7 +16071,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -16097,7 +16097,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -16115,7 +16115,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -16142,7 +16142,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -16172,7 +16172,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="2"/>
@@ -16195,7 +16195,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="2"/>
@@ -16218,7 +16218,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -16250,7 +16250,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!QA!" pad="8"/>
 <connect gate="A" pin="!QH!" pad="17"/>
@@ -16278,7 +16278,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!QA!" pad="8"/>
 <connect gate="A" pin="!QH!" pad="17"/>
@@ -16306,7 +16306,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QA!" pad="8"/>
 <connect gate="A" pin="!QH!" pad="17"/>
@@ -16343,7 +16343,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!F!" pad="12"/>
 <connect gate="A" pin="!F*!" pad="9"/>
@@ -16371,7 +16371,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!F!" pad="12"/>
 <connect gate="A" pin="!F*!" pad="9"/>
@@ -16401,7 +16401,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="12"/>
 <connect gate="A" pin="A/QA" pad="4"/>
@@ -16437,7 +16437,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="11"/>
@@ -16460,7 +16460,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="11"/>
@@ -16483,7 +16483,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="0" pad="13"/>
 <connect gate="A" pin="1" pad="14"/>
@@ -16515,7 +16515,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -16538,7 +16538,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -16570,7 +16570,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -16602,7 +16602,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="D0" pad="8"/>
 <connect gate="A" pin="D1" pad="7"/>
@@ -16638,7 +16638,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="D0" pad="8"/>
 <connect gate="A" pin="D1" pad="7"/>
@@ -16674,7 +16674,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="D0" pad="8"/>
@@ -16710,7 +16710,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="D0" pad="8"/>
@@ -16746,7 +16746,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -16769,7 +16769,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -16792,7 +16792,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -16824,7 +16824,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -16847,7 +16847,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -16870,7 +16870,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -16902,7 +16902,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1A1" pad="2"/>
 <connect gate="A" pin="1A2" pad="4"/>
@@ -16925,7 +16925,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1A1" pad="2"/>
 <connect gate="A" pin="1A2" pad="4"/>
@@ -16948,7 +16948,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1A1" pad="3"/>
 <connect gate="A" pin="1A2" pad="5"/>
@@ -16980,7 +16980,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1A1" pad="2"/>
 <connect gate="A" pin="1A2" pad="4"/>
@@ -17003,7 +17003,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1A1" pad="2"/>
 <connect gate="A" pin="1A2" pad="4"/>
@@ -17026,7 +17026,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1A1" pad="3"/>
 <connect gate="A" pin="1A2" pad="5"/>
@@ -17058,7 +17058,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17088,7 +17088,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17119,7 +17119,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17147,7 +17147,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="PW" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17178,7 +17178,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DB" package="SSOP-065-530-20">
+<device name="DB" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17205,7 +17205,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="SOP-127P-530W-1280L-210H-125F-20">
+<device name="NS" package="SOP-20-127P-530W-1280L-210H-125F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17241,7 +17241,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17269,7 +17269,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17297,7 +17297,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17334,7 +17334,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!1Q!" pad="2"/>
 <connect gate="A" pin="!2Q!" pad="6"/>
@@ -17357,7 +17357,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!1Q!" pad="2"/>
 <connect gate="A" pin="!2Q!" pad="6"/>
@@ -17380,7 +17380,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!1Q!" pad="4"/>
 <connect gate="A" pin="!2Q!" pad="8"/>
@@ -17412,7 +17412,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1J" pad="2"/>
 <connect gate="A" pin="1K" pad="3"/>
@@ -17435,7 +17435,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1J" pad="2"/>
 <connect gate="A" pin="1K" pad="3"/>
@@ -17467,7 +17467,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17494,7 +17494,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17521,7 +17521,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17557,7 +17557,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17580,7 +17580,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17603,7 +17603,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1D" pad="4"/>
 <connect gate="A" pin="1Q" pad="3"/>
@@ -17635,7 +17635,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!1Q!" pad="3"/>
 <connect gate="A" pin="!2Q!" pad="6"/>
@@ -17658,7 +17658,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!1Q!" pad="3"/>
 <connect gate="A" pin="!2Q!" pad="6"/>
@@ -17681,7 +17681,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!1Q!" pad="4"/>
 <connect gate="A" pin="!2Q!" pad="8"/>
@@ -17713,7 +17713,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17741,7 +17741,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17769,7 +17769,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17805,7 +17805,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17832,7 +17832,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17868,7 +17868,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -17900,7 +17900,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1A" pad="5"/>
 <connect gate="A" pin="1B" pad="4"/>
@@ -17937,7 +17937,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -17960,7 +17960,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -17983,7 +17983,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="5"/>
@@ -18016,7 +18016,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="CLR" pad="2"/>
@@ -18039,7 +18039,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="CLR" pad="2"/>
@@ -18062,7 +18062,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="CLR" pad="3"/>
@@ -18083,7 +18083,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="CLR" pad="2"/>
@@ -18115,7 +18115,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QD!" pad="11"/>
 <connect gate="A" pin="A" pad="3"/>
@@ -18138,7 +18138,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QD!" pad="11"/>
 <connect gate="A" pin="A" pad="3"/>
@@ -18161,7 +18161,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QD!" pad="14"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -18193,7 +18193,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1Q1" pad="2"/>
 <connect gate="A" pin="1Q2" pad="5"/>
@@ -18216,7 +18216,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1Q1" pad="2"/>
 <connect gate="A" pin="1Q2" pad="5"/>
@@ -18239,7 +18239,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1Q1" pad="3"/>
 <connect gate="A" pin="1Q2" pad="7"/>
@@ -18271,7 +18271,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!QA!" pad="3"/>
 <connect gate="A" pin="!QB!" pad="8"/>
@@ -18307,7 +18307,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18330,7 +18330,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18353,7 +18353,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -18385,7 +18385,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLR" pad="14"/>
 <connect gate="A" pin="DI1" pad="3"/>
@@ -18425,7 +18425,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -18453,7 +18453,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18489,7 +18489,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -18521,7 +18521,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18553,7 +18553,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18585,7 +18585,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18621,7 +18621,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18648,7 +18648,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18685,7 +18685,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18722,7 +18722,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18759,7 +18759,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="CLR" pad="2"/>
@@ -18791,7 +18791,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18818,7 +18818,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18854,7 +18854,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18881,7 +18881,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18917,7 +18917,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18944,7 +18944,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18980,7 +18980,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -19016,7 +19016,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -19052,7 +19052,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-2.54" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -19071,7 +19071,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -19090,7 +19090,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="6"/>
@@ -19123,7 +19123,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -19145,7 +19145,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -19167,7 +19167,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -19197,7 +19197,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CN!" pad="13"/>
 <connect gate="A" pin="CN+X" pad="15"/>
@@ -19236,7 +19236,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="2.54" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19265,7 +19265,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19292,7 +19292,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19329,7 +19329,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19350,7 +19350,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19371,7 +19371,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="3"/>
 <connect gate="A" pin="I1" pad="4"/>
@@ -19404,7 +19404,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19429,7 +19429,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19454,7 +19454,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="3"/>
 <connect gate="A" pin="I1" pad="4"/>
@@ -19491,7 +19491,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19514,7 +19514,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19537,7 +19537,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19572,7 +19572,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="2.54" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19596,7 +19596,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19620,7 +19620,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19644,7 +19644,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19677,7 +19677,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19700,7 +19700,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19723,7 +19723,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19755,7 +19755,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19780,7 +19780,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19805,7 +19805,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19841,7 +19841,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19865,7 +19865,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19889,7 +19889,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19924,7 +19924,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19956,7 +19956,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19987,7 +19987,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20018,7 +20018,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="2.54" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20039,7 +20039,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20060,7 +20060,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20091,7 +20091,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20122,7 +20122,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="G" pad="3"/>
 <connect gate="A" pin="I0" pad="1"/>
@@ -20143,7 +20143,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="G" pad="3"/>
 <connect gate="A" pin="I0" pad="1"/>
@@ -20175,7 +20175,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="0" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20198,7 +20198,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20221,7 +20221,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20253,7 +20253,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20275,7 +20275,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20297,7 +20297,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20330,7 +20330,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20353,7 +20353,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20376,7 +20376,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20411,7 +20411,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20432,7 +20432,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20453,7 +20453,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="3"/>
 <connect gate="A" pin="I1" pad="4"/>
@@ -20486,7 +20486,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20516,7 +20516,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="11"/>
@@ -20549,7 +20549,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20573,7 +20573,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20596,7 +20596,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20619,7 +20619,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20652,7 +20652,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -20674,7 +20674,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -20695,7 +20695,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="4"/>
@@ -20725,7 +20725,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20748,7 +20748,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20771,7 +20771,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20803,7 +20803,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20836,7 +20836,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1A" pad="1"/>
 <connect gate="A" pin="1B" pad="2"/>
@@ -20859,7 +20859,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1A" pad="1"/>
 <connect gate="A" pin="1B" pad="2"/>
@@ -20882,7 +20882,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="1A" pad="2"/>
 <connect gate="A" pin="1B" pad="3"/>
@@ -20917,7 +20917,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20938,7 +20938,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="DIP-300-14">
+<device name="D" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20959,7 +20959,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20990,7 +20990,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21011,7 +21011,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21032,7 +21032,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -21065,7 +21065,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21086,7 +21086,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21107,7 +21107,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -21140,7 +21140,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21175,7 +21175,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-17.78" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="13"/>
 <connect gate="A" pin="O" pad="12"/>
@@ -21199,7 +21199,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="13"/>
 <connect gate="A" pin="O" pad="12"/>
@@ -21223,7 +21223,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -21245,7 +21245,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DT" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="DT" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="I" pad="13"/>
 <connect gate="A" pin="O" pad="12"/>
@@ -21279,7 +21279,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="2.54" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21300,7 +21300,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21321,7 +21321,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -21354,7 +21354,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21380,7 +21380,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21406,7 +21406,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -21430,7 +21430,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21453,7 +21453,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="DB" package="SSOP-065-530-14">
+<device name="DB" package="SSOP-14-65P-530W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21485,7 +21485,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21521,7 +21521,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G1" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21557,7 +21557,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G1" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21593,7 +21593,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21629,7 +21629,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21665,7 +21665,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="G1" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21697,7 +21697,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21724,7 +21724,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21751,7 +21751,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21787,7 +21787,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21814,7 +21814,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21841,7 +21841,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21877,7 +21877,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="ACL" pad="8"/>
@@ -21913,7 +21913,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="ACLR" pad="8"/>
@@ -21949,7 +21949,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="A" pad="15"/>
@@ -21981,7 +21981,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CCKEN" pad="12"/>
 <connect gate="A" pin="CCLR" pad="10"/>
@@ -22004,7 +22004,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CCKEN" pad="12"/>
 <connect gate="A" pin="CCLR" pad="10"/>
@@ -22027,7 +22027,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="CCKEN" pad="15"/>
 <connect gate="A" pin="CCLR" pad="13"/>
@@ -22059,7 +22059,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CCKEN" pad="12"/>
 <connect gate="A" pin="CCLR" pad="10"/>
@@ -22091,7 +22091,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -22114,7 +22114,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -22137,7 +22137,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="19"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -22169,7 +22169,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CCKEN!" pad="14"/>
 <connect gate="A" pin="!G!" pad="18"/>
@@ -22196,7 +22196,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!CCKEN!" pad="14"/>
 <connect gate="A" pin="!G!" pad="18"/>
@@ -22223,7 +22223,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!CCKEN!" pad="14"/>
 <connect gate="A" pin="!G!" pad="18"/>
@@ -22259,7 +22259,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="QA" pad="15"/>
@@ -22282,7 +22282,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="QA" pad="15"/>
@@ -22314,7 +22314,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="G" pad="13"/>
@@ -22337,7 +22337,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="G" pad="13"/>
@@ -22360,7 +22360,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QH!" pad="12"/>
 <connect gate="A" pin="G" pad="17"/>
@@ -22392,7 +22392,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="G" pad="13"/>
@@ -22415,7 +22415,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="G" pad="13"/>
@@ -22447,7 +22447,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="A" pad="15"/>
@@ -22470,7 +22470,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="A" pad="15"/>
@@ -22493,7 +22493,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QH!" pad="12"/>
 <connect gate="A" pin="A" pad="19"/>
@@ -22525,7 +22525,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="11"/>
 <connect gate="A" pin="A/QA" pad="1"/>
@@ -22552,7 +22552,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="11"/>
 <connect gate="A" pin="A/QA" pad="1"/>
@@ -22579,7 +22579,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="!QH!" pad="11"/>
 <connect gate="A" pin="A/QA" pad="1"/>
@@ -22615,7 +22615,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="QA" pad="15"/>
@@ -22638,7 +22638,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="QA" pad="15"/>
@@ -22670,7 +22670,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="A/!B!" pad="2"/>
 <connect gate="A" pin="A1" pad="3"/>
@@ -22714,7 +22714,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="A/!B!" pad="2"/>
 <connect gate="A" pin="A1" pad="3"/>
@@ -22758,7 +22758,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CAS!" pad="9"/>
 <connect gate="A" pin="!RAS!" pad="7"/>
@@ -22790,7 +22790,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -22826,7 +22826,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -22862,7 +22862,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -22903,7 +22903,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -22935,7 +22935,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D1" pad="15"/>
 <connect gate="A" pin="D2" pad="1"/>
@@ -22958,7 +22958,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="15"/>
 <connect gate="A" pin="D2" pad="1"/>
@@ -22981,7 +22981,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="D1" pad="19"/>
 <connect gate="A" pin="D2" pad="2"/>
@@ -23013,7 +23013,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -23049,7 +23049,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CS" pad="1"/>
 <connect gate="A" pin="M/SCLK" pad="5"/>
@@ -23080,7 +23080,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="CS" pad="1"/>
 <connect gate="A" pin="M/SCLK" pad="5"/>
@@ -23111,7 +23111,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-1143W-1143L-254H-28">
+<device name="FK" package="LCC-28-127P-1143W-1143L-254H">
 <connects>
 <connect gate="A" pin="CS" pad="2"/>
 <connect gate="A" pin="M/SCLK" pad="6"/>
@@ -23151,7 +23151,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="2"/>
 <connect gate="A" pin="CS" pad="1"/>
@@ -23181,7 +23181,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="2"/>
 <connect gate="A" pin="CS" pad="1"/>
@@ -23211,7 +23211,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-1143W-1143L-254H-28">
+<device name="FK" package="LCC-28-127P-1143W-1143L-254H">
 <connects>
 <connect gate="A" pin="CLK" pad="3"/>
 <connect gate="A" pin="CS" pad="2"/>
@@ -23250,7 +23250,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A10" pad="10"/>
@@ -23290,7 +23290,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A10" pad="11"/>
@@ -23326,7 +23326,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A10" pad="11"/>
@@ -23362,7 +23362,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="AS0" pad="18"/>
 <connect gate="A" pin="AS1" pad="17"/>
@@ -23398,7 +23398,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="P0" pad="2"/>
 <connect gate="A" pin="P1" pad="4"/>
@@ -23425,7 +23425,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="P0" pad="2"/>
 <connect gate="A" pin="P1" pad="4"/>
@@ -23452,7 +23452,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="P0" pad="2"/>
 <connect gate="A" pin="P1" pad="4"/>
@@ -23488,7 +23488,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="P0" pad="2"/>
 <connect gate="A" pin="P1" pad="4"/>
@@ -23524,7 +23524,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="G1" pad="2"/>
 <connect gate="A" pin="G2" pad="23"/>
@@ -23553,7 +23553,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="G1" pad="2"/>
 <connect gate="A" pin="G2" pad="23"/>
@@ -23582,7 +23582,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-1143W-1143L-254H-28">
+<device name="FK" package="LCC-28-127P-1143W-1143L-254H">
 <connects>
 <connect gate="A" pin="G1" pad="3"/>
 <connect gate="A" pin="G2" pad="27"/>
@@ -23620,7 +23620,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="G1" pad="2"/>
 <connect gate="A" pin="G2" pad="23"/>
@@ -23658,7 +23658,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -23685,7 +23685,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -23712,7 +23712,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -23748,7 +23748,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -23784,7 +23784,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -23820,7 +23820,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -23856,7 +23856,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -23892,7 +23892,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -23929,7 +23929,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -23966,7 +23966,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -24003,7 +24003,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -24044,7 +24044,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -24086,7 +24086,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -24128,7 +24128,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -24168,7 +24168,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -24203,7 +24203,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -24240,7 +24240,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="12"/>
 <connect gate="A" pin="D0" pad="8"/>
@@ -24284,7 +24284,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="D0" pad="8"/>
 <connect gate="A" pin="D1" pad="7"/>
@@ -24328,7 +24328,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -24368,7 +24368,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -24408,7 +24408,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1A" pad="2"/>
 <connect gate="A" pin="1B" pad="3"/>
@@ -24449,7 +24449,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="CLRQ" pad="27"/>
 <connect gate="A" pin="L/!A!" pad="2"/>
@@ -24493,7 +24493,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -24534,7 +24534,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="C" pad="23"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -24576,7 +24576,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="23"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -24618,7 +24618,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="23"/>
 <connect gate="A" pin="D1" pad="3"/>
@@ -24659,7 +24659,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="4"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -24700,7 +24700,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="23"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -24742,7 +24742,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="C" pad="23"/>
 <connect gate="A" pin="D1" pad="3"/>
@@ -24783,7 +24783,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CN" pad="1"/>
 <connect gate="A" pin="CN+16" pad="11"/>
@@ -24822,7 +24822,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="L/!A!" pad="1"/>
 <connect gate="A" pin="P0" pad="15"/>
@@ -24863,7 +24863,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -24900,7 +24900,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -24936,7 +24936,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -24972,7 +24972,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -24999,7 +24999,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -25026,7 +25026,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -25062,7 +25062,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -25098,7 +25098,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -25134,7 +25134,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25171,7 +25171,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25208,7 +25208,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25237,7 +25237,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25275,7 +25275,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="22"/>
@@ -25312,7 +25312,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25348,7 +25348,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="22"/>
@@ -25385,7 +25385,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25422,7 +25422,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="10D" pad="11"/>
 <connect gate="A" pin="10Q" pad="14"/>
@@ -25462,7 +25462,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="10D" pad="11"/>
 <connect gate="A" pin="10Q" pad="14"/>
@@ -25502,7 +25502,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="23"/>
@@ -25542,7 +25542,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="23"/>
@@ -25582,7 +25582,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="22"/>
@@ -25622,7 +25622,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-24">
+<device name="NT" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="22"/>
@@ -25662,7 +25662,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="2PWR4GND" x="-12.7" y="0"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-28">
+<device name="NT" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="10D" pad="16"/>
 <connect gate="A" pin="10Q" pad="14"/>
@@ -25707,7 +25707,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="2PWR4GND" x="-12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-28">
+<device name="NT" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="10D" pad="16"/>
 <connect gate="A" pin="10Q" pad="14"/>
@@ -25752,7 +25752,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="2PWR4GND" x="-12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-28">
+<device name="NT" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="27"/>
 <connect gate="A" pin="1Q" pad="1"/>
@@ -25797,7 +25797,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="2PWR4GND" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-28">
+<device name="NT" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="27"/>
 <connect gate="A" pin="1Q" pad="1"/>
@@ -25842,7 +25842,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="2PWR4GND" x="-12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-28">
+<device name="NT" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="26"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -25887,7 +25887,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="2PWR4GND" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-600-28">
+<device name="NT" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="1D" pad="26"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -25933,7 +25933,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="PO" symbol="PWRN" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="8"/>
 <connect gate="A" pin="EN" pad="5"/>
@@ -25951,7 +25951,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="8"/>
 <connect gate="A" pin="EN" pad="5"/>
@@ -25979,7 +25979,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -26001,7 +26001,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -26023,7 +26023,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -26057,7 +26057,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-7.62" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -26078,7 +26078,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -26111,7 +26111,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -26135,7 +26135,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -26159,7 +26159,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -26192,7 +26192,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="2PWR3GND" x="-27.94" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="11"/>
 <connect gate="G$1" pin="CLR" pad="14"/>
@@ -26224,7 +26224,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="2PWR3GND" x="-30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="11"/>
 <connect gate="G$1" pin="CLR" pad="14"/>
@@ -26256,7 +26256,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="A" symbol="74305" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="PRE" pad="10"/>
@@ -26289,7 +26289,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-7.62" y="-1.27" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!X!" pad="12"/>
 <connect gate="A" pin="A" pad="1"/>
@@ -26319,7 +26319,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!A!" pad="10"/>
 <connect gate="A" pin="!B!" pad="1"/>
@@ -26349,7 +26349,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="8"/>
 <connect gate="A" pin="CLR" pad="10"/>
@@ -26372,7 +26372,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="8"/>
 <connect gate="A" pin="CLR" pad="10"/>
@@ -26404,7 +26404,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="8"/>
 <connect gate="A" pin="CLK" pad="9"/>
@@ -26434,7 +26434,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="0" pad="16"/>
 <connect gate="A" pin="1" pad="15"/>
@@ -26466,7 +26466,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="9"/>
@@ -26489,7 +26489,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="9"/>
@@ -26521,7 +26521,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-8.89" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="1DA" pad="22"/>
 <connect gate="A" pin="1DB" pad="4"/>
@@ -26561,7 +26561,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -26584,7 +26584,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -26616,7 +26616,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="AN" pad="1"/>
 <connect gate="A" pin="AN1" pad="2"/>
@@ -26643,7 +26643,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="AN" pad="1"/>
 <connect gate="A" pin="AN1" pad="2"/>
@@ -26679,7 +26679,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="2N+0" pad="9"/>
 <connect gate="A" pin="2N+1" pad="11"/>
@@ -26702,7 +26702,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="2N+0" pad="9"/>
 <connect gate="A" pin="2N+1" pad="11"/>
@@ -26734,7 +26734,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="A" symbol="74428" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="BUSEN" pad="22"/>
 <connect gate="A" pin="D0" pad="15"/>
@@ -26778,7 +26778,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -26801,7 +26801,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -26833,7 +26833,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-27.94" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A1" pad="3"/>
 <connect gate="G$1" pin="A2" pad="4"/>
@@ -26873,7 +26873,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWR2GND" x="-35.56" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="JD" package="DIP-600-48">
+<device name="JD" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="A" pin="CB0" pad="28"/>
 <connect gate="A" pin="CB1" pad="27"/>
@@ -26937,7 +26937,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWR2GND" x="-35.56" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="JD" package="DIP-600-48">
+<device name="JD" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="A" pin="CB0" pad="28"/>
 <connect gate="A" pin="CB1" pad="27"/>
@@ -27001,7 +27001,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-33.02" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="NT" package="DIP-300-24">
+<device name="NT" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="1A0" pad="2"/>
 <connect gate="A" pin="1A1" pad="3"/>
@@ -27041,7 +27041,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-32.1818" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-28">
+<device name="N" package="DIP-28-254P-762W">
 <connects>
 <connect gate="A" pin="1A0" pad="4"/>
 <connect gate="A" pin="1A1" pad="5"/>
@@ -27090,7 +27090,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -27111,7 +27111,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -27146,7 +27146,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="F" symbol="7407" x="48.26" y="-25.4"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -27167,7 +27167,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -27202,7 +27202,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-17.78" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="13"/>
 <connect gate="A" pin="O" pad="12"/>
@@ -27223,7 +27223,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="13"/>
 <connect gate="A" pin="O" pad="12"/>
@@ -27253,7 +27253,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="G$1" symbol="74S51" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FK" package="LCC-127P-888W-888L-254H-20">
+<device name="FK" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="G$1" pin="1A" pad="2"/>
 <connect gate="G$1" pin="1B" pad="19"/>
@@ -27272,7 +27272,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="1A" pad="1"/>
 <connect gate="G$1" pin="1B" pad="13"/>
@@ -27291,7 +27291,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1A" pad="1"/>
 <connect gate="G$1" pin="1B" pad="13"/>
@@ -27320,7 +27320,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!Q!" pad="13"/>
 <connect gate="A" pin="CP" pad="1"/>
@@ -27342,7 +27342,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="T"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="13"/>
 <connect gate="A" pin="CP" pad="1"/>
@@ -27373,7 +27373,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN-1" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -27404,7 +27404,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -27443,7 +27443,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OEBA!" pad="21"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -27483,7 +27483,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-22.86" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="M" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="M" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="COM" pad="1"/>
 <connect gate="A" pin="E" pad="15"/>
@@ -27515,7 +27515,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="SM96" package="SSOP-065-530-24">
+<device name="SM96" package="SSOP-24-65P-530W">
 <connects>
 <connect gate="A" pin="COM" pad="1"/>
 <connect gate="A" pin="E" pad="15"/>
@@ -27555,7 +27555,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="G$1" symbol="7416245" x="-10.16" y="-12.7"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-610W-1250L-120H-100F-48">
+<device name="" package="SSOP-48-50P-610W-1250L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!1OE!" pad="48"/>
 <connect gate="G$1" pin="!2OE!" pad="25"/>
@@ -27619,7 +27619,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="G$1" symbol="74LVX3245" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-780L-120H-100F-24">
+<device name="" package="SSOP-24-65P-440W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!G!" pad="22"/>
 <connect gate="G$1" pin="A1" pad="3"/>
@@ -27663,7 +27663,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-5.08" y="-10.16"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -27689,7 +27689,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -27714,7 +27714,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DT" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="DT" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -27748,7 +27748,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="DIP-300-14">
+<device name="D" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>

--- a/751xx.lbr
+++ b/751xx.lbr
@@ -75,7 +75,7 @@
 
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -132,7 +132,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -197,7 +197,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -225,7 +225,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -257,7 +257,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -293,7 +293,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-22">
+<package name="DIP-22-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="-14.605" y1="-0.635" x2="-14.605" y2="-1.905" width="0.2032" layer="21"/>
@@ -327,7 +327,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <text x="-15.24" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.795" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -691,7 +691,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!G" pad="12"/>
 <connect gate="G$1" pin="1A" pad="1"/>
@@ -714,7 +714,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!G" pad="12"/>
 <connect gate="G$1" pin="1A" pad="1"/>
@@ -746,7 +746,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-25.4" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="1,2G" pad="4"/>
 <connect gate="G$1" pin="1A" pad="3"/>
@@ -769,7 +769,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1,2G" pad="4"/>
 <connect gate="G$1" pin="1A" pad="3"/>
@@ -801,7 +801,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="1A" pad="3"/>
 <connect gate="G$1" pin="1W" pad="2"/>
@@ -824,7 +824,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1A" pad="3"/>
 <connect gate="G$1" pin="1W" pad="2"/>
@@ -856,7 +856,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-20">
+<device name="P" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="B1" pad="2"/>
 <connect gate="G$1" pin="B2" pad="3"/>
@@ -883,7 +883,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="SO" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="B1" pad="2"/>
 <connect gate="G$1" pin="B2" pad="3"/>
@@ -919,7 +919,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-20">
+<device name="P" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="ATN" pad="13"/>
 <connect gate="G$1" pin="ATN2" pad="8"/>
@@ -946,7 +946,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="SO" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="ATN" pad="13"/>
 <connect gate="G$1" pin="ATN2" pad="8"/>
@@ -982,7 +982,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-22">
+<device name="P" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="ATN" pad="14"/>
 <connect gate="G$1" pin="ATN2" pad="9"/>
@@ -1020,7 +1020,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-20">
+<device name="P" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="B1" pad="2"/>
 <connect gate="G$1" pin="B2" pad="3"/>
@@ -1047,7 +1047,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="SO" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="B1" pad="2"/>
 <connect gate="G$1" pin="B2" pad="3"/>
@@ -1083,7 +1083,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-22">
+<device name="P" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="ATN" pad="14"/>
 <connect gate="G$1" pin="ATN+EOI" pad="21"/>
@@ -1112,7 +1112,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="SO" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="ATN" pad="14"/>
 <connect gate="G$1" pin="ATN+EOI" pad="21"/>
@@ -1150,7 +1150,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!G" pad="12"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -1173,7 +1173,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!G" pad="12"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -1205,7 +1205,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="1,2EN" pad="4"/>
 <connect gate="G$1" pin="1A" pad="1"/>
@@ -1228,7 +1228,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1,2EN" pad="4"/>
 <connect gate="G$1" pin="1A" pad="1"/>
@@ -1260,7 +1260,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="1,2EN" pad="4"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -1283,7 +1283,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1,2EN" pad="4"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -1315,7 +1315,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$2" symbol="PWRN" x="25.4" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-24">
+<device name="P" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="ATN" pad="9"/>
 <connect gate="G$1" pin="ATN2" pad="16"/>
@@ -1346,7 +1346,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="SO" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="ATN" pad="9"/>
 <connect gate="G$1" pin="ATN2" pad="16"/>

--- a/7tiny-logic.lbr
+++ b/7tiny-logic.lbr
@@ -146,7 +146,7 @@ Thin shrink small outline transistor package (also known as SOT363). 0.65mm pitc
 <rectangle x1="-0.79" y1="-2.2" x2="-0.49" y2="-1.6" layer="51" rot="R180"/>
 <rectangle x1="-2.06" y1="-2.2" x2="-1.76" y2="-1.6" layer="51" rot="R180"/>
 </package>
-<package name="SSOP-65P-280W-295L-135H-60F-8">
+<package name="SSOP-8-65P-280W-295L-135H-60F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.60mm lead length, 3.0mm length, 2.8mm width, 1.35mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.60mm lead length 3.0mm length, 2.8mm width, 1.35mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation DA, LSR-PDSO.&lt;/p&gt;
@@ -179,7 +179,7 @@ JEDEC MO-187F, variation DA, LSR-PDSO.&lt;/p&gt;
 <wire x1="1.45" y1="-1.375" x2="-1.45" y2="-1.375" width="0.0508" layer="51"/>
 <wire x1="1.45" y1="1.375" x2="-1.45" y2="1.375" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-50P-230W-200L-100H-40F-8">
+<package name="SSOP-8-50P-230W-200L-100H-40F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.40mm lead length, 2.0mm length, 2.3mm width, 1.00mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.50mm pitch, 0.40mm lead length 2.0mm length, 2.3mm width, 1.00mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation CA, VSR-PDSO.&lt;/p&gt;
@@ -751,7 +751,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <technology name=""/>
 </technologies>
 </device>
-<device name="FU" package="SSOP-65P-280W-295L-135H-60F-8">
+<device name="FU" package="SSOP-8-65P-280W-295L-135H-60F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -766,7 +766,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <technology name=""/>
 </technologies>
 </device>
-<device name="FK" package="SSOP-50P-230W-200L-100H-40F-8">
+<device name="FK" package="SSOP-8-50P-230W-200L-100H-40F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -807,7 +807,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <technology name=""/>
 </technologies>
 </device>
-<device name="FU" package="SSOP-65P-280W-295L-135H-60F-8">
+<device name="FU" package="SSOP-8-65P-280W-295L-135H-60F">
 <connects>
 <connect gate="A" pin="IN" pad="1"/>
 <connect gate="A" pin="OUT" pad="7"/>
@@ -822,7 +822,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <technology name=""/>
 </technologies>
 </device>
-<device name="FK" package="SSOP-50P-230W-200L-100H-40F-8">
+<device name="FK" package="SSOP-8-50P-230W-200L-100H-40F">
 <connects>
 <connect gate="A" pin="IN" pad="1"/>
 <connect gate="A" pin="OUT" pad="7"/>
@@ -862,7 +862,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <technology name=""/>
 </technologies>
 </device>
-<device name="FU" package="SSOP-65P-280W-295L-135H-60F-8">
+<device name="FU" package="SSOP-8-65P-280W-295L-135H-60F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -877,7 +877,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <technology name=""/>
 </technologies>
 </device>
-<device name="FK" package="SSOP-50P-230W-200L-100H-40F-8">
+<device name="FK" package="SSOP-8-50P-230W-200L-100H-40F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>

--- a/akm.lbr
+++ b/akm.lbr
@@ -78,7 +78,7 @@ Mixed-signal integrated circuits for audio, video, networking and wireless commu
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="LQFP-50P-700W-700L-160H-48">
+<package name="LQFP-48-50P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
@@ -291,7 +291,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <rectangle x1="5.55" y1="2.5" x2="5.85" y2="3.9" layer="51" rot="R270"/>
 <rectangle x1="5.55" y1="3.3" x2="5.85" y2="4.7" layer="51" rot="R270"/>
 </package>
-<package name="SSOP-065-530-28">
+<package name="SSOP-28-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 28 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JEDEC MO-150B. Variation AH.</description>
 <circle x="-4.185" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -433,7 +433,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <rectangle x1="-4.05" y1="2.75" x2="-3.75" y2="3.95" layer="51"/>
 <rectangle x1="-4.7" y1="2.75" x2="-4.4" y2="3.95" layer="51"/>
 </package>
-<package name="LQFP-50P-1000W-1000L-160H-64">
+<package name="LQFP-64-50P-1000W-1000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
@@ -638,7 +638,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <rectangle x1="-3.075" y1="2.75" x2="-2.775" y2="3.95" layer="51"/>
 <rectangle x1="-3.725" y1="2.75" x2="-3.425" y2="3.95" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-16">
+<package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -726,7 +726,7 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <text x="-2.6475" y="-1.3575" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.3175" y="-1.405" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -1988,7 +1988,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="AK4384" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="VT" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="VT" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="ACKS/CCLK" pad="7"/>
 <connect gate="G$1" pin="AOUTL" pad="11"/>
@@ -2020,7 +2020,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="AK4122" x="0" y="0"/>
 </gates>
 <devices>
-<device name="VQ" package="LQFP-50P-700W-700L-160H-48">
+<device name="VQ" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="AVDD" pad="14"/>
 <connect gate="G$1" pin="AVSS" pad="13"/>
@@ -2230,7 +2230,7 @@ Quad Output, 24-Bit, 192 kHz</description>
 <gate name="G$1" symbol="AK4114" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="AVDD" pad="38"/>
 <connect gate="G$1" pin="AVSS" pad="41"/>
@@ -2450,7 +2450,7 @@ High Feature, 24-Bit, 96 kHz</description>
 <gate name="G$1" symbol="AK4112" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-28">
+<device name="" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="AUTO" pad="15"/>
 <connect gate="G$1" pin="AVDD" pad="9"/>
@@ -2586,7 +2586,7 @@ High Performance, 24-Bit, 192 kHz</description>
 <gate name="G$1" symbol="AK7730" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!INIT_RESET!" pad="35"/>
 <connect gate="G$1" pin="!S_RESET!" pad="34"/>
@@ -2650,7 +2650,7 @@ High Performance, 24-Bit, 192 kHz</description>
 <gate name="G$1" symbol="AK7744" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!INIT_RESET!" pad="11"/>
 <connect gate="G$1" pin="!RQ!" pad="37"/>
@@ -2730,7 +2730,7 @@ High Performance, 24-Bit, 192 kHz</description>
 <gate name="G$1" symbol="AK7730_EE" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!INIT_RESET!" pad="35"/>
 <connect gate="G$1" pin="!S_RESET!" pad="34"/>
@@ -2794,7 +2794,7 @@ Super High Performance, 192kHz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5394" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="22"/>
 <connect gate="G$1" pin="AINL+" pad="4"/>
@@ -2838,7 +2838,7 @@ Enhanced Dual Bit, 96kHz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5393" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="22"/>
 <connect gate="G$1" pin="AINL+" pad="4"/>
@@ -2882,7 +2882,7 @@ Enhanced Dual Bit, 48Hz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5392" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="22"/>
 <connect gate="G$1" pin="AINL+" pad="4"/>
@@ -2926,7 +2926,7 @@ Enhanced Dual Bit, 48Hz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5385" x="0" y="0"/>
 </gates>
 <devices>
-<device name="AVS" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="AVS" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AVDD" pad="23"/>
 <connect gate="G$1" pin="AVSS" pad="2"/>
@@ -2961,7 +2961,7 @@ Enhanced Dual Bit, 48Hz, 24-Bit, 2ch, Delta Sigma</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="AVF" package="SSOP-065-530-28">
+<device name="AVF" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="AVDD" pad="23"/>
 <connect gate="G$1" pin="AVSS" pad="2"/>
@@ -3005,7 +3005,7 @@ Enhanced Dual Bit, 48Hz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5383" x="0" y="0"/>
 </gates>
 <devices>
-<device name="VS" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="VS" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="22"/>
 <connect gate="G$1" pin="AINL+" pad="4"/>
@@ -3040,7 +3040,7 @@ Enhanced Dual Bit, 48Hz, 24-Bit, 2ch, Delta Sigma</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="VF" package="SSOP-065-530-28">
+<device name="VF" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="22"/>
 <connect gate="G$1" pin="AINL+" pad="4"/>
@@ -3084,7 +3084,7 @@ Enhanced Dual Bit, 48Hz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5381" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="5"/>
 <connect gate="G$1" pin="AINL" pad="2"/>
@@ -3116,7 +3116,7 @@ Enhanced Dual Bit, 48Hz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5359" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="5"/>
 <connect gate="G$1" pin="AINL" pad="2"/>
@@ -3148,7 +3148,7 @@ Enhanced Dual Bit, 48Hz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5357" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="5"/>
 <connect gate="G$1" pin="AINL" pad="2"/>
@@ -3180,7 +3180,7 @@ Enhanced Dual Bit, 48Hz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5384" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-28">
+<device name="" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="AVDD" pad="8"/>
 <connect gate="G$1" pin="AVSS" pad="7"/>
@@ -3223,7 +3223,7 @@ Enhanced Dual Bit, 48Hz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK4115" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="ACKS" pad="54"/>
 <connect gate="G$1" pin="AVDD@52" pad="52"/>
@@ -3303,7 +3303,7 @@ Single-ended, 24-Bit, 192kHz, Delta Sigma</description>
 <gate name="G$1" symbol="AK5386" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="5"/>
 <connect gate="G$1" pin="AINL" pad="2"/>
@@ -3335,7 +3335,7 @@ Low Power, 16-Bit Delta Sigma</description>
 <gate name="G$1" symbol="AK4550" x="0" y="0"/>
 </gates>
 <devices>
-<device name="VT" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="VT" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!PWAD!" pad="13"/>
 <connect gate="G$1" pin="!PWDA!" pad="14"/>
@@ -3367,7 +3367,7 @@ Low Power, 16-Bit Delta Sigma</description>
 <gate name="G$1" symbol="AK4386" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="BICK" pad="2"/>
 <connect gate="G$1" pin="DEM" pad="8"/>
@@ -3399,7 +3399,7 @@ Low Power, 16-Bit Delta Sigma</description>
 <gate name="G$1" symbol="AK5720" x="2.54" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="BICK" pad="12"/>
 <connect gate="G$1" pin="CKS" pad="16"/>

--- a/allegro-micro.lbr
+++ b/allegro-micro.lbr
@@ -290,7 +290,7 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <rectangle x1="-0.3175" y1="-7.62" x2="0.3175" y2="-5.3976" layer="21"/>
 <rectangle x1="1.5875" y1="-7.62" x2="2.2225" y2="-5.3976" layer="21"/>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -318,7 +318,7 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -352,7 +352,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -471,7 +471,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <gate name="G$1" symbol="A3966" x="0" y="0"/>
 </gates>
 <devices>
-<device name="A" package="DIP-300-16">
+<device name="A" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="EN1" pad="3"/>
 <connect gate="G$1" pin="EN2" pad="14"/>
@@ -494,7 +494,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="LB" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="LB" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="EN1" pad="3"/>
 <connect gate="G$1" pin="EN2" pad="14"/>
@@ -527,7 +527,7 @@ Fully Integrated, Hall Effect-Based&lt;br&gt;
 <gate name="G$1" symbol="ACS712/ACS713" x="0" y="0"/>
 </gates>
 <devices>
-<device name="LC" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="LC" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FILTER" pad="6"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -584,7 +584,7 @@ Fully Integrated, Hall Effect-Based&lt;br&gt;
 <gate name="G$1" symbol="ACS712/ACS713" x="0" y="0"/>
 </gates>
 <devices>
-<device name="LC" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="LC" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FILTER" pad="6"/>
 <connect gate="G$1" pin="GND" pad="5"/>

--- a/altera.lbr
+++ b/altera.lbr
@@ -1465,7 +1465,7 @@ Based on the following sources:
 <rectangle x1="-12.3762" y1="14.097" x2="-12.1222" y2="14.732" layer="21"/>
 <rectangle x1="-12.8763" y1="14.097" x2="-12.6223" y2="14.732" layer="21"/>
 </package>
-<package name="QFP-65P-2800W-2800L-385H-160F-160">
+<package name="QFP-160-65P-2800W-2800L-385H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 160 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DD-2, PQFP-G.
@@ -1799,7 +1799,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1400W-2000L-340H-160F-100">
+<package name="QFP-100-65P-1400W-2000L-340H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.40mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-022B, variation GC-1, PQFP-G.
@@ -7480,7 +7480,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <text x="-7.5499" y="-6.4" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-0.905" y="-11.525" size="0.8128" layer="51">BGA600</text>
 </package>
-<package name="PLCC-127P-2931W-2931L-457H-84">
+<package name="PLCC-84-127P-2931W-2931L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 29.31mm length, 29.31mm width, 4.57mm max height, 84 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 29.31mm body length, 29.31mm body width, 4.57mm max height, 84 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AF.&lt;/p&gt;
@@ -7670,7 +7670,7 @@ JEDEC MS-018A, variation AF.&lt;/p&gt;
 <wire x1="14.6558" y1="13.365" x2="14.6558" y2="14.6558" width="0.2032" layer="21"/>
 <wire x1="14.6558" y1="14.6558" x2="13.365" y2="14.6558" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1658W-1658L-457H-44">
+<package name="PLCC-44-127P-1658W-1658L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 16.59mm length, 16.59mm width, 4.57mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body width, 4.57mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AC.&lt;/p&gt;
@@ -7780,7 +7780,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <wire x1="8.2931" y1="7.015" x2="8.2931" y2="8.2931" width="0.2032" layer="21"/>
 <wire x1="8.2931" y1="8.2931" x2="7.015" y2="8.2931" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-2423W-2423L-457H-68">
+<package name="PLCC-68-127P-2423W-2423L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 24.23mm length, 24.23mm width, 4.57mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body width, 4.57mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AE.&lt;/p&gt;
@@ -9661,7 +9661,7 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <wire x1="0.492" y1="-1.444" x2="0.492" y2="-0.428" width="0.3048" layer="51"/>
 <wire x1="4.81" y1="-0.936" x2="4.81" y2="-2.714" width="0.3048" layer="51"/>
 </package>
-<package name="PLCC-SOCKET-TH-11X11-44">
+<package name="PLCC-SOCKET-TH-44-11X11">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 44 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 &lt;/p&gt;</description>
@@ -9912,7 +9912,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <wire x1="11.43" y1="-11.43" x2="11.43" y2="11.43" width="0.2032" layer="21"/>
 <wire x1="11.43" y1="11.43" x2="-10.16" y2="11.43" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1000W-1000L-120H-44">
+<package name="TQFP-44-80P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
@@ -10014,7 +10014,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -22990,7 +22990,7 @@ MAX 7000 family</description>
 <gate name="P" symbol="PWR3-4" x="30.48" y="2.54" addlevel="always"/>
 </gates>
 <devices>
-<device name="J44" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="J44" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="P" pin="GND" pad="10"/>
 <connect gate="P" pin="GND@1" pad="22"/>
@@ -23041,7 +23041,7 @@ MAX 7000 family</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S44" package="PLCC-SOCKET-TH-11X11-44">
+<device name="S44" package="PLCC-SOCKET-TH-44-11X11">
 <connects>
 <connect gate="P" pin="GND" pad="10"/>
 <connect gate="P" pin="GND@1" pad="22"/>
@@ -23092,7 +23092,7 @@ MAX 7000 family</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T44" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="T44" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="P" pin="GND" pad="4"/>
 <connect gate="P" pin="GND@1" pad="16"/>
@@ -23153,7 +23153,7 @@ MAX 7000 family</description>
 <gate name="P" symbol="PWR3-4" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="J44" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="J44" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="0" pin="GCLK1" pad="43"/>
 <connect gate="0" pin="GCLR/GCLR" pad="1"/>
@@ -23204,7 +23204,7 @@ MAX 7000 family</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S44" package="PLCC-SOCKET-TH-11X11-44">
+<device name="S44" package="PLCC-SOCKET-TH-44-11X11">
 <connects>
 <connect gate="0" pin="GCLK1" pad="43"/>
 <connect gate="0" pin="GCLR/GCLR" pad="1"/>
@@ -23255,7 +23255,7 @@ MAX 7000 family</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T44" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="T44" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="0" pin="GCLK1" pad="37"/>
 <connect gate="0" pin="GCLR/GCLR" pad="39"/>
@@ -23316,7 +23316,7 @@ MAX 7000 family</description>
 <gate name="_" symbol="7064-68" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="P" pin="GND" pad="6"/>
 <connect gate="P" pin="GND@1" pad="16"/>
@@ -23401,7 +23401,7 @@ MAX 7000 family</description>
 <gate name="P" symbol="PWR8-2-6" x="43.18" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2931W-2931L-457H-84">
+<device name="" package="PLCC-84-127P-2931W-2931L-457H">
 <connects>
 <connect gate="P" pin="GND" pad="7"/>
 <connect gate="P" pin="GND@1" pad="19"/>
@@ -23518,7 +23518,7 @@ MAX 7000 family</description>
 <gate name="NC16" symbol="NC" x="76.2" y="-15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="NC1" pin="NC" pad="1"/>
 <connect gate="NC10" pin="NC" pad="50"/>
@@ -23651,7 +23651,7 @@ MAX 7000 family</description>
 <gate name="NC16" symbol="NC" x="66.04" y="-17.78" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-2000L-340H-160F-100">
+<device name="" package="QFP-100-65P-1400W-2000L-340H-160F">
 <connects>
 <connect gate="NC1" pin="NC" pad="1"/>
 <connect gate="NC10" pin="NC" pad="52"/>
@@ -23768,7 +23768,7 @@ MAX 7000 family</description>
 <gate name="P" symbol="PWR8-2-6" x="48.26" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="P" pin="GND" pad="6"/>
 <connect gate="P" pin="GND@1" pad="16"/>
@@ -23857,7 +23857,7 @@ MAX 7000 family</description>
 <gate name="NC4" symbol="NC" x="73.66" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2931W-2931L-457H-84">
+<device name="" package="PLCC-84-127P-2931W-2931L-457H">
 <connects>
 <connect gate="NC1" pin="NC" pad="6"/>
 <connect gate="NC2" pin="NC" pad="39"/>
@@ -23966,7 +23966,7 @@ MAX 7000 family</description>
 <gate name="_" symbol="7096" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-2000L-340H-160F-100">
+<device name="" package="QFP-100-65P-1400W-2000L-340H-160F">
 <connects>
 <connect gate="NC1" pin="NC" pad="9"/>
 <connect gate="NC2" pin="NC" pad="24"/>
@@ -24098,7 +24098,7 @@ MAX 7000 family</description>
 <gate name="16" symbol="GND" x="73.66" y="-22.86" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2931W-2931L-457H-84">
+<device name="" package="PLCC-84-127P-2931W-2931L-457H">
 <connects>
 <connect gate="1" pin="VCC" pad="3"/>
 <connect gate="10" pin="GND" pad="19"/>
@@ -24214,7 +24214,7 @@ MAX 7000 family</description>
 <gate name="16" symbol="GND" x="68.58" y="-27.94" addlevel="always"/>
 </gates>
 <devices>
-<device name="P" package="QFP-65P-1400W-2000L-340H-160F-100">
+<device name="P" package="QFP-100-65P-1400W-2000L-340H-160F">
 <connects>
 <connect gate="1" pin="VCC" pad="41"/>
 <connect gate="10" pin="GND" pad="28"/>
@@ -24321,7 +24321,7 @@ MAX 7000 family</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="T" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="1" pin="VCC" pad="39"/>
 <connect gate="10" pin="GND" pad="26"/>
@@ -24497,7 +24497,7 @@ MAX 7000 family</description>
 <gate name="16" symbol="GND" x="63.5" y="-25.4" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-2800W-2800L-385H-160F-160">
+<device name="" package="QFP-160-65P-2800W-2800L-385H-160F">
 <connects>
 <connect gate="1" pin="VCC" pad="61"/>
 <connect gate="10" pin="GND" pad="42"/>
@@ -25205,7 +25205,7 @@ MAX 7000 family</description>
 <gate name="_" symbol="7256P160" x="0" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-2800W-2800L-385H-160F-160">
+<device name="" package="QFP-160-65P-2800W-2800L-385H-160F">
 <connects>
 <connect gate="G1" pin="GND" pad="3"/>
 <connect gate="G10" pin="GND" pad="111"/>
@@ -25386,7 +25386,7 @@ MAX 7000 family</description>
 <gate name="NC4" symbol="NC" x="35.56" y="-17.78" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2931W-2931L-457H-84">
+<device name="" package="PLCC-84-127P-2931W-2931L-457H">
 <connects>
 <connect gate="NC1" pin="NC" pad="6"/>
 <connect gate="NC2" pin="NC" pad="39"/>
@@ -25487,7 +25487,7 @@ MAX 7000 family</description>
 <gate name="P" symbol="PWR8-2-6" x="45.72" y="-5.08" addlevel="always"/>
 </gates>
 <devices>
-<device name="P" package="QFP-65P-1400W-2000L-340H-160F-100">
+<device name="P" package="QFP-100-65P-1400W-2000L-340H-160F">
 <connects>
 <connect gate="P" pin="GND" pad="13"/>
 <connect gate="P" pin="GND@1" pad="28"/>
@@ -25594,7 +25594,7 @@ MAX 7000 family</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="T" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="P" pin="GND" pad="38"/>
 <connect gate="P" pin="GND@1" pad="86"/>
@@ -25751,7 +25751,7 @@ MAX 7000 family</description>
 <gate name="_" symbol="7160P160" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-2800W-2800L-385H-160F-160">
+<device name="" package="QFP-160-65P-2800W-2800L-385H-160F">
 <connects>
 <connect gate="NC1" pin="NC" pad="1"/>
 <connect gate="NC10" pin="NC" pad="37"/>
@@ -26175,7 +26175,7 @@ MAX 7000 family</description>
 <gate name="NC8" symbol="NC" x="40.64" y="-27.94" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-2800W-2800L-385H-160F-160">
+<device name="" package="QFP-160-65P-2800W-2800L-385H-160F">
 <connects>
 <connect gate="G" pin="GCLK1" pad="139"/>
 <connect gate="G" pin="GCLR/GCLR" pad="141"/>

--- a/am29-memory.lbr
+++ b/am29-memory.lbr
@@ -75,7 +75,7 @@
 <description>&lt;b&gt;Advanced Micro Devices Flash Memories&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="SSOP-50P-1840W-800L-120H-80F-32">
+<package name="SSOP-32-50P-1840W-800L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 8.0mm length, 18.4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 8.0mm length, 18.4mm width, 1.20mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation BD, R-PDSO-G.&lt;/p&gt;
@@ -280,7 +280,7 @@ JEDEC MO-142D, variation BD, R-PDSO-G.&lt;/p&gt;
 <vertex x="-31.75" y="-3.81"/>
 </polygon>
 </package>
-<package name="PLCC-127P-1397W-1143L-355H-32">
+<package name="PLCC-32-127P-1397W-1143L-355H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 11.43mm length, 13.97mm width, 3.56mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Rectangular plastic leaded chip carrier. 1.27mm pitch, 11.43mm body length, 13.97mm body width, 3.56mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-016A, variation AE.&lt;/p&gt;
@@ -417,7 +417,7 @@ JEDEC MS-016A, variation AE.&lt;/p&gt;
 <vertex x="-6.35" y="-0.762"/>
 </polygon>
 </package>
-<package name="SSOP-50P-1840W-1000L-120H-80F-40">
+<package name="SSOP-40-50P-1840W-1000L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 10.0mm length, 18.4mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 10.0mm length, 18.4mm width, 1.20mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation CD, R-PDSO-G.&lt;/p&gt;
@@ -907,7 +907,7 @@ JEDEC MO-142D, variation CD, R-PDSO-G.&lt;/p&gt;
 <vertex x="-3.81" y="-0.762"/>
 </polygon>
 </package>
-<package name="PLCC-SOCKET-TH-7X9-32">
+<package name="PLCC-SOCKET-TH-32-7X9">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 32 leads (7x9), through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 32 leads.
 &lt;/p&gt;</description>
@@ -1098,7 +1098,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 32 leads.
 <wire x1="8.89" y1="-10.16" x2="8.89" y2="10.16" width="0.2032" layer="21"/>
 <wire x1="8.89" y1="10.16" x2="-7.62" y2="10.16" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-32">
+<package name="DIP-32-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <pad name="1" x="-19.05" y="-3.81" drill="0.8128" shape="long" rot="R90" first="yes"/>
@@ -1870,7 +1870,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 32 leads.
 <vertex x="-6.35" y="-0.762"/>
 </polygon>
 </package>
-<package name="SSOP-50P-1840W-1200L-120H-80F-48">
+<package name="SSOP-48-50P-1840W-1200L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
@@ -3082,7 +3082,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <gate name="NC2" symbol="NC" x="20.32" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-50P-1840W-800L-120H-80F-32">
+<device name="E" package="SSOP-32-50P-1840W-800L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="30"/>
 <connect gate="G$1" pin="!OE!" pad="32"/>
@@ -3121,7 +3121,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-32">
+<device name="P" package="DIP-32-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -3160,7 +3160,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="J" package="PLCC-127P-1397W-1143L-355H-32">
+<device name="J" package="PLCC-32-127P-1397W-1143L-355H">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -3266,7 +3266,7 @@ boot sector flash memory</description>
 <gate name="NC4" symbol="NC" x="35.56" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1000L-120H-80F-40">
+<device name="" package="SSOP-40-50P-1840W-1000L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!!RDBY!" pad="12"/>
 <connect gate="G$1" pin="!CE!" pad="22"/>
@@ -3391,7 +3391,7 @@ boot sector flash memory</description>
 <gate name="G$1" symbol="29LV400" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1200L-120H-80F-48">
+<device name="" package="SSOP-48-50P-1840W-1200L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!!RDBY!" pad="15"/>
 <connect gate="G$1" pin="!BYTE!" pad="47"/>
@@ -3592,7 +3592,7 @@ boot sector flash memory</description>
 <gate name="G$1" symbol="AM29F010" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-7X9-32">
+<device name="" package="PLCC-SOCKET-TH-32-7X9">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -3641,7 +3641,7 @@ boot sector flash memory</description>
 <gate name="P" symbol="VCC-GND" x="17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-32">
+<device name="" package="DIP-32-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -3690,7 +3690,7 @@ boot sector flash memory</description>
 <gate name="P" symbol="VCC-GND" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1397W-1143L-355H-32">
+<device name="" package="PLCC-32-127P-1397W-1143L-355H">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -3739,7 +3739,7 @@ boot sector flash memory</description>
 <gate name="P" symbol="VCC-GND" x="17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-800L-120H-80F-32">
+<device name="" package="SSOP-32-50P-1840W-800L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="30"/>
 <connect gate="G$1" pin="!OE!" pad="32"/>
@@ -3793,7 +3793,7 @@ boot sector flash memory</description>
 <gate name="P" symbol="VCC2GND" x="30.48" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1200L-120H-80F-48">
+<device name="" package="SSOP-48-50P-1840W-1200L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!!RDBY!" pad="15"/>
 <connect gate="G$1" pin="!BYTE!" pad="47"/>
@@ -3917,7 +3917,7 @@ boot sector flash memory</description>
 <gate name="G$1" symbol="AM29DL320" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-50P-1840W-1200L-120H-80F-48">
+<device name="E" package="SSOP-48-50P-1840W-1200L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!!RYBY!" pad="15"/>
 <connect gate="G$1" pin="!BYTE!" pad="47"/>

--- a/amd-mach.lbr
+++ b/amd-mach.lbr
@@ -75,7 +75,7 @@
 <description>&lt;b&gt;AMD MACH4/MACH5 Family (Vantis)&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="PLCC-127P-2931W-2931L-457H-84">
+<package name="PLCC-84-127P-2931W-2931L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 29.31mm length, 29.31mm width, 4.57mm max height, 84 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 29.31mm body length, 29.31mm body width, 4.57mm max height, 84 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AF.&lt;/p&gt;
@@ -265,7 +265,7 @@ JEDEC MS-018A, variation AF.&lt;/p&gt;
 <wire x1="14.6558" y1="13.365" x2="14.6558" y2="14.6558" width="0.2032" layer="21"/>
 <wire x1="14.6558" y1="14.6558" x2="13.365" y2="14.6558" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1400W-2000L-315H-160F-100">
+<package name="QFP-100-65P-1400W-2000L-315H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-022B, variation GC-2, PQFP-G.
@@ -479,7 +479,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-2000W-2000L-120H-144">
+<package name="TQFP-144-50P-2000W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
@@ -781,7 +781,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-2800W-2800L-385H-130F-208">
+<package name="QFP-208-50P-2800W-2800L-385H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation FA-2, S-R-PQFP.
@@ -1784,7 +1784,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm lengt
 <vertex x="-3.175" y="-0.762"/>
 </polygon>
 </package>
-<package name="PLCC-127P-1658W-1658L-457H-44">
+<package name="PLCC-44-127P-1658W-1658L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 16.59mm length, 16.59mm width, 4.57mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body width, 4.57mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AC.&lt;/p&gt;
@@ -1894,7 +1894,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <wire x1="8.2931" y1="7.015" x2="8.2931" y2="8.2931" width="0.2032" layer="21"/>
 <wire x1="8.2931" y1="8.2931" x2="7.015" y2="8.2931" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-700W-700L-120H-48">
+<package name="TQFP-48-50P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
@@ -2004,7 +2004,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-2800W-2800L-385H-160F-144">
+<package name="QFP-144-65P-2800W-2800L-385H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DC-2, PQFP-G.
@@ -2306,7 +2306,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-2800W-2800L-385H-160F-160">
+<package name="QFP-160-65P-2800W-2800L-385H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 160 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DD-2, PQFP-G.
@@ -2640,7 +2640,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-3200W-3200L-409H-130F-240">
+<package name="QFP-240-50P-3200W-3200L-410H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 32mm length, 32mm width, 4.10mm max height, 240 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 32mm length, 32mm width, 4.10mm max height, 240 leads, high standoff.
 &lt;p/&gt;JEDEC MS-029A, variation GA, S-R-PQFP.
@@ -3940,7 +3940,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 32mm lengt
 <vertex x="1.23" y="4.03"/>
 </polygon>
 </package>
-<package name="PLCC-127P-2423W-2423L-457H-68">
+<package name="PLCC-68-127P-2423W-2423L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 24.23mm length, 24.23mm width, 4.57mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body width, 4.57mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AE.&lt;/p&gt;
@@ -4098,7 +4098,7 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <wire x1="12.1158" y1="10.825" x2="12.1158" y2="12.1158" width="0.2032" layer="21"/>
 <wire x1="12.1158" y1="12.1158" x2="10.825" y2="12.1158" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1000W-1000L-120H-44">
+<package name="TQFP-44-80P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
@@ -4200,7 +4200,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -6758,7 +6758,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M4-32-44" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="11"/>
 <connect gate="G$1" pin="CLK1/I1" pad="33"/>
@@ -6817,7 +6817,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M4-32-44" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="5"/>
 <connect gate="G$1" pin="CLK1/I1" pad="27"/>
@@ -6876,7 +6876,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M4-96/48" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="11"/>
 <connect gate="G$1" pin="CLK1/I1" pad="14"/>
@@ -6991,7 +6991,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M4-128N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2931W-2931L-457H-84">
+<device name="" package="PLCC-84-127P-2931W-2931L-457H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="20"/>
 <connect gate="G$1" pin="CLK1/I1" pad="23"/>
@@ -7090,7 +7090,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M4-128-P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-2000L-315H-160F-100">
+<device name="" package="QFP-100-65P-1400W-2000L-315H-160F">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="13"/>
 <connect gate="G$1" pin="CLK1/I1" pad="18"/>
@@ -7205,7 +7205,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M4-128-T" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="11"/>
 <connect gate="G$1" pin="CLK1/I1" pad="14"/>
@@ -7320,7 +7320,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M4-192-T" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-2000W-2000L-120H-144">
+<device name="" package="TQFP-144-50P-2000W-2000L-120H">
 <connects>
 <connect gate="G$1" pin="CLK0" pad="124"/>
 <connect gate="G$1" pin="CLK1" pad="49"/>
@@ -7544,7 +7544,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="V24" symbol="VCC" x="45.72" y="-50.8" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-50P-2800W-2800L-385H-130F-208">
+<device name="" package="QFP-208-50P-2800W-2800L-385H-130F">
 <connects>
 <connect gate="A" pin="IO0" pad="190"/>
 <connect gate="A" pin="IO1" pad="191"/>
@@ -8151,7 +8151,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G1" symbol="M5-P100" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-2000L-315H-160F-100">
+<device name="" package="QFP-100-65P-1400W-2000L-315H-160F">
 <connects>
 <connect gate="G1" pin="CLK0/I0" pad="13"/>
 <connect gate="G1" pin="CLK1/I1" pad="18"/>
@@ -8266,7 +8266,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G1" symbol="M5-T68" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G1" pin="CLK0/I0" pad="11"/>
 <connect gate="G1" pin="CLK1/I1" pad="15"/>
@@ -8381,7 +8381,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G1" symbol="M5-P174" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-2000L-315H-160F-100">
+<device name="" package="QFP-100-65P-1400W-2000L-315H-160F">
 <connects>
 <connect gate="G1" pin="CLK0/I0" pad="11"/>
 <connect gate="G1" pin="CLK1/I1" pad="15"/>
@@ -8496,7 +8496,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G1" symbol="M5-144" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-2800W-2800L-385H-160F-144">
+<device name="" package="QFP-144-65P-2800W-2800L-385H-160F">
 <connects>
 <connect gate="G1" pin="CLK0/I0" pad="17"/>
 <connect gate="G1" pin="CLK1/I1" pad="20"/>
@@ -8655,7 +8655,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M5-144" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-2000W-2000L-120H-144">
+<device name="" package="TQFP-144-50P-2000W-2000L-120H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="17"/>
 <connect gate="G$1" pin="CLK1/I1" pad="20"/>
@@ -8854,7 +8854,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="V14" symbol="VCC" x="30.48" y="20.32" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-2800W-2800L-385H-160F-160">
+<device name="" package="QFP-160-65P-2800W-2800L-385H-160F">
 <connects>
 <connect gate="A" pin="IO0" pad="2"/>
 <connect gate="A" pin="IO1" pad="3"/>
@@ -9079,7 +9079,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="V14" symbol="VCC" x="38.1" y="20.32" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-50P-2800W-2800L-385H-130F-208">
+<device name="" package="QFP-208-50P-2800W-2800L-385H-130F">
 <connects>
 <connect gate="A" pin="IO0" pad="2"/>
 <connect gate="A" pin="IO1" pad="3"/>
@@ -9362,7 +9362,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="L" symbol="IO183" x="187.96" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="QFP-50P-3200W-3200L-409H-130F-240">
+<device name="" package="QFP-240-50P-3200W-3200L-410H-130F">
 <connects>
 <connect gate="A" pin="IO0" pad="2"/>
 <connect gate="A" pin="IO1" pad="3"/>
@@ -9956,7 +9956,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M4-32-48" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-700W-700L-120H-48">
+<device name="" package="TQFP-48-50P-700W-700L-120H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="5"/>
 <connect gate="G$1" pin="CLK1/I1" pad="29"/>
@@ -10490,7 +10490,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M4-32-44" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="11"/>
 <connect gate="G$1" pin="CLK1/I1" pad="33"/>
@@ -10549,7 +10549,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M4-32-44" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="5"/>
 <connect gate="G$1" pin="CLK1/I1" pad="27"/>
@@ -10608,7 +10608,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M4-128N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2931W-2931L-457H-84">
+<device name="" package="PLCC-84-127P-2931W-2931L-457H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="20"/>
 <connect gate="G$1" pin="CLK1/I1" pad="23"/>
@@ -10707,7 +10707,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M131P100" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-2000L-315H-160F-100">
+<device name="" package="QFP-100-65P-1400W-2000L-315H-160F">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="13"/>
 <connect gate="G$1" pin="CLK1/I1" pad="18"/>
@@ -10822,7 +10822,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M131T100" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="11"/>
 <connect gate="G$1" pin="CLK1/I1" pad="15"/>
@@ -10937,7 +10937,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M4-32-44" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="11"/>
 <connect gate="G$1" pin="CLK1/I1" pad="33"/>
@@ -10996,7 +10996,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M4-32-44" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="5"/>
 <connect gate="G$1" pin="CLK1/I1" pad="27"/>
@@ -11055,7 +11055,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="M221-P68" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="15"/>
 <connect gate="G$1" pin="CLK1/I1" pad="16"/>
@@ -11138,7 +11138,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="MACH231" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2931W-2931L-457H-84">
+<device name="" package="PLCC-84-127P-2931W-2931L-457H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="20"/>
 <connect gate="G$1" pin="CLK1/I1" pad="23"/>
@@ -11263,7 +11263,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="NC2" symbol="NC" x="60.96" y="22.86" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-2000L-315H-160F-100">
+<device name="" package="QFP-100-65P-1400W-2000L-315H-160F">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="13"/>
 <connect gate="G$1" pin="CLK1/I1" pad="18"/>
@@ -11404,7 +11404,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="NC5" symbol="NC" x="68.58" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="CLK0/I0" pad="11"/>
 <connect gate="G$1" pin="CLK1/I1" pad="15"/>

--- a/analog-devices.lbr
+++ b/analog-devices.lbr
@@ -812,7 +812,7 @@
 <rectangle x1="-14.3863" y1="15.9893" x2="-14.1196" y2="16.4338" layer="21"/>
 <rectangle x1="-14.8863" y1="15.9893" x2="-14.6196" y2="16.4338" layer="21"/>
 </package>
-<package name="QFP-50P-2800W-2800L-385H-130F-208">
+<package name="QFP-208-50P-2800W-2800L-385H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation FA-2, S-R-PQFP.
@@ -1268,7 +1268,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm lengt
 <rectangle x1="0.4572" y1="1.8542" x2="0.8128" y2="2.8702" layer="51"/>
 <rectangle x1="1.7272" y1="1.8542" x2="2.0828" y2="2.8702" layer="51"/>
 </package>
-<package name="QFP-65P-1000W-1000L-245H-195F-52">
+<package name="QFP-52-65P-1000W-1000L-245H-195F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation AC-2, S-R-PQFP-G.
@@ -1420,7 +1420,7 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 10mm length, 10mm wi
 <text x="-25.4" y="3.81" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-8.89" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="LCC-127P-888W-888L-254H-20">
+<package name="LCC-20-127P-888W-888L-254H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 8.89mm length, 8.89mm width, 2.54mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 8.89mm body length, 8.89mm body width, 2.54mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CB.&lt;/p&gt;
@@ -1521,7 +1521,7 @@ Leadless chip carrier. 1.27mm pitch, 8.89mm body length, 8.89mm body width, 2.54
 <text x="-2.54" y="5.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3.81" y="-6.35" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SSOP-50P-300W-300L-110H-95F-10">
+<package name="SSOP-10-50P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
@@ -1787,7 +1787,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <smd name="P15" x="7" y="-6" dx="0.6" dy="0.6" layer="1" roundness="100"/>
 <smd name="R15" x="7" y="-7" dx="0.6" dy="0.6" layer="1" roundness="100"/>
 </package>
-<package name="TQFP-65P-1400W-1400L-120H-80">
+<package name="TQFP-80-65P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEC, T-PQFP-G.
@@ -1961,7 +1961,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-896W-896L-457H-20">
+<package name="PLCC-20-127P-896W-896L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 8.97mm length, 8.97mm width, 4.57mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 8.97mm body length, 8.97mm body width, 4.57mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AA.&lt;/p&gt;
@@ -2023,7 +2023,7 @@ JEDEC MS-018A, variation AA.&lt;/p&gt;
 <wire x1="4.4831" y1="3.205" x2="4.4831" y2="4.4831" width="0.2032" layer="21"/>
 <wire x1="4.4831" y1="4.4831" x2="3.205" y2="4.4831" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -2237,7 +2237,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-1400W-1400L-160H-100">
+<package name="LQFP-100-50P-1400W-1400L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BED, L-PQFP-G.
@@ -2451,7 +2451,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-16">
+<package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -2496,7 +2496,7 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-970L-120H-100F-28">
+<package name="SSOP-28-65P-440W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 4.4mm width, 1.20mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 4.4mm width, 1.20mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
@@ -2565,7 +2565,7 @@ JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.1" x2="4.75" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.1" x2="-4.75" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -2585,7 +2585,7 @@ JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -2611,7 +2611,7 @@ JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -2639,7 +2639,7 @@ JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -2669,7 +2669,7 @@ JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -2705,7 +2705,7 @@ JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -2739,7 +2739,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -2788,7 +2788,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -2838,7 +2838,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-650L-120H-100F-20">
+<package name="SSOP-20-65P-440W-650L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
@@ -2891,7 +2891,7 @@ JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.15" y1="-2.1" x2="3.15" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.1" x2="-3.15" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -3014,7 +3014,7 @@ stop mask for exposed thermal ground underneath</description>
 <rectangle x1="-2.5" y1="-1.7" x2="2.5" y2="1.7" layer="29"/>
 <rectangle x1="-2.4" y1="-1.6" x2="2.4" y2="1.6" layer="31"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -3079,7 +3079,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-780L-120H-100F-24">
+<package name="SSOP-24-65P-440W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
@@ -3190,7 +3190,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <wire x1="1.45" y1="-0.65" x2="1.45" y2="0.65" width="0.2032" layer="21"/>
 <wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -3715,7 +3715,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <vertex x="-5.15" y="4.75"/>
 </polygon>
 </package>
-<package name="SSOP-065-530-20">
+<package name="SSOP-20-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 20 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JEDEC MO-150B. Variation AE.</description>
 <circle x="-2.885" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -3965,7 +3965,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <wire x1="-2.2" y1="2.2" x2="-1.4" y2="2.2" width="0.2032" layer="21"/>
 <rectangle x1="-2.2" y1="1.6" x2="-1.6" y2="2.2" layer="21"/>
 </package>
-<package name="LQFP-50P-700W-700L-160H-48">
+<package name="LQFP-48-50P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
@@ -4096,7 +4096,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <wire x1="1" y1="-0.625" x2="-1" y2="-0.625" width="0.2032" layer="51"/>
 <wire x1="1" y1="0.625" x2="1" y2="-0.625" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-700W-700L-120H-32">
+<package name="TQFP-32-80P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.
@@ -7888,7 +7888,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="-VCC" symbol="VCC32" x="71.12" y="96.52" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-50P-2800W-2800L-385H-130F-208">
+<device name="" package="QFP-208-50P-2800W-2800L-385H-130F">
 <connects>
 <connect gate="-GND" pin="GND" pad="3"/>
 <connect gate="-GND" pin="GND@1" pad="10"/>
@@ -8401,7 +8401,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="G$1" symbol="ADUC812" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1000W-1000L-245H-195F-52">
+<device name="" package="QFP-52-65P-1000W-1000L-245H-195F">
 <connects>
 <connect gate="G$1" pin="!EA" pad="40"/>
 <connect gate="G$1" pin="!PSEN" pad="41"/>
@@ -8514,7 +8514,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="G$1" symbol="AD767" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="10V" pad="2"/>
@@ -8553,7 +8553,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="G$1" symbol="AD736" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+VS" pad="7"/>
 <connect gate="G$1" pin="-VS" pad="4"/>
@@ -8576,7 +8576,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="G$1" symbol="AD736" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+VS" pad="7"/>
 <connect gate="G$1" pin="-VS" pad="4"/>
@@ -8609,7 +8609,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="NC10" symbol="NC" x="35.56" y="-27.94" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="LCC-127P-888W-888L-254H-20">
+<device name="" package="LCC-20-127P-888W-888L-254H">
 <connects>
 <connect gate="G$1" pin="+VS" pad="20"/>
 <connect gate="G$1" pin="-VS" pad="4"/>
@@ -8673,7 +8673,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="NC4" symbol="NC" x="27.94" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+VS" pad="14"/>
 <connect gate="G$1" pin="-VS" pad="3"/>
@@ -8702,7 +8702,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="G$1" symbol="AD595" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+ALM" pad="12"/>
 <connect gate="G$1" pin="+C" pad="2"/>
@@ -8731,7 +8731,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="G$1" symbol="AD595" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+ALM" pad="12"/>
 <connect gate="G$1" pin="+C" pad="2"/>
@@ -8760,7 +8760,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="G$1" symbol="AD8801" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CLK!" pad="9"/>
 <connect gate="G$1" pin="!CS!" pad="7"/>
@@ -8791,7 +8791,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="G$1" symbol="AD8803" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CLK!" pad="10"/>
 <connect gate="G$1" pin="!CS!" pad="7"/>
@@ -8826,7 +8826,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="8" symbol="NC" x="20.32" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="1" pin="NC" pad="1"/>
 <connect gate="5" pin="NC" pad="5"/>
@@ -8841,7 +8841,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="1" pin="NC" pad="1"/>
 <connect gate="5" pin="NC" pad="5"/>
@@ -8864,7 +8864,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="G$1" symbol="AD538" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="DIP-300-18">
+<device name="D" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="+10V" pad="4"/>
 <connect gate="G$1" pin="+2V" pad="5"/>
@@ -8899,7 +8899,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <gate name="G$1" symbol="AD654" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+VIN" pad="4"/>
 <connect gate="G$1" pin="+VS" pad="8"/>
@@ -8923,7 +8923,7 @@ single-chip microcomputer optimized for digital signal processing (DSP)</descrip
 <gate name="G$1" symbol="ADSP2189" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!BGH" pad="95"/>
 <connect gate="G$1" pin="!BMS" pad="21"/>
@@ -9344,7 +9344,7 @@ single-chip microcomputer optimized for digital signal processing (DSP)</descrip
 <gate name="G$1" symbol="ADUC814" x="0" y="0"/>
 </gates>
 <devices>
-<device name="RU" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="RU" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND@1" pad="14"/>
 <connect gate="G$1" pin="AGND@2" pad="15"/>
@@ -9387,7 +9387,7 @@ single-chip microcomputer optimized for digital signal processing (DSP)</descrip
 <gate name="G$1" symbol="AD831" x="10.16" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-896W-896L-457H-20">
+<device name="" package="PLCC-20-127P-896W-896L-457H">
 <connects>
 <connect gate="G$1" pin="AN" pad="3"/>
 <connect gate="G$1" pin="AP" pad="19"/>
@@ -9421,7 +9421,7 @@ single-chip microcomputer optimized for digital signal processing (DSP)</descrip
 <gate name="AD9854" symbol="AD9843-1" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="-(TQFP)" package="TQFP-65P-1400W-1400L-120H-80">
+<device name="-(TQFP)" package="TQFP-80-65P-1400W-1400L-120H">
 <connects>
 <connect gate="AD9854" pin="(NC1)" pad="13"/>
 <connect gate="AD9854" pin="(NC2)" pad="35"/>
@@ -9516,7 +9516,7 @@ single-chip microcomputer optimized for digital signal processing (DSP)</descrip
 <gate name="G$1" symbol="AD623" x="0" y="0"/>
 </gates>
 <devices>
-<device name="ARM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="ARM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -9531,7 +9531,7 @@ single-chip microcomputer optimized for digital signal processing (DSP)</descrip
 <technology name=""/>
 </technologies>
 </device>
-<device name="AR" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="AR" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -9546,7 +9546,7 @@ single-chip microcomputer optimized for digital signal processing (DSP)</descrip
 <technology name=""/>
 </technologies>
 </device>
-<device name="AN" package="DIP-300-8">
+<device name="AN" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -9570,7 +9570,7 @@ single-chip microcomputer optimized for digital signal processing (DSP)</descrip
 <gate name="P" symbol="PWR+-" x="2.54" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="AR" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="AR" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="IN+" pad="3"/>
 <connect gate="A" pin="IN-" pad="2"/>
@@ -9603,7 +9603,7 @@ Low Cost, Low Power 12-Bit</description>
 <gate name="G$1" symbol="AD8137" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="-IN" pad="1"/>
@@ -9626,7 +9626,7 @@ Low Cost, Low Power 12-Bit</description>
 <gate name="G$1" symbol="AD421" x="0" y="0"/>
 </gates>
 <devices>
-<device name="R" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="R" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="BOOST" pad="15"/>
 <connect gate="G$1" pin="C1" pad="12"/>
@@ -9649,7 +9649,7 @@ Low Cost, Low Power 12-Bit</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="BOOST" pad="15"/>
 <connect gate="G$1" pin="C1" pad="12"/>
@@ -9680,7 +9680,7 @@ Low Cost, Low Power 12-Bit</description>
 <gate name="G$1" symbol="AD7399" x="0" y="0"/>
 </gates>
 <devices>
-<device name="RU" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="RU" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="9"/>
 <connect gate="G$1" pin="!LDAC!" pad="7"/>
@@ -9703,7 +9703,7 @@ Low Cost, Low Power 12-Bit</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="R" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="9"/>
 <connect gate="G$1" pin="!LDAC!" pad="7"/>
@@ -9735,7 +9735,7 @@ Sigma-Delta ADC with On-Chip In-Amp</description>
 <gate name="G$1" symbol="AD7799" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="AIN1(+)" pad="5"/>
@@ -9767,7 +9767,7 @@ Low Power 20 mW 2.3 V to 5.5 V</description>
 <gate name="G$1" symbol="AD9833" x="0" y="0"/>
 </gates>
 <devices>
-<device name="BRM" package="SSOP-50P-300W-300L-110H-95F-10">
+<device name="BRM" package="SSOP-10-50P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="9"/>
 <connect gate="G$1" pin="CAP" pad="3"/>
@@ -9792,7 +9792,7 @@ Low Power 20 mW 2.3 V to 5.5 V</description>
 <gate name="G$1" symbol="SSM2141" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -9814,7 +9814,7 @@ Low Power 20 mW 2.3 V to 5.5 V</description>
 <gate name="G$1" symbol="SSM2142" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="S" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="FORCE+" pad="14"/>
 <connect gate="G$1" pin="FORCE-" pad="3"/>
@@ -9829,7 +9829,7 @@ Low Power 20 mW 2.3 V to 5.5 V</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="FORCE+" pad="8"/>
 <connect gate="G$1" pin="FORCE-" pad="1"/>
@@ -9853,7 +9853,7 @@ Programmable Gain</description>
 <gate name="G$1" symbol="AD8251" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-300W-300L-110H-95F-10">
+<device name="" package="SSOP-10-50P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="A0" pad="4"/>
 <connect gate="G$1" pin="A1" pad="5"/>
@@ -9879,7 +9879,7 @@ CMOS, Low-Voltage, 3-Wire Serially-Controlled</description>
 <gate name="G$1" symbol="ADG738" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="2"/>
 <connect gate="G$1" pin="!SYNC!" pad="16"/>
@@ -9910,7 +9910,7 @@ CMOS, Low-Voltage, 3-Wire Serially-Controlled</description>
 <gate name="G$1" symbol="ADUM1200" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND1" pad="4"/>
 <connect gate="G$1" pin="GND2" pad="5"/>
@@ -9933,7 +9933,7 @@ CMOS, Low-Voltage, 3-Wire Serially-Controlled</description>
 <gate name="G$1" symbol="ADUM1201" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND1" pad="4"/>
 <connect gate="G$1" pin="GND2" pad="5"/>
@@ -9957,7 +9957,7 @@ Low Cost, Low Power CMOS General Purpose Analog Front End</description>
 <gate name="G$1" symbol="AD73311" x="0" y="0"/>
 </gates>
 <devices>
-<device name="ARU" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="ARU" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="13"/>
 <connect gate="G$1" pin="AGND@10" pad="10"/>
@@ -9985,7 +9985,7 @@ Low Cost, Low Power CMOS General Purpose Analog Front End</description>
 <technology name="L"/>
 </technologies>
 </device>
-<device name="AR" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="AR" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="13"/>
 <connect gate="G$1" pin="AGND@10" pad="10"/>
@@ -10065,7 +10065,7 @@ Single-Channel, 12-/16-Bit, Serial Input,&lt;br&gt;
 <gate name="-4" symbol="DIGI-POT" x="27.94" y="-12.7" addlevel="always"/>
 </gates>
 <devices>
-<device name="BRU" package="SSOP-65P-440W-780L-120H-100F-24">
+<device name="BRU" package="SSOP-24-65P-440W-780L-120H-100F">
 <connects>
 <connect gate="-1" pin="A" pad="18"/>
 <connect gate="-1" pin="B" pad="16"/>
@@ -10096,7 +10096,7 @@ Single-Channel, 12-/16-Bit, Serial Input,&lt;br&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="BN" package="DIP-300-24">
+<device name="BN" package="DIP-24-254P-762W">
 <connects>
 <connect gate="-1" pin="A" pad="18"/>
 <connect gate="-1" pin="B" pad="16"/>
@@ -10127,7 +10127,7 @@ Single-Channel, 12-/16-Bit, Serial Input,&lt;br&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="BR" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="BR" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="-1" pin="A" pad="18"/>
 <connect gate="-1" pin="B" pad="16"/>
@@ -10170,7 +10170,7 @@ Single-Channel, 12-/16-Bit, Serial Input,&lt;br&gt;
 <gate name="-CNTL" symbol="AD5204" x="0" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="BN" package="DIP-300-24">
+<device name="BN" package="DIP-24-254P-762W">
 <connects>
 <connect gate="-1" pin="A" pad="18"/>
 <connect gate="-1" pin="B" pad="16"/>
@@ -10198,7 +10198,7 @@ Single-Channel, 12-/16-Bit, Serial Input,&lt;br&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="BR" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="BR" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="-1" pin="A" pad="18"/>
 <connect gate="-1" pin="B" pad="16"/>
@@ -10226,7 +10226,7 @@ Single-Channel, 12-/16-Bit, Serial Input,&lt;br&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="BRU" package="SSOP-65P-440W-780L-120H-100F-24">
+<device name="BRU" package="SSOP-24-65P-440W-780L-120H-100F">
 <connects>
 <connect gate="-1" pin="A" pad="18"/>
 <connect gate="-1" pin="B" pad="16"/>
@@ -10263,7 +10263,7 @@ Single-Channel, 12-/16-Bit, Serial Input,&lt;br&gt;
 <gate name="G$1" symbol="REF03" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="TRIM" pad="5"/>
@@ -10274,7 +10274,7 @@ Single-Channel, 12-/16-Bit, Serial Input,&lt;br&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="TRIM" pad="5"/>
@@ -10314,7 +10314,7 @@ Micropower, Low Noise with Shutdown</description>
 <gate name="G$1" symbol="ADM3483E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -10401,7 +10401,7 @@ CMOS Low Voltage, 2-ohm SPST</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="RM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="RM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="D" pad="1"/>
 <connect gate="G$1" pin="IN" pad="6"/>
@@ -10423,7 +10423,7 @@ CMOS Low Voltage, 2-ohm SPST</description>
 <gate name="P" symbol="PWRN_VDDGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="RM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="RM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="D" pad="1"/>
 <connect gate="G$1" pin="IN" pad="6"/>
@@ -10469,7 +10469,7 @@ CMOS Low Voltage, 4-ohm DPDT</description>
 <gate name="P" symbol="PWRN_VDDGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="RM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="RM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="D" pad="1"/>
 <connect gate="G$1" pin="IN" pad="6"/>
@@ -10504,7 +10504,7 @@ adjustable output LDO regulator</description>
 <gate name="G$1" symbol="ADP3334" x="0" y="0"/>
 </gates>
 <devices>
-<device name="AR" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="AR" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FB" pad="7"/>
 <connect gate="G$1" pin="GND" pad="1"/>
@@ -10519,7 +10519,7 @@ adjustable output LDO regulator</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="ARM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="ARM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="FB" pad="3"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -10595,7 +10595,7 @@ SPI Interface, 2.7 V to 5.5 V, &lt;100 ?A, 8-/10-/12-Bit</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -10673,7 +10673,7 @@ Rail-to-Rail, Very Fast, 2.5 V to 5.5 V, Single-Supply</description>
 <gate name="G$1" symbol="AD8132" x="0" y="0"/>
 </gates>
 <devices>
-<device name="R" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="-IN" pad="1"/>
@@ -10687,7 +10687,7 @@ Rail-to-Rail, Very Fast, 2.5 V to 5.5 V, Single-Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="RM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="RM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="-IN" pad="1"/>
@@ -10709,7 +10709,7 @@ Rail-to-Rail, Very Fast, 2.5 V to 5.5 V, Single-Supply</description>
 <gate name="G$1" symbol="AD8129/8130" x="0" y="0"/>
 </gates>
 <devices>
-<device name="RM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="RM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="1"/>
 <connect gate="G$1" pin="-IN" pad="8"/>
@@ -10724,7 +10724,7 @@ Rail-to-Rail, Very Fast, 2.5 V to 5.5 V, Single-Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="1"/>
 <connect gate="G$1" pin="-IN" pad="8"/>
@@ -10748,7 +10748,7 @@ Rail-to-Rail, Very Fast, 2.5 V to 5.5 V, Single-Supply</description>
 <gate name="G$1" symbol="AD8314" x="0" y="0"/>
 </gates>
 <devices>
-<device name="RM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="RM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="COMM" pad="5"/>
 <connect gate="G$1" pin="ENBL" pad="2"/>
@@ -10921,7 +10921,7 @@ Rail-to-Rail, Very Fast, 2.5 V to 5.5 V, Single-Supply</description>
 <gate name="G$1" symbol="ADF4110" x="0" y="0"/>
 </gates>
 <devices>
-<device name="BRU" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="BRU" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="4"/>
 <connect gate="G$1" pin="AVDD" pad="7"/>
@@ -10992,7 +10992,7 @@ Analog Devices</description>
 <gate name="G$1" symbol="ADF4002BRU" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="4"/>
 <connect gate="G$1" pin="AVDD" pad="7"/>
@@ -11147,7 +11147,7 @@ Dual 12 Bit, 250 MSPS</description>
 <gate name="G$1" symbol="AD7992" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-300W-300L-110H-95F-10">
+<device name="" package="SSOP-10-50P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!CONVST!" pad="1"/>
 <connect gate="G$1" pin="AGND@2" pad="2"/>
@@ -11172,7 +11172,7 @@ Dual 12 Bit, 250 MSPS</description>
 <gate name="G$1" symbol="ADE7763" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-20">
+<device name="" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="17"/>
 <connect gate="G$1" pin="!IRQ!" pad="14"/>
@@ -11250,7 +11250,7 @@ Dual 12 Bit, 250 MSPS</description>
 <gate name="G$1" symbol="ADUM4160" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="DD+" pad="10"/>
 <connect gate="G$1" pin="DD-" pad="11"/>
@@ -11305,7 +11305,7 @@ Dual 12 Bit, 250 MSPS</description>
 <gate name="G$1" symbol="AD7740" x="0" y="0"/>
 </gates>
 <devices>
-<device name="RM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="RM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="BUF" pad="8"/>
 <connect gate="G$1" pin="CLKIN" pad="2"/>
@@ -11486,7 +11486,7 @@ Single-Supply, Rail-to-Rail, Fast, Low Power 2.5 V to 5.5 V</description>
 <gate name="G$1" symbol="AD8362" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="ACOM@10" pad="10"/>
 <connect gate="G$1" pin="ACOM@16" pad="16"/>
@@ -11558,7 +11558,7 @@ Single Channel, 12-/16-Bit, Serial Input, HART Connectivity</description>
 <gate name="G$1" symbol="AD7660" x="0" y="0"/>
 </gates>
 <devices>
-<device name="ST-48" package="LQFP-50P-700W-700L-160H-48">
+<device name="ST-48" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!CNVST!" pad="35"/>
 <connect gate="G$1" pin="!CS!" pad="32"/>
@@ -11610,7 +11610,7 @@ Single Channel, 12-/16-Bit, Serial Input, HART Connectivity</description>
 <gate name="G$1" symbol="ADR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="R" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="TEMP" pad="3"/>
@@ -11649,7 +11649,7 @@ Single Channel, 12-/16-Bit, Serial Input, HART Connectivity</description>
 <gate name="G$1" symbol="ADR42" x="0" y="0"/>
 </gates>
 <devices>
-<device name="R" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="TRIM" pad="5"/>
@@ -11663,7 +11663,7 @@ Single Channel, 12-/16-Bit, Serial Input, HART Connectivity</description>
 <technology name="5"/>
 </technologies>
 </device>
-<device name="RM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="RM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="TRIM" pad="5"/>
@@ -11686,7 +11686,7 @@ Single Channel, 12-/16-Bit, Serial Input, HART Connectivity</description>
 <gate name="G$1" symbol="AD5764" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-700W-700L-120H-32">
+<device name="" package="TQFP-32-80P-700W-700L-120H">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="5"/>
 <connect gate="G$1" pin="!LDAC!" pad="6"/>
@@ -11734,7 +11734,7 @@ Low Power, Wide Supply Range, Unity-Gain Difference Amplifiers</description>
 <gate name="G$1" symbol="AD8276" x="0" y="0"/>
 </gates>
 <devices>
-<device name="RM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="RM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="3"/>
 <connect gate="G$1" pin="IN-" pad="2"/>
@@ -11748,7 +11748,7 @@ Low Power, Wide Supply Range, Unity-Gain Difference Amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="3"/>
 <connect gate="G$1" pin="IN-" pad="2"/>
@@ -11845,7 +11845,7 @@ TXRX DUAL RS232 3.3V</description>
 <gate name="G$2" symbol="ADM3202" x="33.02" y="-12.7"/>
 </gates>
 <devices>
-<device name="R" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="R" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="C1+" pad="1"/>
 <connect gate="G$2" pin="C1-" pad="3"/>
@@ -11868,7 +11868,7 @@ TXRX DUAL RS232 3.3V</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="RW" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="RW" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$2" pin="C1+" pad="1"/>
 <connect gate="G$2" pin="C1-" pad="3"/>
@@ -11891,7 +11891,7 @@ TXRX DUAL RS232 3.3V</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="RU" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="RU" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$2" pin="C1+" pad="1"/>
 <connect gate="G$2" pin="C1-" pad="3"/>
@@ -11914,7 +11914,7 @@ TXRX DUAL RS232 3.3V</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$2" pin="C1+" pad="1"/>
 <connect gate="G$2" pin="C1-" pad="3"/>
@@ -11987,7 +11987,7 @@ TXRX DUAL RS232 3.3V</description>
 <gate name="G$1" symbol="ADM708S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="R" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="1"/>
 <connect gate="G$1" pin="!PFO!" pad="5"/>
@@ -12001,7 +12001,7 @@ TXRX DUAL RS232 3.3V</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="1"/>
 <connect gate="G$1" pin="!PFO!" pad="5"/>
@@ -12026,7 +12026,7 @@ TXRX DUAL RS232 3.3V</description>
 <gate name="G$1" symbol="ADG1433" x="38.1" y="-5.08" addlevel="always"/>
 </gates>
 <devices>
-<device name="RU" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="RU" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="D" pad="3"/>
 <connect gate="A" pin="SA" pad="2"/>
@@ -12084,7 +12084,7 @@ TXRX DUAL RS232 3.3V</description>
 <gate name="-4" symbol="ADG1434-SW" x="0" y="-45.72" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="-1" pin="D" pad="3"/>
 <connect gate="-1" pin="SA" pad="2"/>
@@ -12149,7 +12149,7 @@ TXRX DUAL RS232 3.3V</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="-1" pin="D" pad="3"/>
 <connect gate="-1" pin="SA" pad="2"/>
@@ -12221,7 +12221,7 @@ TXRX DUAL RS232 3.3V</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="RM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="RM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="D" pad="1"/>
 <connect gate="A" pin="GND" pad="3"/>
@@ -12241,7 +12241,7 @@ TXRX DUAL RS232 3.3V</description>
 <gates>
 </gates>
 <devices>
-<device name="RU" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="RU" package="SSOP-20-65P-440W-650L-120H-100F">
 <technologies>
 <technology name=""/>
 </technologies>
@@ -12258,7 +12258,7 @@ TXRX DUAL RS232 3.3V</description>
 <gate name="P" symbol="ADG734" x="-43.18" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="RU" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="RU" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="-1" pin="D" pad="3"/>
 <connect gate="-1" pin="IN" pad="1"/>

--- a/atmel-arm.lbr
+++ b/atmel-arm.lbr
@@ -108,7 +108,7 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <text x="-12.7" y="3.175" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-12.7" y="-3.81" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="LQFP-50P-1000W-1000L-160H-64">
+<package name="LQFP-64-50P-1000W-1000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
@@ -250,7 +250,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-700W-700L-160H-48">
+<package name="LQFP-48-50P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
@@ -360,7 +360,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-1400W-1400L-160H-100">
+<package name="LQFP-100-50P-1400W-1400L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BED, L-PQFP-G.
@@ -574,7 +574,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -1945,7 +1945,7 @@ pitch 0.80, outline 15x15 mm</description>
 <rectangle x1="6.096" y1="1.016" x2="6.604" y2="1.524" layer="51"/>
 <rectangle x1="6.096" y1="-1.524" x2="6.604" y2="-1.016" layer="51"/>
 </package>
-<package name="LQFP-50P-2000W-2000L-160H-144">
+<package name="LQFP-144-50P-2000W-2000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
@@ -2247,7 +2247,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-2000W-2000L-120H-144">
+<package name="TQFP-144-50P-2000W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
@@ -3726,7 +3726,7 @@ ARM7 Processor</description>
 <gate name="G$1" symbol="AT91SAM7S512/256/128/64/321" x="2.54" y="7.62"/>
 </gates>
 <devices>
-<device name="-AU" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="-AU" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="AD0/PCK1/TD/PA17" pad="9"/>
 <connect gate="G$1" pin="AD1/PCK2/RD/PA18" pad="10"/>
@@ -3895,7 +3895,7 @@ ARM7 Processor</description>
 <gate name="G$1" symbol="AT91SAM7S32/16" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-AU" package="LQFP-50P-700W-700L-160H-48">
+<device name="-AU" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="AD0/PGMD5/PA17" pad="9"/>
 <connect gate="G$1" pin="AD1/PGMD6/PA18" pad="10"/>
@@ -3959,7 +3959,7 @@ ARM7 Processor</description>
 <gate name="G$1" symbol="AT91SAM7X512/256/128" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-AU" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="-AU" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="AD0/PWM0/TIOA2/PB27" pad="9"/>
 <connect gate="G$1" pin="AD1/PWM1/TIOB2/PB28" pad="10"/>
@@ -4075,7 +4075,7 @@ ARM7 Processor</description>
 <gate name="G$1" symbol="AT91SAM7A3" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!NRST" pad="2"/>
 <connect gate="G$1" pin="ADC0_AD0/PB14" pad="80"/>

--- a/atmel-avr.lbr
+++ b/atmel-avr.lbr
@@ -78,7 +78,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="TQFP-80P-700W-700L-120H-32">
+<package name="TQFP-32-80P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.
@@ -156,7 +156,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1000W-1000L-120H-44">
+<package name="TQFP-44-80P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
@@ -258,7 +258,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-700W-700L-120H-48">
+<package name="TQFP-48-50P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
@@ -368,7 +368,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1400W-1400L-120H-64">
+<package name="TQFP-64-80P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.
@@ -510,7 +510,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -2087,7 +2087,7 @@ Enhanced</description>
 <text x="-5.715" y="-2.2225" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -2121,7 +2121,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-530W-530L-210H-125F-8">
+<package name="SOP-8-127P-530W-530L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -2534,7 +2534,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <rectangle x1="-2" y1="-2" x2="-0.5" y2="-0.5" layer="31"/>
 <rectangle x1="0.5" y1="-2" x2="2" y2="-0.5" layer="31"/>
 </package>
-<package name="TQFP-50P-2000W-2000L-120H-144">
+<package name="TQFP-144-50P-2000W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
@@ -4257,7 +4257,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="ATMEGA3250/6450" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="-A" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="(!SS!/PCINT8)PB0" pad="19"/>
 <connect gate="G$1" pin="(ADC0)PF0" pad="97"/>
@@ -4372,7 +4372,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="AT90CAN32/64/128" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A2" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="-A2" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="20"/>
 <connect gate="G$1" pin="(A10)PC2" pad="37"/>
@@ -4594,7 +4594,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="ATMEGA162" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="-A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="4"/>
 <connect gate="G$1" pin="(!WR!)PD6" pad="12"/>
@@ -4705,7 +4705,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="ATMEGA164P/324P/644P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="-A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="4"/>
 <connect gate="G$1" pin="(PCINT0/ADC0)PA0" pad="37"/>
@@ -4815,7 +4815,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="ATMEGA165P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="-A" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="(ICP1)PD0" pad="25"/>
 <connect gate="G$1" pin="(INT0)PD1" pad="26"/>
@@ -4966,7 +4966,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="ATMEGA169" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="-A" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="(AIN1/PCINT3)PE3" pad="5"/>
 <connect gate="G$1" pin="(CLKO/PCINT7)PE7" pad="9"/>
@@ -5117,7 +5117,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="ATMEGA325/645" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="-A" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="(!SS!/PCINT8)PB0" pad="10"/>
 <connect gate="G$1" pin="(AIN1/PCINT3)PE3" pad="5"/>
@@ -5267,7 +5267,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="ATMEGA329/649" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="-A" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="(AIN1/PCINT3)PE3" pad="5"/>
 <connect gate="G$1" pin="(CLKO/PCINT7)PE7" pad="9"/>
@@ -5420,7 +5420,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="ATMEGA640/1280/2560" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="-A" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="30"/>
 <connect gate="G$1" pin="(!RD!)PG1" pad="52"/>
@@ -5645,7 +5645,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="ATMEGA1281/2561" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="-A" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!(SS!/PCINT0)PB0" pad="10"/>
 <connect gate="G$1" pin="!RESET" pad="20"/>
@@ -5795,7 +5795,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="ATMEGA3290/6490" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="-A" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="(!SS!/PCINT8)PB0" pad="19"/>
 <connect gate="G$1" pin="(AIN1/PCINT3)PE3" pad="5"/>
@@ -5911,7 +5911,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="AT90USB646/647/1286/1287" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-MD" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="-MD" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="20"/>
 <connect gate="G$1" pin="(!RD!)PE1" pad="34"/>
@@ -6062,7 +6062,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="ATMEGA48P/88P/168P/328P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-80P-700W-700L-120H-32">
+<device name="-A" package="TQFP-32-80P-700W-700L-120H">
 <connects>
 <connect gate="G$1" pin="(PCINT0/CLKO/ICP1)PB0" pad="12"/>
 <connect gate="G$1" pin="(PCINT1/OC1A)PB1" pad="13"/>
@@ -6151,7 +6151,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="ATMEGA1284P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="-A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="4"/>
 <connect gate="G$1" pin="(PCINT0/ADC0)PA0" pad="37"/>
@@ -6261,7 +6261,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="ATXMEGA16D4/32D4/64D4/128D4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="-A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(!SS!)PD4" pad="24"/>
 <connect gate="G$1" pin="(!SS!/OC1A/OC0CLS)PC4" pad="14"/>
@@ -6442,7 +6442,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <technology name=""/>
 </technologies>
 </device>
-<device name="-A" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="-A" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="(!SS!/OC1A)PD4" pad="30"/>
 <connect gate="G$1" pin="(!SS!/OC1A/OC0CLS)PC4" pad="20"/>
@@ -6537,7 +6537,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S2" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="-8S2" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="(PCINT0/OC0A/AIN0/MOSI)PB0" pad="5"/>
 <connect gate="G$1" pin="(PCINT1/INT0/OC0B/AIN1/MISO)PB1" pad="6"/>
@@ -6552,7 +6552,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S1" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="-8S1" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(PCINT0/OC0A/AIN0/MOSI)PB0" pad="5"/>
 <connect gate="G$1" pin="(PCINT1/INT0/OC0B/AIN1/MISO)PB1" pad="6"/>
@@ -6606,7 +6606,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="AT90USB82/162" x="17.78" y="12.7"/>
 </gates>
 <devices>
-<device name="A" package="TQFP-80P-700W-700L-120H-32">
+<device name="A" package="TQFP-32-80P-700W-700L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET!(PC1/DW)" pad="24"/>
 <connect gate="G$1" pin="(!CTS!/!HWB!/T0/INT7)PD7" pad="13"/>

--- a/atmel-avr32.lbr
+++ b/atmel-avr32.lbr
@@ -76,7 +76,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="LQFP-50P-2000W-2000L-160H-144">
+<package name="LQFP-144-50P-2000W-2000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
@@ -378,7 +378,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -1066,7 +1066,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="AT32UC3A1XXX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="18"/>
 <connect gate="G$1" pin="ADVREF" pad="60"/>
@@ -1241,7 +1241,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="&gt;NAME" symbol="AT32UC3A0XXX-IO" x="63.5" y="-43.18" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-2000W-2000L-160H-144">
+<device name="" package="LQFP-144-50P-2000W-2000L-160H">
 <connects>
 <connect gate="&gt;NAME" pin="!RESET" pad="23"/>
 <connect gate="&gt;NAME" pin="DAC-DATAN[0]/EIM-EXTINT[5]/USART0-CTS/PA04" pad="34"/>

--- a/atmel-xmega.lbr
+++ b/atmel-xmega.lbr
@@ -78,7 +78,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 20132, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -292,7 +292,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-700W-700L-120H-32">
+<package name="TQFP-32-80P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.
@@ -370,7 +370,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1000W-1000L-120H-44">
+<package name="TQFP-44-80P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
@@ -472,7 +472,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-700W-700L-120H-48">
+<package name="TQFP-48-50P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
@@ -582,7 +582,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1400W-1400L-120H-64">
+<package name="TQFP-64-80P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.
@@ -1473,7 +1473,7 @@ Enhanced</description>
 <gate name="G$1" symbol="ATXMEGA16D4/32D4/64D4/128D4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(!SS!)PD4" pad="24"/>
 <connect gate="G$1" pin="(!SS!/OC1A/OC0CLS)PC4" pad="14"/>
@@ -1654,7 +1654,7 @@ Enhanced</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="A" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="A" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="(!SS!/OC1A)PD4" pad="30"/>
 <connect gate="G$1" pin="(!SS!/OC1A/OC0CLS)PC4" pad="20"/>
@@ -1733,7 +1733,7 @@ Enhanced</description>
 <gate name="G$1" symbol="ATXMEGA128A1U" x="0" y="0"/>
 </gates>
 <devices>
-<device name="AU" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="AU" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="AVCC@4" pad="4"/>
 <connect gate="G$1" pin="AVCC@94" pad="94"/>
@@ -1908,7 +1908,7 @@ Enhanced</description>
 <gate name="G$1" symbol="ATXMEGA256/192/128/64A3U" x="0" y="0"/>
 </gates>
 <devices>
-<device name="A" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="A" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="(!SS!/OC1A)PD4" pad="30"/>
 <connect gate="G$1" pin="(!SS!/OC1A)PE4" pad="40"/>

--- a/atmel.lbr
+++ b/atmel.lbr
@@ -83,7 +83,7 @@ Based on the following sources:&lt;p&gt;
 &lt;/ul&gt;
 &lt;author&gt;Revised by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="PLCC-127P-1658W-1658L-457H-44">
+<package name="PLCC-44-127P-1658W-1658L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 16.59mm length, 16.59mm width, 4.57mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body width, 4.57mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AC.&lt;/p&gt;
@@ -193,7 +193,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <wire x1="8.2931" y1="7.015" x2="8.2931" y2="8.2931" width="0.2032" layer="21"/>
 <wire x1="8.2931" y1="8.2931" x2="7.015" y2="8.2931" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-SMD-11X11-44">
+<package name="PLCC-SOCKET-SMD-44-11X11">
 <description>&lt;b&gt;PLCC socket (1.27mm pitch, 44 leads, SMD)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 1.27mm lead pitch, 44 leads.
 &lt;/p&gt;</description>
@@ -445,7 +445,7 @@ Plastic leaded chip carrier socket. 1.27mm lead pitch, 44 leads.
 <wire x1="11.049" y1="-11.049" x2="11.049" y2="11.049" width="0.2032" layer="21"/>
 <wire x1="11.049" y1="11.049" x2="-10.033" y2="11.049" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-20">
+<package name="SSOP-20-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 20 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JEDEC MO-150B. Variation AE.</description>
 <circle x="-2.885" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -899,7 +899,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <rectangle x1="-2.921" y1="-0.381" x2="-2.159" y2="0.381" layer="21" rot="R180"/>
 <rectangle x1="-2.921" y1="-2.159" x2="-2.159" y2="-0.381" layer="51" rot="R180"/>
 </package>
-<package name="TQFP-80P-700W-700L-120H-32">
+<package name="TQFP-32-80P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.
@@ -977,7 +977,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-700W-700L-120H-48">
+<package name="TQFP-48-50P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
@@ -1087,7 +1087,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-2000W-2000L-120H-144">
+<package name="TQFP-144-50P-2000W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
@@ -1389,7 +1389,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1400W-1400L-120H-64">
+<package name="TQFP-64-80P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.
@@ -1531,7 +1531,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-11X11-44">
+<package name="PLCC-SOCKET-TH-44-11X11">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 44 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 &lt;/p&gt;</description>
@@ -1782,7 +1782,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <wire x1="11.43" y1="-11.43" x2="11.43" y2="11.43" width="0.2032" layer="21"/>
 <wire x1="11.43" y1="11.43" x2="-10.16" y2="11.43" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-700W-700L-160H-48">
+<package name="LQFP-48-50P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
@@ -1892,7 +1892,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-1000W-1000L-160H-64">
+<package name="LQFP-64-50P-1000W-1000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
@@ -2176,7 +2176,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <rectangle x1="-3.375" y1="4" x2="-3.125" y2="4.5" layer="51"/>
 <rectangle x1="-3.875" y1="4" x2="-3.625" y2="4.5" layer="51"/>
 </package>
-<package name="TQFP-80P-1000W-1000L-120H-44">
+<package name="TQFP-44-80P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
@@ -2278,7 +2278,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -2545,7 +2545,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <text x="-2.5" y="-5.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <rectangle x1="-3.5" y1="2.8" x2="-2.8" y2="3.5" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -2565,7 +2565,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -2597,7 +2597,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -2649,7 +2649,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -2689,7 +2689,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -2723,7 +2723,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -2841,7 +2841,7 @@ pitch 0.5 mm, body 5x5 mm</description>
 <rectangle x1="0.75" y1="-1.25" x2="1.25" y2="-0.75" layer="31"/>
 <rectangle x1="-1.25" y1="-1.25" x2="-0.75" y2="-0.75" layer="31"/>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -5971,7 +5971,7 @@ UART&lt;p&gt;
 <gate name="G$1" symbol="32-I/O-3" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="40"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="39"/>
@@ -6033,7 +6033,7 @@ UART&lt;p&gt;
 <gate name="G$1" symbol="32-I/O-4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="J-S" package="PLCC-SOCKET-TH-11X11-44">
+<device name="J-S" package="PLCC-SOCKET-TH-44-11X11">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="43"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="42"/>
@@ -6085,7 +6085,7 @@ UART&lt;p&gt;
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="J" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="43"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="42"/>
@@ -6137,7 +6137,7 @@ UART&lt;p&gt;
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J-SM" package="PLCC-SOCKET-SMD-11X11-44">
+<device name="J-SM" package="PLCC-SOCKET-SMD-44-11X11">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="43"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="42"/>
@@ -6189,7 +6189,7 @@ UART&lt;p&gt;
 <technology name="S"/>
 </technologies>
 </device>
-<device name="A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="37"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="36"/>
@@ -6253,7 +6253,7 @@ UART&lt;p&gt;
 <gate name="G$1" symbol="32-I/O-3" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="40"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="39"/>
@@ -6314,7 +6314,7 @@ UART&lt;p&gt;
 <gate name="G$1" symbol="32-I/O-4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="J-S" package="PLCC-SOCKET-TH-11X11-44">
+<device name="J-S" package="PLCC-SOCKET-TH-44-11X11">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="43"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="42"/>
@@ -6366,7 +6366,7 @@ UART&lt;p&gt;
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J-SM" package="PLCC-SOCKET-SMD-11X11-44">
+<device name="J-SM" package="PLCC-SOCKET-SMD-44-11X11">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="43"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="42"/>
@@ -6418,7 +6418,7 @@ UART&lt;p&gt;
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="J" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="43"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="42"/>
@@ -6470,7 +6470,7 @@ UART&lt;p&gt;
 <technology name="S"/>
 </technologies>
 </device>
-<device name="A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="37"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="36"/>
@@ -6533,7 +6533,7 @@ UART</description>
 <gate name="G$1" symbol="32-I/O-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-40">
+<device name="P" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="23"/>
 <connect gate="G$1" pin="(A11)PC3" pad="24"/>
@@ -6580,7 +6580,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="J1" package="PLCC-SOCKET-TH-11X11-44">
+<device name="J1" package="PLCC-SOCKET-TH-44-11X11">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="26"/>
 <connect gate="G$1" pin="(A11)PC3" pad="27"/>
@@ -6627,7 +6627,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="J2" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="J2" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="26"/>
 <connect gate="G$1" pin="(A11)PC3" pad="27"/>
@@ -6674,7 +6674,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="J3" package="PLCC-SOCKET-SMD-11X11-44">
+<device name="J3" package="PLCC-SOCKET-SMD-44-11X11">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="26"/>
 <connect gate="G$1" pin="(A11)PC3" pad="27"/>
@@ -6721,7 +6721,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="20"/>
 <connect gate="G$1" pin="(A11)PC3" pad="21"/>
@@ -6780,7 +6780,7 @@ UART</description>
 <gate name="G$1" symbol="32-I/O-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="20"/>
 <connect gate="G$1" pin="(A11)PC3" pad="21"/>
@@ -6843,7 +6843,7 @@ UART</description>
 <gate name="G$1" symbol="32-I/O-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="J-S" package="PLCC-SOCKET-TH-11X11-44">
+<device name="J-S" package="PLCC-SOCKET-TH-44-11X11">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="26"/>
 <connect gate="G$1" pin="(A11)PC3" pad="27"/>
@@ -6894,7 +6894,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="J" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="J" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="26"/>
 <connect gate="G$1" pin="(A11)PC3" pad="27"/>
@@ -6945,7 +6945,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="J-SM" package="PLCC-SOCKET-SMD-11X11-44">
+<device name="J-SM" package="PLCC-SOCKET-SMD-44-11X11">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="26"/>
 <connect gate="G$1" pin="(A11)PC3" pad="27"/>
@@ -6996,7 +6996,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="20"/>
 <connect gate="G$1" pin="(A11)PC3" pad="21"/>
@@ -7059,7 +7059,7 @@ UART</description>
 <gate name="G$1" symbol="32-I/O-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="23"/>
 <connect gate="G$1" pin="(A11)PC3" pad="24"/>
@@ -7119,7 +7119,7 @@ UART&lt;p&gt;
 <gate name="G$1" symbol="20-I/O-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="A" package="TQFP-80P-700W-700L-120H-32">
+<device name="A" package="TQFP-32-80P-700W-700L-120H">
 <connects>
 <connect gate="G$1" pin="(ADC0)PC0" pad="23"/>
 <connect gate="G$1" pin="(ADC1)PC1" pad="24"/>
@@ -7171,7 +7171,7 @@ UART&lt;p&gt;
 <gate name="G$1" symbol="20-I/O-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="(ADC0)PC0)" pad="23"/>
 <connect gate="G$1" pin="(ADC1)PC1" pad="24"/>
@@ -7219,7 +7219,7 @@ UART&lt;p&gt;
 <gate name="G$1" symbol="20-I/O-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="(ADC0)PC0)" pad="23"/>
 <connect gate="G$1" pin="(ADC1)PC1" pad="24"/>
@@ -7254,7 +7254,7 @@ UART&lt;p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="A" package="TQFP-80P-700W-700L-120H-32">
+<device name="A" package="TQFP-32-80P-700W-700L-120H">
 <connects>
 <connect gate="G$1" pin="(ADC0)PC0)" pad="23"/>
 <connect gate="G$1" pin="(ADC1)PC1" pad="24"/>
@@ -7300,7 +7300,7 @@ UART&lt;p&gt;
 <gate name="G$1" symbol="3-I/O-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="(MISO)PB1" pad="6"/>
 <connect gate="G$1" pin="(MOSI)PB0" pad="5"/>
@@ -7316,7 +7316,7 @@ UART&lt;p&gt;
 <technology name="S"/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(MISO)PB1" pad="6"/>
 <connect gate="G$1" pin="(MOSI)PB0" pad="5"/>
@@ -7343,7 +7343,7 @@ UART&lt;p&gt;
 <gate name="G$1" symbol="5-I/O-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(CLOCK)PB3" pad="2"/>
 <connect gate="G$1" pin="(MISO)PB1" pad="6"/>
@@ -7359,7 +7359,7 @@ UART&lt;p&gt;
 <technology name="S"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="(CLOCK)PB3" pad="2"/>
 <connect gate="G$1" pin="(MISO)PB1" pad="6"/>
@@ -7387,7 +7387,7 @@ UART</description>
 <gate name="G$1" symbol="15-I/O-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-20">
+<device name="P" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="(AIN0)PB0" pad="12"/>
 <connect gate="G$1" pin="(AIN1)PB1" pad="13"/>
@@ -7414,7 +7414,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="S" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="(AIN0)PB0" pad="12"/>
 <connect gate="G$1" pin="(AIN1)PB1" pad="13"/>
@@ -7451,7 +7451,7 @@ UART</description>
 <gate name="G$1" symbol="15-I/O-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-20">
+<device name="P" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="(AIN0)PB0" pad="12"/>
 <connect gate="G$1" pin="(AIN1)PB1" pad="13"/>
@@ -7478,7 +7478,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="S" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="(AIN0)PB0" pad="12"/>
 <connect gate="G$1" pin="(AIN1)PB1" pad="13"/>
@@ -7505,7 +7505,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="Y" package="SSOP-065-530-20">
+<device name="Y" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="(AIN0)PB0" pad="12"/>
 <connect gate="G$1" pin="(AIN1)PB1" pad="13"/>
@@ -7541,7 +7541,7 @@ UART</description>
 <gate name="G$1" symbol="6-I/O-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="(AIN0)PB0" pad="5"/>
 <connect gate="G$1" pin="(AIN1)PB1" pad="6"/>
@@ -7556,7 +7556,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(AIN0)PB0" pad="5"/>
 <connect gate="G$1" pin="(AIN1)PB1" pad="6"/>
@@ -7580,7 +7580,7 @@ UART</description>
 <gate name="G$1" symbol="6-I/O-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="(AIN0)PB0" pad="5"/>
 <connect gate="G$1" pin="(AIN1)PB1" pad="6"/>
@@ -7596,7 +7596,7 @@ UART</description>
 <technology name="L"/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(AIN0)PB0" pad="5"/>
 <connect gate="G$1" pin="(AIN1)PB1" pad="6"/>
@@ -7622,7 +7622,7 @@ UART</description>
 <gate name="G$1" symbol="6-I/O-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="(MISO)PB1" pad="6"/>
 <connect gate="G$1" pin="(MOSI)PB0" pad="5"/>
@@ -7637,7 +7637,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(MISO)PB1" pad="6"/>
 <connect gate="G$1" pin="(MOSI)PB0" pad="5"/>
@@ -7663,7 +7663,7 @@ UART</description>
 <gate name="G$1" symbol="5-I/O-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="(CLOCK)PB3" pad="2"/>
 <connect gate="G$1" pin="(MISO)PB1" pad="6"/>
@@ -7678,7 +7678,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(CLOCK)PB3" pad="2"/>
 <connect gate="G$1" pin="(MISO)PB1" pad="6"/>
@@ -7708,7 +7708,7 @@ RTC&lt;p&gt;
 <gate name="G$1" symbol="48-I/O-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="37"/>
 <connect gate="G$1" pin="(A11)PC3" pad="38"/>
@@ -7793,7 +7793,7 @@ RTC&lt;p&gt;
 <gate name="G$1" symbol="15-I/O-3" x="0" y="0"/>
 </gates>
 <devices>
-<device name="A" package="TQFP-50P-700W-700L-120H-48">
+<device name="A" package="TQFP-48-50P-700W-700L-120H">
 <connects>
 <connect gate="G$1" pin="ADIN0" pad="1"/>
 <connect gate="G$1" pin="ADIN1" pad="13"/>
@@ -7861,7 +7861,7 @@ hardware multiplier</description>
 <gate name="G$1" symbol="35-I/O-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="23"/>
 <connect gate="G$1" pin="(A11)PC3" pad="24"/>
@@ -7922,7 +7922,7 @@ hardware multiplier</description>
 <gate name="G$1" symbol="35-I/O-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="J" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="J" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="26"/>
 <connect gate="G$1" pin="(A11)PC3" pad="27"/>
@@ -7974,7 +7974,7 @@ hardware multiplier</description>
 <technology name="L"/>
 </technologies>
 </device>
-<device name="J-S" package="PLCC-SOCKET-TH-11X11-44">
+<device name="J-S" package="PLCC-SOCKET-TH-44-11X11">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="26"/>
 <connect gate="G$1" pin="(A11)PC3" pad="27"/>
@@ -8025,7 +8025,7 @@ hardware multiplier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="J-SM" package="PLCC-SOCKET-SMD-11X11-44">
+<device name="J-SM" package="PLCC-SOCKET-SMD-44-11X11">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="26"/>
 <connect gate="G$1" pin="(A11)PC3" pad="27"/>
@@ -8076,7 +8076,7 @@ hardware multiplier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="20"/>
 <connect gate="G$1" pin="(A11)PC3" pad="21"/>
@@ -8139,7 +8139,7 @@ hardware multiplier</description>
 <gate name="G$1" symbol="6-I/O-3" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="(ADC0)PB5" pad="1"/>
 <connect gate="G$1" pin="(ADC1)PB2" pad="7"/>
@@ -8154,7 +8154,7 @@ hardware multiplier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(ADC0)PB5" pad="1"/>
 <connect gate="G$1" pin="(ADC1)PB2" pad="7"/>
@@ -8183,7 +8183,7 @@ hardware multiplier</description>
 <gate name="G$1" symbol="32-I/O-5" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="40"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="39"/>
@@ -8245,7 +8245,7 @@ hardware multiplier</description>
 <gate name="G$1" symbol="32-I/O-6" x="0" y="0"/>
 </gates>
 <devices>
-<device name="A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="37"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="36"/>
@@ -8306,7 +8306,7 @@ hardware multiplier</description>
 <gate name="G$1" symbol="20-I/O-3" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="(IR)PA2" pad="25"/>
 <connect gate="G$1" pin="GND" pad="8"/>
@@ -8352,7 +8352,7 @@ hardware multiplier</description>
 <gate name="G$1" symbol="20-I/O-4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="A" package="TQFP-80P-700W-700L-120H-32">
+<device name="A" package="TQFP-32-80P-700W-700L-120H">
 <connects>
 <connect gate="G$1" pin="(IR)PA2" pad="25"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -8407,7 +8407,7 @@ RTC&lt;p&gt;
 <gate name="G$1" symbol="48-I/O-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="01" pad="21"/>
 <connect gate="G$1" pin="02" pad="22"/>
@@ -8532,7 +8532,7 @@ USART&lt;p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="-AI" package="TQFP-80P-700W-700L-120H-32">
+<device name="-AI" package="TQFP-32-80P-700W-700L-120H">
 <connects>
 <connect gate="G$1" pin="(ADC0)PC0" pad="23"/>
 <connect gate="G$1" pin="(ADC1)PC1" pad="24"/>
@@ -8585,7 +8585,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="23-I/O-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="22"/>
 <connect gate="G$1" pin="AREF" pad="21"/>
@@ -8633,7 +8633,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="32-I/O-M8535-A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="-A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="37"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="36"/>
@@ -8735,7 +8735,7 @@ USART&lt;p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="-J" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="-J" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="43"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="42"/>
@@ -8799,7 +8799,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="32-I/O-M8535-P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="40"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="39"/>
@@ -8859,7 +8859,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="32-I/O-7" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="23"/>
 <connect gate="G$1" pin="(A11)PC3" pad="24"/>
@@ -8919,7 +8919,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="32-I/O-M8515-A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="-A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="20"/>
 <connect gate="G$1" pin="(A11)PC3" pad="21"/>
@@ -9021,7 +9021,7 @@ USART&lt;p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="-J" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="-J" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="(A10)PC2" pad="26"/>
 <connect gate="G$1" pin="(A11)PC3" pad="27"/>
@@ -9136,7 +9136,7 @@ USART&lt;p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="-A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="-A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="37"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="36"/>
@@ -9200,7 +9200,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="32-I/O-M16-P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="40"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="39"/>
@@ -9311,7 +9311,7 @@ USART&lt;p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="-A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="-A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="37"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="36"/>
@@ -9375,7 +9375,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="32-I/O-M32-P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="40"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="39"/>
@@ -9506,7 +9506,7 @@ DUAL USART&lt;p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="-A" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="-A" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="20"/>
 <connect gate="G$1" pin="(A10)PC2" pad="37"/>
@@ -9661,7 +9661,7 @@ DUAL USART&lt;p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="-A" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="-A" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!PEN!" pad="1"/>
 <connect gate="G$1" pin="!RESET!" pad="20"/>
@@ -9817,7 +9817,7 @@ USART&lt;p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="-A" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="-A" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="(AIN1/PCINT3)PE3" pad="5"/>
 <connect gate="G$1" pin="(CLKO/PCINT7)PE7" pad="9"/>
@@ -9901,7 +9901,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="MEGA323" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="9"/>
 <connect gate="G$1" pin="(ADC0)PA0" pad="40"/>
@@ -9961,7 +9961,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="MEGA323-A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-A" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="-A" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="4"/>
 <connect gate="G$1" pin="(ADC0)PA0" pad="37"/>
@@ -10138,7 +10138,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="TINY26" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="20"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="19"/>
@@ -10173,7 +10173,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="SAM9708" x="0" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-2000W-2000L-120H-144">
+<device name="" package="TQFP-144-50P-2000W-2000L-120H">
 <connects>
 <connect gate="G$1" pin="A0" pad="12"/>
 <connect gate="G$1" pin="A1" pad="13"/>
@@ -10384,7 +10384,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="MEGA1281/2561" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!(SS!/PCINT0)PB0" pad="10"/>
 <connect gate="G$1" pin="!RESET!" pad="20"/>
@@ -10464,7 +10464,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="AT90USB64/128" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="20"/>
 <connect gate="G$1" pin="(#RD)PE1" pad="34"/>
@@ -10544,7 +10544,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="MEGA162" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!(SS!/OC3B)PB4" pad="5"/>
 <connect gate="G$1" pin="!RESET!" pad="9"/>
@@ -10670,7 +10670,7 @@ USART&lt;p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="A" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="A" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="20"/>
 <connect gate="G$1" pin="(AIN1/PCINT3)PE3" pad="5"/>
@@ -10750,7 +10750,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="MEGA162-44" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-AU" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="-AU" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!(SS!/OC3B)PB4" pad="44"/>
 <connect gate="G$1" pin="(A10/PCINT10)PC2" pad="20"/>
@@ -10815,7 +10815,7 @@ SINGLE USART&lt;p&gt;
 <gate name="G$1" symbol="MEGA325P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!(SS!/PCINT8)PB0" pad="10"/>
 <connect gate="G$1" pin="!RESET!/PG5" pad="20"/>
@@ -10993,7 +10993,7 @@ Low Power Transceiver  for ZigBee, IEEE 802.15.4,&lt;br&gt;
 <gate name="G$1" symbol="TINY24A-14S1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(PCINT0/AREF/ADC0)PA0" pad="13"/>
 <connect gate="G$1" pin="(PCINT1/AIN0/ADC1)PA1" pad="12"/>

--- a/burr-brown.lbr
+++ b/burr-brown.lbr
@@ -123,7 +123,7 @@
 <rectangle x1="1.016" y1="3.175" x2="1.524" y2="4.826" layer="51"/>
 <rectangle x1="3.556" y1="3.175" x2="4.064" y2="4.826" layer="51"/>
 </package>
-<package name="SOP-127P-890W-1790L-265H-155F-28">
+<package name="SOP-28-127P-890W-1790L-265H-155F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 17.90mm length, 8.90mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body length,
 8.90mm body width, 2.65mm max height, 28 leads.
@@ -566,7 +566,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <rectangle x1="-6.7691" y1="-4.5085" x2="-6.5659" y2="-3.6703" layer="51"/>
 <rectangle x1="-7.4041" y1="-4.5085" x2="-7.2009" y2="-3.6703" layer="51"/>
 </package>
-<package name="PLCC-127P-2423W-2423L-457H-68">
+<package name="PLCC-68-127P-2423W-2423L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 24.23mm length, 24.23mm width, 4.57mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body width, 4.57mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AE.&lt;/p&gt;
@@ -794,7 +794,7 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <rectangle x1="-3.5941" y1="-4.5085" x2="-3.3909" y2="-3.6703" layer="51"/>
 <rectangle x1="-4.2291" y1="-4.5085" x2="-4.0259" y2="-3.6703" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1155L-265H-140F-18">
+<package name="SOP-18-127P-750W-1155L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
@@ -847,7 +847,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -1104,7 +1104,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <rectangle x1="2.1214" y1="-3.429" x2="2.3246" y2="-2.5908" layer="51"/>
 <rectangle x1="2.7564" y1="-3.429" x2="2.9596" y2="-2.5908" layer="51"/>
 </package>
-<package name="SSOP-65P-610W-970L-120H-100F-28">
+<package name="SSOP-28-65P-610W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 6.1mm width, 1.20mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 6.1mm width, 1.20mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation DB, R-PDSO-G.&lt;/p&gt;
@@ -1173,7 +1173,7 @@ JEDEC MO-153F, variation DB, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.95" x2="4.75" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.95" x2="-4.75" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-780L-120H-100F-24">
+<package name="SSOP-24-65P-610W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 7.8mm length, 6.1mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm length, 6.1mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation DA, R-PDSO-G.&lt;/p&gt;
@@ -1234,7 +1234,7 @@ JEDEC MO-153F, variation DA, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.95" x2="3.8" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.95" x2="-3.8" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-20">
+<package name="SSOP-20-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 20 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JEDEC MO-150B. Variation AE.</description>
 <circle x="-2.885" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -1502,7 +1502,7 @@ msot008b.pdf</description>
 <rectangle x1="-0.635" y1="-9.525" x2="0.635" y2="-4.445" layer="51"/>
 <rectangle x1="1.905" y1="-9.525" x2="3.175" y2="-4.445" layer="51"/>
 </package>
-<package name="PLCC-127P-1150W-1150L-457H-28">
+<package name="PLCC-28-127P-1150W-1150L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 11.51mm length, 11.51mm width, 4.57mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 11.51mm body length, 11.51mm body width, 4.57mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AB.&lt;/p&gt;
@@ -1719,7 +1719,7 @@ Small outline package J-lead. Lead pitch 1.27mm, body width 400mil/10.15mm. 28 l
 <wire x1="9.3100" y1="4.9780" x2="9.3100" y2="-4.9780" width="0.2032" layer="21"/>
 <wire x1="9.3100" y1="4.9780" x2="8.8650" y2="4.9780" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-7X7-28">
+<package name="PLCC-SOCKET-TH-28-7X7">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 28 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 28 leads.
 &lt;/p&gt;</description>
@@ -1917,7 +1917,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <wire x1="1.45" y1="-0.65" x2="1.45" y2="0.65" width="0.2032" layer="21"/>
 <wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -1946,7 +1946,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <wire x1="1.4" y1="-1.4" x2="1.4" y2="1.4" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="1.4" x2="-1.4" y2="1.4" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-970L-200H-100F-28">
+<package name="SSOP-28-65P-610W-970L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 6.1mm width, 2.00mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 6.1mm width, 2.00mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation DB, R-PDSO-G.&lt;/p&gt;
@@ -2033,7 +2033,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <wire x1="3.25" y1="-1.75" x2="-3.25" y2="-1.75" width="0.2032" layer="21"/>
 <wire x1="3.25" y1="1.75" x2="3.25" y2="-1.75" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -2053,7 +2053,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -2079,7 +2079,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -2107,7 +2107,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -2137,7 +2137,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -2169,7 +2169,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -2209,7 +2209,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -2249,7 +2249,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -2304,7 +2304,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-11.43" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.35" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -2338,7 +2338,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -2384,7 +2384,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -2433,7 +2433,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -9147,7 +9147,7 @@ Low Power</description>
 <gate name="G$1" symbol="INA2128" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="INA+" pad="2"/>
 <connect gate="G$1" pin="INA-" pad="1"/>
@@ -9170,7 +9170,7 @@ Low Power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="INA+" pad="2"/>
 <connect gate="G$1" pin="INA-" pad="1"/>
@@ -9202,7 +9202,7 @@ Dual, Low Power, G = 10, 100</description>
 <gate name="G$1" symbol="INA2141" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="INA+" pad="2"/>
 <connect gate="G$1" pin="INA-" pad="1"/>
@@ -9225,7 +9225,7 @@ Dual, Low Power, G = 10, 100</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="INA+" pad="2"/>
 <connect gate="G$1" pin="INA-" pad="1"/>
@@ -9272,7 +9272,7 @@ Precision, Lowest Cost</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND1" pad="4"/>
 <connect gate="G$1" pin="GND2" pad="5"/>
@@ -9295,7 +9295,7 @@ Precision, Lowest Cost</description>
 <gate name="G$1" symbol="ADS7821" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="26"/>
 <connect gate="G$1" pin="!CS" pad="25"/>
@@ -9330,7 +9330,7 @@ Precision, Lowest Cost</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="26"/>
 <connect gate="G$1" pin="!CS" pad="25"/>
@@ -9373,7 +9373,7 @@ Precision, Lowest Cost</description>
 <gate name="G$1" symbol="ADS7820" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="26"/>
 <connect gate="G$1" pin="!CS" pad="25"/>
@@ -9408,7 +9408,7 @@ Precision, Lowest Cost</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="26"/>
 <connect gate="G$1" pin="!CS" pad="25"/>
@@ -9451,7 +9451,7 @@ Precision, Lowest Cost</description>
 <gate name="G$1" symbol="ADS7812" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="14"/>
 <connect gate="G$1" pin="!CONV" pad="12"/>
@@ -9474,7 +9474,7 @@ Precision, Lowest Cost</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="14"/>
 <connect gate="G$1" pin="!CONV" pad="12"/>
@@ -9505,7 +9505,7 @@ Precision, Lowest Cost</description>
 <gate name="G$1" symbol="ADS7821" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="26"/>
 <connect gate="G$1" pin="!CS" pad="25"/>
@@ -9540,7 +9540,7 @@ Precision, Lowest Cost</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="26"/>
 <connect gate="G$1" pin="!CS" pad="25"/>
@@ -9584,7 +9584,7 @@ Precision Switched Integrator Transimpedance</description>
 <gate name="G$1" symbol="IVC102" x="-5.08" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="-IN" pad="3"/>
 <connect gate="G$1" pin="AGND" pad="1"/>
@@ -9692,7 +9692,7 @@ Single-Ended 16-Channel/Differential 8-Channel</description>
 <gate name="G$1" symbol="MPC506" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="+V" pad="1"/>
 <connect gate="G$1" pin="-V" pad="27"/>
@@ -9727,7 +9727,7 @@ Single-Ended 16-Channel/Differential 8-Channel</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="+V" pad="1"/>
 <connect gate="G$1" pin="-V" pad="27"/>
@@ -9771,7 +9771,7 @@ Single-Ended 16-Channel/Differential 8-Channel</description>
 <gate name="G$1" symbol="MPC507" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="+V" pad="1"/>
 <connect gate="G$1" pin="-V" pad="27"/>
@@ -9806,7 +9806,7 @@ Single-Ended 16-Channel/Differential 8-Channel</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="+V" pad="1"/>
 <connect gate="G$1" pin="-V" pad="27"/>
@@ -9850,7 +9850,7 @@ Single-Ended 8-Channel/Differential 4-Channell</description>
 <gate name="G$1" symbol="MPC508" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+V" pad="13"/>
 <connect gate="G$1" pin="-V" pad="3"/>
@@ -9873,7 +9873,7 @@ Single-Ended 8-Channel/Differential 4-Channell</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+V" pad="13"/>
 <connect gate="G$1" pin="-V" pad="3"/>
@@ -9905,7 +9905,7 @@ Single-Ended 8-Channel/Differential 4-Channel</description>
 <gate name="G$1" symbol="MPC509" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+V" pad="14"/>
 <connect gate="G$1" pin="-V" pad="3"/>
@@ -9928,7 +9928,7 @@ Single-Ended 8-Channel/Differential 4-Channel</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+V" pad="14"/>
 <connect gate="G$1" pin="-V" pad="3"/>
@@ -10281,7 +10281,7 @@ Serial Interface</description>
 <gate name="G$1" symbol="DAC4814" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CLK" pad="19"/>
 <connect gate="G$1" pin="!CLR" pad="24"/>
@@ -10325,7 +10325,7 @@ Serial Interface</description>
 <gate name="G$1" symbol="DAC4815" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CLR" pad="14"/>
 <connect gate="G$1" pin="!CS" pad="16"/>
@@ -10368,7 +10368,7 @@ Serial Interface</description>
 <gate name="G$1" symbol="ADS7819" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="25"/>
 <connect gate="G$1" pin="!CS" pad="24"/>
@@ -10403,7 +10403,7 @@ Serial Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="25"/>
 <connect gate="G$1" pin="!CS" pad="24"/>
@@ -10446,7 +10446,7 @@ Serial Interface</description>
 <gate name="G$1" symbol="ADS7824" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="24"/>
 <connect gate="G$1" pin="!CS" pad="23"/>
@@ -10481,7 +10481,7 @@ Serial Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="24"/>
 <connect gate="G$1" pin="!CS" pad="23"/>
@@ -10524,7 +10524,7 @@ Serial Interface</description>
 <gate name="G$1" symbol="ADS7824" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="24"/>
 <connect gate="G$1" pin="!CS" pad="23"/>
@@ -10559,7 +10559,7 @@ Serial Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="24"/>
 <connect gate="G$1" pin="!CS" pad="23"/>
@@ -10602,7 +10602,7 @@ Serial Interface</description>
 <gate name="G$1" symbol="ADS7819" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="25"/>
 <connect gate="G$1" pin="!CS" pad="24"/>
@@ -10637,7 +10637,7 @@ Serial Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="25"/>
 <connect gate="G$1" pin="!CS" pad="24"/>
@@ -10681,7 +10681,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7833" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="AGND" pad="67"/>
 <connect gate="G$1" pin="AOUT" pad="62"/>
@@ -10764,7 +10764,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS800" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="E" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -10799,7 +10799,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -10842,7 +10842,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7819" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="25"/>
 <connect gate="G$1" pin="!CS" pad="24"/>
@@ -10877,7 +10877,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="25"/>
 <connect gate="G$1" pin="!CS" pad="24"/>
@@ -10920,7 +10920,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7817" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="E" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!CS!/SHDN" pad="5"/>
 <connect gate="G$1" pin="+IN" pad="2"/>
@@ -10935,7 +10935,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!/SHDN" pad="5"/>
 <connect gate="G$1" pin="+IN" pad="2"/>
@@ -10973,7 +10973,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7817" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="E" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!CS!/SHDN" pad="5"/>
 <connect gate="G$1" pin="+IN" pad="2"/>
@@ -10988,7 +10988,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!/SHDN" pad="5"/>
 <connect gate="G$1" pin="+IN" pad="2"/>
@@ -11026,7 +11026,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7806" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="24"/>
 <connect gate="G$1" pin="!CS" pad="23"/>
@@ -11061,7 +11061,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="24"/>
 <connect gate="G$1" pin="!CS" pad="23"/>
@@ -11104,7 +11104,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7806" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="24"/>
 <connect gate="G$1" pin="!CS" pad="23"/>
@@ -11139,7 +11139,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="24"/>
 <connect gate="G$1" pin="!CS" pad="23"/>
@@ -11182,7 +11182,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7809" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-20">
+<device name="P" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="17"/>
 <connect gate="G$1" pin="!CS" pad="16"/>
@@ -11209,7 +11209,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="U" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="17"/>
 <connect gate="G$1" pin="!CS" pad="16"/>
@@ -11244,7 +11244,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7812" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="14"/>
 <connect gate="G$1" pin="!CONV" pad="12"/>
@@ -11267,7 +11267,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="14"/>
 <connect gate="G$1" pin="!CONV" pad="12"/>
@@ -11298,7 +11298,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7815" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="26"/>
 <connect gate="G$1" pin="!CS" pad="25"/>
@@ -11341,7 +11341,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS1212" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-18">
+<device name="P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="5"/>
 <connect gate="G$1" pin="!DRDY" pad="14"/>
@@ -11366,7 +11366,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="U" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="5"/>
 <connect gate="G$1" pin="!DRDY" pad="14"/>
@@ -11399,7 +11399,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS1213" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-24">
+<device name="P" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="8"/>
 <connect gate="G$1" pin="!DRDY" pad="17"/>
@@ -11430,7 +11430,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="E" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="E" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="10"/>
 <connect gate="G$1" pin="!DRDY" pad="19"/>
@@ -11461,7 +11461,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="U" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="8"/>
 <connect gate="G$1" pin="!DRDY" pad="17"/>
@@ -11500,7 +11500,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS1212" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-18">
+<device name="P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="5"/>
 <connect gate="G$1" pin="!DRDY" pad="14"/>
@@ -11525,7 +11525,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="U" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="5"/>
 <connect gate="G$1" pin="!DRDY" pad="14"/>
@@ -11558,7 +11558,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS1211" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-24">
+<device name="P" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="8"/>
 <connect gate="G$1" pin="!DRDY" pad="17"/>
@@ -11620,7 +11620,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="U" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="8"/>
 <connect gate="G$1" pin="!DRDY" pad="17"/>
@@ -11659,7 +11659,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7817" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!/SHDN" pad="5"/>
 <connect gate="G$1" pin="+IN" pad="2"/>
@@ -11674,7 +11674,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!/SHDN" pad="5"/>
 <connect gate="G$1" pin="+IN" pad="2"/>
@@ -11698,7 +11698,7 @@ External Ref. and Low; Power, Powerdown</description>
 <gate name="G$1" symbol="ADS931" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="E" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!OE" pad="16"/>
 <connect gate="G$1" pin="+VS" pad="1"/>
@@ -11742,7 +11742,7 @@ Internal Ref. and Low Power, Powerdown</description>
 <gate name="G$1" symbol="ADS930" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="E" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="24"/>
 <connect gate="G$1" pin="!OE" pad="16"/>
@@ -11785,7 +11785,7 @@ Internal Ref. and Low Power, Powerdown</description>
 <gate name="G$1" symbol="ADS902" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="E" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!OE" pad="16"/>
 <connect gate="G$1" pin="+VS" pad="1"/>
@@ -11829,7 +11829,7 @@ Int Reference and Adjustable Fullscale Range</description>
 <gate name="G$1" symbol="ADS900" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="E" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="24"/>
 <connect gate="G$1" pin="!OE" pad="16"/>
@@ -11872,7 +11872,7 @@ Int Reference and Adjustable Fullscale Range</description>
 <gate name="G$1" symbol="ADS801" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="E" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -11907,7 +11907,7 @@ Int Reference and Adjustable Fullscale Range</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -11950,7 +11950,7 @@ Int Reference and Adjustable Fullscale Range</description>
 <gate name="G$1" symbol="ADS801" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="E" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -11985,7 +11985,7 @@ Int Reference and Adjustable Fullscale Range</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -12029,7 +12029,7 @@ with Int References and 9.5 bit ENOB</description>
 <gate name="G$1" symbol="ADS820" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="E" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -12064,7 +12064,7 @@ with Int References and 9.5 bit ENOB</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -12108,7 +12108,7 @@ with Int References and 9.3 bit ENOB</description>
 <gate name="G$1" symbol="ADS820" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="E" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -12143,7 +12143,7 @@ with Int References and 9.3 bit ENOB</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -12187,7 +12187,7 @@ program. i/p range  w/Pwrdown</description>
 <gate name="G$1" symbol="ADS823" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="E" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="24"/>
 <connect gate="G$1" pin="!OE" pad="12"/>
@@ -12231,7 +12231,7 @@ program. i/p range w/Pwrdown</description>
 <gate name="G$1" symbol="ADS823" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="E" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="24"/>
 <connect gate="G$1" pin="!OE" pad="12"/>
@@ -12275,7 +12275,7 @@ Low Noise, Precision</description>
 <gate name="G$1" symbol="2TRIMSUB" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12337,7 +12337,7 @@ MicroAmplifier(TM) Series; Product Folder:OPA2340</description>
 <gate name="B" symbol="OP-AMP" x="10.16" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="E" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12352,7 +12352,7 @@ MicroAmplifier(TM) Series; Product Folder:OPA2340</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12367,7 +12367,7 @@ MicroAmplifier(TM) Series; Product Folder:OPA2340</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12414,7 +12414,7 @@ MicroAmplifier(TM) Series; Product Folder:OPA2340</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12435,7 +12435,7 @@ MicroAmplifier(TM) Series; Product Folder:OPA2340</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12477,7 +12477,7 @@ Single-Supply, MicroAmplifier(TM) Series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12489,7 +12489,7 @@ Single-Supply, MicroAmplifier(TM) Series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12509,7 +12509,7 @@ Single-Supply, MicroAmplifier(TM) Series</description>
 <gate name="G$1" symbol="2+2-" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="+VS1" pad="7"/>
@@ -12523,7 +12523,7 @@ Single-Supply, MicroAmplifier(TM) Series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="+VS1" pad="7"/>
@@ -12565,7 +12565,7 @@ Single-Supply, MicroAmplifier(TM) Series</description>
 <gate name="G$1" symbol="SUBS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12587,7 +12587,7 @@ Single-Supply, MicroPower</description>
 <gate name="G$1" symbol="2TRIM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12601,7 +12601,7 @@ Single-Supply, MicroPower</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12624,7 +12624,7 @@ Single-Supply, MicroPower</description>
 <gate name="G$1" symbol="2TRIM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12638,7 +12638,7 @@ Single-Supply, MicroPower</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12661,7 +12661,7 @@ Ultra-Low Bias Current</description>
 <gate name="G$1" symbol="SUBS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12674,7 +12674,7 @@ Ultra-Low Bias Current</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12696,7 +12696,7 @@ High Speed FET-Input</description>
 <gate name="G$1" symbol="2TRIM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12710,7 +12710,7 @@ High Speed FET-Input</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12734,7 +12734,7 @@ Product Folder:OPA2132</description>
 <gate name="B" symbol="OP-AMP" x="10.16" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12749,7 +12749,7 @@ Product Folder:OPA2132</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12775,7 +12775,7 @@ Product Folder:OPA2132</description>
 <gate name="D" symbol="OP-AMP" x="10.16" y="-12.7"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12796,7 +12796,7 @@ Product Folder:OPA2132</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12826,7 +12826,7 @@ General Purpose FET-Input</description>
 <gate name="G$1" symbol="2TRIM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12840,7 +12840,7 @@ General Purpose FET-Input</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12864,7 +12864,7 @@ Product Folder:OPA2131</description>
 <gate name="B" symbol="OP-AMP" x="10.16" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12879,7 +12879,7 @@ Product Folder:OPA2131</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12905,7 +12905,7 @@ Product Folder:OPA2131</description>
 <gate name="D" symbol="OP-AMP" x="10.16" y="-7.62"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12926,7 +12926,7 @@ Product Folder:OPA2131</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12947,7 +12947,7 @@ Product Folder:OPA2131</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="N" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12977,7 +12977,7 @@ Low Power, Precision FET-Input</description>
 <gate name="G$1" symbol="2TRIM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12991,7 +12991,7 @@ Low Power, Precision FET-Input</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13014,7 +13014,7 @@ Low Power, Precision FET-Input</description>
 <gate name="A" symbol="OP-AMP+-" x="-10.16" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13029,7 +13029,7 @@ Low Power, Precision FET-Input</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13055,7 +13055,7 @@ Low Power, Precision FET-Input</description>
 <gate name="D" symbol="OP-AMP" x="10.16" y="-12.7"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13076,7 +13076,7 @@ Low Power, Precision FET-Input</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13106,7 +13106,7 @@ SoundPlus(TM) High Performance Audio</description>
 <gate name="G$1" symbol="2TRIM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13120,7 +13120,7 @@ SoundPlus(TM) High Performance Audio</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13143,7 +13143,7 @@ SoundPlus(TM) High Performance Audio</description>
 <gate name="B" symbol="OP-AMP" x="12.7" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13158,7 +13158,7 @@ SoundPlus(TM) High Performance Audio</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13181,7 +13181,7 @@ SoundPlus(TM) High Performance Audio</description>
 <gate name="G$1" symbol="2TRIM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13195,7 +13195,7 @@ SoundPlus(TM) High Performance Audio</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13217,7 +13217,7 @@ SoundPlus(TM) High Performance Audio</description>
 <gate name="G$1" symbol="2TRIM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13240,7 +13240,7 @@ Low Power, Precision, Single-Supply</description>
 <gate name="G$1" symbol="2TRIM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13254,7 +13254,7 @@ Low Power, Precision, Single-Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13277,7 +13277,7 @@ Low Power, Precision, Single-Supply</description>
 <gate name="B" symbol="OP-AMP" x="15.24" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13292,7 +13292,7 @@ Low Power, Precision, Single-Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13318,7 +13318,7 @@ Low Power, Precision, Single-Supply</description>
 <gate name="D" symbol="OP-AMP" x="12.7" y="-12.7"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13339,7 +13339,7 @@ Low Power, Precision, Single-Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13381,7 +13381,7 @@ Single-Supply, MicroAmplifier(TM) Series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13403,7 +13403,7 @@ MicroAmplifier(TM) Series; Product Folder:OPA2237</description>
 <gate name="B" symbol="OP-AMP" x="12.7" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="E" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13418,7 +13418,7 @@ MicroAmplifier(TM) Series; Product Folder:OPA2237</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13487,7 +13487,7 @@ Single-Supply, MicroPower, MicroAmplifier(TM) Series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13499,7 +13499,7 @@ Single-Supply, MicroPower, MicroAmplifier(TM) Series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13521,7 +13521,7 @@ MicroAmplifier Series; Product Folder:OPA2336,</description>
 <gate name="B" symbol="OP-AMP" x="12.7" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="E" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13536,7 +13536,7 @@ MicroAmplifier Series; Product Folder:OPA2336,</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13551,7 +13551,7 @@ MicroAmplifier Series; Product Folder:OPA2336,</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13599,7 +13599,7 @@ MicroAmplifier (TM) Series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13620,7 +13620,7 @@ MicroAmplifier (TM) Series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13650,7 +13650,7 @@ Precision, High-Speed</description>
 <gate name="G$1" symbol="2TRIM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13664,7 +13664,7 @@ Precision, High-Speed</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13711,7 +13711,7 @@ Precision, High-Speed</description>
 <gate name="G$1" symbol="2TRIM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13725,7 +13725,7 @@ Precision, High-Speed</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13772,7 +13772,7 @@ Wideband, Low Distortion</description>
 <gate name="G$1" symbol="2+2-" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="+VS1" pad="7"/>
@@ -13794,7 +13794,7 @@ Wideband, Low Distortion</description>
 <gate name="G$1" symbol="2+2-" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="+VS1" pad="7"/>
@@ -13840,7 +13840,7 @@ Wideband, Low Distortion</description>
 <gate name="D" symbol="OP-AMP" x="10.16" y="-12.7"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13861,7 +13861,7 @@ Wideband, Low Distortion</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13893,7 +13893,7 @@ Wideband, Low Distortion</description>
 <gate name="D" symbol="OP-AMP" x="10.16" y="-12.7"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13914,7 +13914,7 @@ Wideband, Low Distortion</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13944,7 +13944,7 @@ Wideband, Low Distortion</description>
 <gate name="B" symbol="OP-AMP" x="12.7" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="E" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13959,7 +13959,7 @@ Wideband, Low Distortion</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13974,7 +13974,7 @@ Wideband, Low Distortion</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14010,7 +14010,7 @@ Wideband, Low Power, Current Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14022,7 +14022,7 @@ Wideband, Low Power, Current Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14043,7 +14043,7 @@ Wideband, Low Power, Current Feedback</description>
 <gate name="B" symbol="OP-AMP" x="10.16" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="E" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14058,7 +14058,7 @@ Wideband, Low Power, Current Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14073,7 +14073,7 @@ Wideband, Low Power, Current Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14097,7 +14097,7 @@ Wideband, Switched-Input</description>
 <gate name="G$1" symbol="OPA678" x="5.08" y="-2.54"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CHA" pad="12"/>
 <connect gate="G$1" pin="+INA" pad="1"/>
@@ -14120,7 +14120,7 @@ Wideband, Switched-Input</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CHA" pad="12"/>
 <connect gate="G$1" pin="+INA" pad="1"/>
@@ -14152,7 +14152,7 @@ Wideband, FET-Input</description>
 <gate name="G$1" symbol="2+2-" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="+VS1" pad="7"/>
@@ -14166,7 +14166,7 @@ Wideband, FET-Input</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="+VS1" pad="7"/>
@@ -14201,7 +14201,7 @@ Wideband, Low Power, Voltage Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14213,7 +14213,7 @@ Wideband, Low Power, Voltage Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14246,7 +14246,7 @@ Wideband, Low Power, Voltage Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14258,7 +14258,7 @@ Wideband, Low Power, Voltage Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14279,7 +14279,7 @@ Wideband, Low Power, Voltage Feedback</description>
 <gate name="G$1" symbol="PCM1726" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-20">
+<device name="" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="10"/>
 <connect gate="G$1" pin="BCKIN" pad="14"/>
@@ -14315,7 +14315,7 @@ with Programmable Dual PLL</description>
 <gate name="G$1" symbol="PCM1727" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-610W-780L-120H-100F-24">
+<device name="" package="SSOP-24-65P-610W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!RSTB" pad="10"/>
 <connect gate="G$1" pin="!ZERO" pad="16"/>
@@ -14356,7 +14356,7 @@ with Programmable Dual PLL</description>
 <gate name="P" symbol="PWRN" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BCKIN" pad="3"/>
 <connect gate="G$1" pin="CAP" pad="5"/>
@@ -14386,7 +14386,7 @@ with Programmable PLL</description>
 <gate name="G$1" symbol="PCM1723" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-610W-780L-120H-100F-24">
+<device name="" package="SSOP-24-65P-610W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="12"/>
 <connect gate="G$1" pin="BCKIN" pad="16"/>
@@ -14425,7 +14425,7 @@ with Programmable PLL</description>
 <gate name="G$1" symbol="PCM1717" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-20">
+<device name="" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="10"/>
 <connect gate="G$1" pin="BCKIN" pad="6"/>
@@ -14504,7 +14504,7 @@ MPEG2/AC-3 Compatible</description>
 <gate name="G$1" symbol="PCM1721" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-610W-780L-120H-100F-24">
+<device name="" package="SSOP-24-65P-610W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="12"/>
 <connect gate="G$1" pin="BCKIN" pad="16"/>
@@ -14544,7 +14544,7 @@ MPEG2/AC-3 Compatible</description>
 <gate name="G$1" symbol="PCM1720" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-20">
+<device name="" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="10"/>
 <connect gate="G$1" pin="BCKIN" pad="14"/>
@@ -14579,7 +14579,7 @@ MPEG2/AC-3 Compatible</description>
 <gate name="G$1" symbol="PCM1719" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="10"/>
 <connect gate="G$1" pin="BCKIN" pad="6"/>
@@ -14657,7 +14657,7 @@ MPEG2/AC-3 Compatible</description>
 <gate name="G$1" symbol="PCM1702" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+VCC" pad="9"/>
 <connect gate="G$1" pin="+VDD" pad="3"/>
@@ -14688,7 +14688,7 @@ MPEG2/AC-3 Compatible</description>
 <gate name="G$1" symbol="PCM1702U" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+VCC" pad="11"/>
 <connect gate="G$1" pin="+VDD" pad="4"/>
@@ -14724,7 +14724,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="PCM1710" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="AGND1" pad="14"/>
 <connect gate="G$1" pin="AGND2L" pad="19"/>
@@ -14767,7 +14767,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="PCM1800" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-610W-780L-120H-100F-24">
+<device name="" package="SSOP-24-65P-610W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="24"/>
 <connect gate="G$1" pin="BCK" pad="14"/>
@@ -14807,7 +14807,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="PCM3000" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND1" pad="3"/>
 <connect gate="G$1" pin="AGND2" pad="13"/>
@@ -14851,7 +14851,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="PCM3001" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND1" pad="3"/>
 <connect gate="G$1" pin="AGND2" pad="13"/>
@@ -14894,7 +14894,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="PCM1712" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="AGND1" pad="14"/>
 <connect gate="G$1" pin="AGND2L" pad="19"/>
@@ -14937,7 +14937,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="PGA206" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="5"/>
 <connect gate="G$1" pin="-IN" pad="4"/>
@@ -14960,7 +14960,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="5"/>
 <connect gate="G$1" pin="-IN" pad="4"/>
@@ -14991,7 +14991,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="PGA206" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="5"/>
 <connect gate="G$1" pin="-IN" pad="4"/>
@@ -15014,7 +15014,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="5"/>
 <connect gate="G$1" pin="-IN" pad="4"/>
@@ -15060,7 +15060,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="COM" pad="4"/>
 <connect gate="G$1" pin="NC" pad="1"/>
@@ -15075,7 +15075,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COM" pad="4"/>
 <connect gate="G$1" pin="NC" pad="1"/>
@@ -15098,7 +15098,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="REF200" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="I1H" pad="8"/>
 <connect gate="G$1" pin="I1L" pad="1"/>
@@ -15113,7 +15113,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="I1H" pad="8"/>
 <connect gate="G$1" pin="I1L" pad="1"/>
@@ -15136,7 +15136,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="REF1004" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="4"/>
 <connect gate="G$1" pin="C" pad="6"/>
@@ -15159,7 +15159,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="XTR101" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="4"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -15188,7 +15188,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="XTR101U" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="4"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -15219,7 +15219,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="DAC712" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CLR" pad="9"/>
 <connect gate="G$1" pin="!WR" pad="10"/>
@@ -15254,7 +15254,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CLR" pad="9"/>
 <connect gate="G$1" pin="!WR" pad="10"/>
@@ -15297,7 +15297,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="DAC714" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CLK" pad="1"/>
 <connect gate="G$1" pin="!CLR" pad="16"/>
@@ -15320,7 +15320,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLK" pad="1"/>
 <connect gate="G$1" pin="!CLR" pad="16"/>
@@ -15351,7 +15351,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="DAC712" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CLR" pad="9"/>
 <connect gate="G$1" pin="!WR" pad="10"/>
@@ -15386,7 +15386,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CLR" pad="9"/>
 <connect gate="G$1" pin="!WR" pad="10"/>
@@ -15429,7 +15429,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="DAC725" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!A0" pad="4"/>
 <connect gate="G$1" pin="!A1" pad="5"/>
@@ -15472,7 +15472,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="DAC813" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!LDAC" pad="12"/>
 <connect gate="G$1" pin="!LLSB" pad="15"/>
@@ -15507,7 +15507,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!LDAC" pad="12"/>
 <connect gate="G$1" pin="!LLSB" pad="15"/>
@@ -15551,7 +15551,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="DAC4813" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!LDAC" pad="19"/>
 <connect gate="G$1" pin="!RESET" pad="13"/>
@@ -15594,7 +15594,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="DAC7800" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CLR" pad="11"/>
 <connect gate="G$1" pin="!CS" pad="8"/>
@@ -15617,7 +15617,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR" pad="11"/>
 <connect gate="G$1" pin="!CS" pad="8"/>
@@ -15648,7 +15648,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="DAC7801" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-24">
+<device name="P" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CLR" pad="17"/>
 <connect gate="G$1" pin="!CS" pad="5"/>
@@ -15679,7 +15679,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="U" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR" pad="17"/>
 <connect gate="G$1" pin="!CS" pad="5"/>
@@ -15719,7 +15719,7 @@ Multiplying</description>
 <gate name="G$1" symbol="DAC7802" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-24">
+<device name="P" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CSA" pad="5"/>
 <connect gate="G$1" pin="!CSB" pad="20"/>
@@ -15750,7 +15750,7 @@ Multiplying</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="U" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CSA" pad="5"/>
 <connect gate="G$1" pin="!CSB" pad="20"/>
@@ -15790,7 +15790,7 @@ Precision, Low Power, G = 10, 100</description>
 <gate name="G$1" symbol="INA141" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -15805,7 +15805,7 @@ Precision, Low Power, G = 10, 100</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -15921,7 +15921,7 @@ with RTD Excitation And Linearization</description>
 <gate name="G$1" symbol="XTR103" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="4"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -15944,7 +15944,7 @@ with RTD Excitation And Linearization</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="4"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -15976,7 +15976,7 @@ with Bridge Excitation And Linearization</description>
 <gate name="G$1" symbol="XTR104" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="1"/>
 <connect gate="G$1" pin="+LIN" pad="3"/>
@@ -15999,7 +15999,7 @@ with Bridge Excitation And Linearization</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="1"/>
 <connect gate="G$1" pin="+LIN" pad="3"/>
@@ -16031,7 +16031,7 @@ with Sensor Excitation and Linearization</description>
 <gate name="G$1" symbol="XTR105" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="13"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16052,7 +16052,7 @@ with Sensor Excitation and Linearization</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="13"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16082,7 +16082,7 @@ Ext Reference and Adjustable Fullscale Range</description>
 <gate name="G$1" symbol="ADS901" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-610W-970L-120H-100F-28">
+<device name="E" package="SSOP-28-65P-610W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!OE" pad="16"/>
 <connect gate="G$1" pin="+VS" pad="1"/>
@@ -16126,7 +16126,7 @@ Microprocessor-Compatible</description>
 <gate name="G$1" symbol="ADS574" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="3"/>
 <connect gate="G$1" pin="10VR" pad="13"/>
@@ -16161,7 +16161,7 @@ Microprocessor-Compatible</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="3"/>
 <connect gate="G$1" pin="10VR" pad="13"/>
@@ -16196,7 +16196,7 @@ Microprocessor-Compatible</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JE" package="DIP-300-28">
+<device name="JE" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="3"/>
 <connect gate="G$1" pin="10VR" pad="13"/>
@@ -16240,7 +16240,7 @@ Microprocessor Compatible</description>
 <gate name="G$1" symbol="ADS574" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="3"/>
 <connect gate="G$1" pin="10VR" pad="13"/>
@@ -16275,7 +16275,7 @@ Microprocessor Compatible</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="3"/>
 <connect gate="G$1" pin="10VR" pad="13"/>
@@ -16310,7 +16310,7 @@ Microprocessor Compatible</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JE" package="DIP-300-28">
+<device name="JE" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="3"/>
 <connect gate="G$1" pin="10VR" pad="13"/>
@@ -16353,7 +16353,7 @@ Microprocessor Compatible</description>
 <gate name="G$1" symbol="ADS7800" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="21"/>
 <connect gate="G$1" pin="!CS" pad="20"/>
@@ -16384,7 +16384,7 @@ Microprocessor Compatible</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="21"/>
 <connect gate="G$1" pin="!CS" pad="20"/>
@@ -16423,7 +16423,7 @@ Microprocessor Compatible</description>
 <gate name="G$1" symbol="ACF2101" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-24">
+<device name="P" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="CAPA" pad="4"/>
 <connect gate="G$1" pin="CAPB" pad="9"/>
@@ -16454,7 +16454,7 @@ Microprocessor Compatible</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="U" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CAPA" pad="22"/>
 <connect gate="G$1" pin="CAPB" pad="3"/>
@@ -16556,7 +16556,7 @@ Microprocessor Compatible</description>
 <gate name="G$1" symbol="DDC101U" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="U" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!DTR" pad="18"/>
 <connect gate="G$1" pin="!DVAL" pad="15"/>
@@ -16587,7 +16587,7 @@ Microprocessor Compatible</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!DTR" pad="20"/>
 <connect gate="G$1" pin="!DVAL" pad="17"/>
@@ -16626,7 +16626,7 @@ Microprocessor Compatible</description>
 <gate name="G$1" symbol="PCM63P" x="2.54" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="+VA" pad="2"/>
 <connect gate="G$1" pin="+VD" pad="13"/>
@@ -16740,7 +16740,7 @@ Precision, Low Power</description>
 <gate name="G$1" symbol="INA128" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16755,7 +16755,7 @@ Precision, Low Power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16779,7 +16779,7 @@ Precision, Low Power</description>
 <gate name="G$1" symbol="INA128" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16794,7 +16794,7 @@ Precision, Low Power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16818,7 +16818,7 @@ Precision, Low Power</description>
 <gate name="G$1" symbol="INA134" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16833,7 +16833,7 @@ Precision, Low Power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16857,7 +16857,7 @@ Precision, Low Power</description>
 <gate name="G$1" symbol="INA2134" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+INA" pad="3"/>
 <connect gate="G$1" pin="+INB" pad="5"/>
@@ -16878,7 +16878,7 @@ Precision, Low Power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+INA" pad="3"/>
 <connect gate="G$1" pin="+INB" pad="5"/>
@@ -16908,7 +16908,7 @@ Single Supply, MicroPower</description>
 <gate name="G$1" symbol="INA122" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16923,7 +16923,7 @@ Single Supply, MicroPower</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16947,7 +16947,7 @@ Low Power, Single-Supply</description>
 <gate name="G$1" symbol="INA134" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16962,7 +16962,7 @@ Low Power, Single-Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16986,7 +16986,7 @@ Precision, Low Power</description>
 <gate name="G$1" symbol="INA118" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17001,7 +17001,7 @@ Precision, Low Power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17025,7 +17025,7 @@ with Precision Voltage Reference</description>
 <gate name="G$1" symbol="INA125" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!SLEEP" pad="2"/>
 <connect gate="G$1" pin="+IN" pad="6"/>
@@ -17048,7 +17048,7 @@ with Precision Voltage Reference</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!SLEEP" pad="2"/>
 <connect gate="G$1" pin="+IN" pad="6"/>
@@ -17095,7 +17095,7 @@ High Common-Mode Voltage</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17110,7 +17110,7 @@ High Common-Mode Voltage</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17134,7 +17134,7 @@ Ultra Low Input Bias Current</description>
 <gate name="G$1" symbol="INA116" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="6"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -17157,7 +17157,7 @@ Ultra Low Input Bias Current</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="6"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -17188,7 +17188,7 @@ Ultra Low Input Bias Current</description>
 <gate name="G$1" symbol="INA114" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17211,7 +17211,7 @@ Ultra Low Input Bias Current</description>
 <gate name="G$1" symbol="INA114U" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="5"/>
 <connect gate="G$1" pin="-IN" pad="4"/>
@@ -17243,7 +17243,7 @@ High Speed FET-Input</description>
 <gate name="G$1" symbol="INA114" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17266,7 +17266,7 @@ High Speed FET-Input</description>
 <gate name="G$1" symbol="INA114U" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="5"/>
 <connect gate="G$1" pin="-IN" pad="4"/>
@@ -17298,7 +17298,7 @@ Low Distortion, Low Noise</description>
 <gate name="G$1" symbol="INA103" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+GD" pad="5"/>
 <connect gate="G$1" pin="+GS" pad="2"/>
@@ -17321,7 +17321,7 @@ Low Distortion, Low Noise</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+GD" pad="5"/>
 <connect gate="G$1" pin="+GS" pad="2"/>
@@ -17353,7 +17353,7 @@ Low Distortion, Low Noise</description>
 <gate name="G$1" symbol="INA134" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17368,7 +17368,7 @@ Low Distortion, Low Noise</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17392,7 +17392,7 @@ Low Distortion, Low Noise</description>
 <gate name="G$1" symbol="INA2134" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+INA" pad="3"/>
 <connect gate="G$1" pin="+INB" pad="5"/>
@@ -17413,7 +17413,7 @@ Low Distortion, Low Noise</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+INA" pad="3"/>
 <connect gate="G$1" pin="+INB" pad="5"/>
@@ -17457,7 +17457,7 @@ Low Distortion, Low Noise</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17472,7 +17472,7 @@ Low Distortion, Low Noise</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17519,7 +17519,7 @@ Micropower, Single and Dual Versions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+INA" pad="2"/>
 <connect gate="G$1" pin="+INB" pad="15"/>
@@ -17542,7 +17542,7 @@ Micropower, Single and Dual Versions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+INA" pad="2"/>
 <connect gate="G$1" pin="+INB" pad="15"/>
@@ -17574,7 +17574,7 @@ Micropower, Single and Dual Versions</description>
 <gate name="G$1" symbol="INA126" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="E" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17589,7 +17589,7 @@ Micropower, Single and Dual Versions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17604,7 +17604,7 @@ Micropower, Single and Dual Versions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17668,7 +17668,7 @@ Micropower, Single and Dual Versions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="BW" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -17680,7 +17680,7 @@ Micropower, Single and Dual Versions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BW" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -17700,7 +17700,7 @@ Micropower, Single and Dual Versions</description>
 <gate name="G$1" symbol="DAC56" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+VL" pad="3"/>
 <connect gate="G$1" pin="+VS" pad="16"/>
@@ -17723,7 +17723,7 @@ Micropower, Single and Dual Versions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+VL" pad="3"/>
 <connect gate="G$1" pin="+VS" pad="16"/>
@@ -17819,7 +17819,7 @@ with Current Source and Sink Capability</description>
 <gate name="G$1" symbol="ADS7804" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="26"/>
 <connect gate="G$1" pin="!CS" pad="25"/>
@@ -17892,7 +17892,7 @@ with Current Source and Sink Capability</description>
 <gate name="G" symbol="ADS7803" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G" pin="!BUSY!" pad="22"/>
 <connect gate="G" pin="!CAL!" pad="26"/>
@@ -17936,7 +17936,7 @@ with Current Source and Sink Capability</description>
 <gate name="G" symbol="DAC7541A" x="5.08" y="0" addlevel="can"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-18">
+<device name="P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G" pin="B1(MSB)" pad="4"/>
 <connect gate="G" pin="B10" pad="13"/>
@@ -17970,7 +17970,7 @@ with Current Source and Sink Capability</description>
 <gate name="P" symbol="PWRN" x="22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="16MASPAN" pad="9"/>
 <connect gate="G$1" pin="4MASPAN" pad="10"/>
@@ -18001,7 +18001,7 @@ with Current Source and Sink Capability</description>
 <gate name="G$1" symbol="ADC7802" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PLC" package="PLCC-127P-1150W-1150L-457H-28">
+<device name="PLC" package="PLCC-28-127P-1150W-1150L-457H">
 <connects>
 <connect gate="G$1" pin="!BUSY!" pad="22"/>
 <connect gate="G$1" pin="!CAL!" pad="26"/>
@@ -18036,7 +18036,7 @@ with Current Source and Sink Capability</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PLC-S" package="PLCC-SOCKET-TH-7X7-28">
+<device name="PLC-S" package="PLCC-SOCKET-TH-28-7X7">
 <connects>
 <connect gate="G$1" pin="!BUSY!" pad="22"/>
 <connect gate="G$1" pin="!CAL!" pad="26"/>
@@ -18108,7 +18108,7 @@ with Current Source and Sink Capability</description>
 <gate name="G$1" symbol="XTR101A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="4"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -18177,7 +18177,7 @@ with Current Source and Sink Capability</description>
 <gate name="G$1" symbol="ADS8344" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SSOP-065-530-20">
+<device name="U" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="18"/>
 <connect gate="G$1" pin="!SHDN" pad="10"/>
@@ -18214,7 +18214,7 @@ Fast-Settling FET-Input</description>
 <gate name="P" symbol="+-VCC" x="22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!10!" pad="13"/>
 <connect gate="G$1" pin="!100!" pad="12"/>
@@ -18237,7 +18237,7 @@ Fast-Settling FET-Input</description>
 <technology name="K"/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!10!" pad="13"/>
 <connect gate="G$1" pin="!100!" pad="12"/>
@@ -18268,7 +18268,7 @@ Fast-Settling FET-Input</description>
 <gate name="G$1" symbol="INA326" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -18290,7 +18290,7 @@ Fast-Settling FET-Input</description>
 <gate name="G$1" symbol="BUF634F" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BW" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -18311,7 +18311,7 @@ Fast-Settling FET-Input</description>
 <gate name="G$1" symbol="PCM1796" x="0" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-610W-970L-200H-100F-28">
+<device name="" package="SSOP-28-65P-610W-970L-200H-100F">
 <connects>
 <connect gate="G$1" pin="!MS!" pad="10"/>
 <connect gate="G$1" pin="!RST!" pad="14"/>
@@ -18354,7 +18354,7 @@ Fast-Settling FET-Input</description>
 <gate name="G$1" symbol="PCM2902" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-610W-970L-200H-100F-28">
+<device name="" package="SSOP-28-65P-610W-970L-200H-100F">
 <connects>
 <connect gate="G$1" pin="!SSPND!" pad="28"/>
 <connect gate="G$1" pin="AGNDC" pad="11"/>
@@ -18398,7 +18398,7 @@ High-Side, Bidirectional</description>
 <gate name="G$1" symbol="INA170" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="IN+" pad="2"/>
@@ -18420,7 +18420,7 @@ High-Side, Bidirectional</description>
 <gate name="G$1" symbol="XTR115" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="B" pad="6"/>
 <connect gate="G$1" pin="E" pad="5"/>
@@ -18444,7 +18444,7 @@ Quad, Serial Input, 12-Bit, Voltage Output</description>
 <gate name="G$1" symbol="DAC7715" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="12"/>
 <connect gate="G$1" pin="!LOADDACS!" pad="13"/>

--- a/cirrus-arm.lbr
+++ b/cirrus-arm.lbr
@@ -483,7 +483,7 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <text x="-12.065" y="3.175" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-12.065" y="-3.81" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="LQFP-50P-2800W-2800L-160H-208">
+<package name="LQFP-208-50P-2800W-2800L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 208 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BJB, L-PQFP-G.
@@ -1977,7 +1977,7 @@ Source: EP73xx.bsd</description>
 <gate name="G$1" symbol="EP73XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-2800W-2800L-160H-208">
+<device name="" package="LQFP-208-50P-2800W-2800L-160H">
 <connects>
 <connect gate="G$1" pin="A0" pad="178"/>
 <connect gate="G$1" pin="A1" pad="176"/>

--- a/cirrus.lbr
+++ b/cirrus.lbr
@@ -132,7 +132,7 @@ body 5x5mm/JEDEC MO-220</description>
 <text x="-2.54" y="-3.81" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <rectangle x1="-2.5" y1="2.1" x2="-2.1" y2="2.5" layer="21"/>
 </package>
-<package name="LQFP-50P-700W-700L-160H-48">
+<package name="LQFP-48-50P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
@@ -242,7 +242,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-780L-120H-100F-24">
+<package name="SSOP-24-65P-440W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
@@ -303,7 +303,7 @@ JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.1" x2="3.8" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.1" x2="-3.8" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -517,7 +517,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-970L-120H-100F-28">
+<package name="SSOP-28-65P-440W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 4.4mm width, 1.20mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 4.4mm width, 1.20mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
@@ -586,7 +586,7 @@ JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.1" x2="4.75" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.1" x2="-4.75" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -651,7 +651,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -724,7 +724,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -774,7 +774,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-50P-300W-300L-110H-95F-10">
+<package name="SSOP-10-50P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
@@ -1047,7 +1047,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <rectangle x1="-2" y1="-3.5" x2="-1" y2="-2.5" layer="31"/>
 <rectangle x1="-3.5" y1="-3.5" x2="-2.5" y2="-2.5" layer="31"/>
 </package>
-<package name="LQFP-50P-1000W-1000L-160H-64">
+<package name="LQFP-64-50P-1000W-1000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
@@ -1189,7 +1189,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-24">
+<package name="SSOP-24-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 24 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JEDEC MO-150B. Variation AG.</description>
 <circle x="-3.535" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -2384,7 +2384,7 @@ Stereo 114 dB, 192 kHz, Multi-Bit Audio A/D Converter</description>
 <gate name="G$1" symbol="CS5361" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-KSZ" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="-KSZ" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!HPF!" pad="11"/>
 <connect gate="G$1" pin="!OVFL!" pad="15"/>
@@ -2415,7 +2415,7 @@ Stereo 114 dB, 192 kHz, Multi-Bit Audio A/D Converter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-KZZ" package="SSOP-65P-440W-780L-120H-100F-24">
+<device name="-KZZ" package="SSOP-24-65P-440W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!HPF!" pad="11"/>
 <connect gate="G$1" pin="!OVFL!" pad="15"/>
@@ -2455,7 +2455,7 @@ Stereo 114 dB, 192 kHz, Multi-Bit Audio A/D Converter</description>
 <gate name="G$1" symbol="CS8406_SW" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-CSS" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="-CSS" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="9"/>
 <connect gate="G$1" pin="AD0/!CS!" pad="2"/>
@@ -2490,7 +2490,7 @@ Stereo 114 dB, 192 kHz, Multi-Bit Audio A/D Converter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-CZZ" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="-CZZ" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="9"/>
 <connect gate="G$1" pin="AD0/!CS!" pad="2"/>
@@ -2534,7 +2534,7 @@ Stereo 114 dB, 192 kHz, Multi-Bit Audio A/D Converter</description>
 <gate name="G$1" symbol="CS8406_HW" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-CSS" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="-CSS" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!AUDIO!" pad="19"/>
 <connect gate="G$1" pin="!EMPH!" pad="3"/>
@@ -2569,7 +2569,7 @@ Stereo 114 dB, 192 kHz, Multi-Bit Audio A/D Converter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-CZZ" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="-CZZ" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!AUDIO!" pad="19"/>
 <connect gate="G$1" pin="!EMPH!" pad="3"/>
@@ -2613,7 +2613,7 @@ Stereo 120 dB, 192 kHz, Multi-Bit Audio D/A with Volume Control</description>
 <gate name="G$1" symbol="CS4398" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="13"/>
 <connect gate="G$1" pin="AGND" pad="21"/>
@@ -2657,7 +2657,7 @@ Stereo 108 dB, 192 kHz, Multi-Bit Audio A/D Converter</description>
 <gate name="G$1" symbol="CS5351" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-KSZ" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="-KSZ" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!HPF!" pad="11"/>
 <connect gate="G$1" pin="!OVFL!" pad="15"/>
@@ -2688,7 +2688,7 @@ Stereo 108 dB, 192 kHz, Multi-Bit Audio A/D Converter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-KZZ" package="SSOP-65P-440W-780L-120H-100F-24">
+<device name="-KZZ" package="SSOP-24-65P-440W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!HPF!" pad="11"/>
 <connect gate="G$1" pin="!OVFL!" pad="15"/>
@@ -2728,7 +2728,7 @@ CrystalLAN 100BASE-X and 10BASE-T Transceiver</description>
 <gate name="G$1" symbol="CS8952EB" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!LPSTRT!" pad="50"/>
 <connect gate="G$1" pin="!MII_IRQ!" pad="26"/>
@@ -2844,7 +2844,7 @@ CrystalLAN 100BASE-X and 10BASE-T Transceiver</description>
 <gate name="G$1" symbol="CS3310" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!MUTE!" pad="8"/>
@@ -2971,7 +2971,7 @@ Low Power, Stereo CODEC with Headphone Amp</description>
 <gate name="G$1" symbol="CS4202" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!ID0!" pad="45"/>
 <connect gate="G$1" pin="!ID1!" pad="46"/>
@@ -3034,7 +3034,7 @@ Low Power, Stereo CODEC with Headphone Amp</description>
 <gate name="IC1" symbol="CS4340" x="5.08" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="IC1" pin="!RST!" pad="1"/>
 <connect gate="IC1" pin="AGND" pad="13"/>
@@ -3066,7 +3066,7 @@ Low Power, Stereo CODEC with Headphone Amp</description>
 <gate name="G$1" symbol="CS8416_HW" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!AUDIO!" pad="15"/>
 <connect gate="G$1" pin="!RST!" pad="9"/>
@@ -3110,7 +3110,7 @@ Low Power, Stereo CODEC with Headphone Amp</description>
 <gate name="G$1" symbol="CS8416_SW" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="9"/>
 <connect gate="G$1" pin="AD0/!CS!" pad="14"/>
@@ -3154,7 +3154,7 @@ Low Power, Stereo CODEC with Headphone Amp</description>
 <gate name="G$1" symbol="CS4271_SW" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!AMUTEC!" pad="23"/>
 <connect gate="G$1" pin="!BMUTEC!" pad="28"/>
@@ -3197,7 +3197,7 @@ Low Power, Stereo CODEC with Headphone Amp</description>
 <gate name="G$1" symbol="CS2300-CP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-300W-300L-110H-95F-10">
+<device name="" package="SSOP-10-50P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="AD0/!CS!" pad="8"/>
 <connect gate="G$1" pin="AUX_OUT" pad="4"/>
@@ -3339,7 +3339,7 @@ Low Power, Stereo CODEC with Headphone Amp</description>
 <gate name="G$1" symbol="CS42448" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="3"/>
 <connect gate="G$1" pin="AD0/!CS!" pad="1"/>
@@ -3535,7 +3535,7 @@ Ultra-low-noise PGIA</description>
 <gate name="G$1" symbol="CS5534" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-AS" package="SSOP-065-530-24">
+<device name="-AS" package="SSOP-24-65P-530W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="16"/>
 <connect gate="G$1" pin="A0" pad="9"/>
@@ -3574,7 +3574,7 @@ Ultra-low-noise PGIA</description>
 <gate name="G$1" symbol="CS2100-CP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-300W-300L-110H-95F-10">
+<device name="" package="SSOP-10-50P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="AD0/!CS!" pad="8"/>
 <connect gate="G$1" pin="AUX_OUT" pad="4"/>
@@ -3600,7 +3600,7 @@ Ultra-low-noise PGIA</description>
 <gate name="G$1" symbol="CS4384" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="19"/>
 <connect gate="G$1" pin="AD0" pad="17"/>
@@ -3656,7 +3656,7 @@ Ultra-low-noise PGIA</description>
 <gate name="G$1" symbol="CS5368" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!OVFL!" pad="36"/>
 <connect gate="G$1" pin="!RST!" pad="41"/>

--- a/cml-micro.lbr
+++ b/cml-micro.lbr
@@ -77,7 +77,7 @@ source from: http://www.cmlmicro.com/
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SSOP-65P-440W-780L-120H-100F-24">
+<package name="SSOP-24-65P-440W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
@@ -138,7 +138,7 @@ JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.1" x2="3.8" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.1" x2="-3.8" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -164,7 +164,7 @@ JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -200,7 +200,7 @@ JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SSOP-65P-440W-970L-120H-100F-28">
+<package name="SSOP-28-65P-440W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 4.4mm width, 1.20mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 4.4mm width, 1.20mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
@@ -269,7 +269,7 @@ JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.1" x2="4.75" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.1" x2="-4.75" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -297,7 +297,7 @@ JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SSOP-065-530-28">
+<package name="SSOP-28-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 28 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JEDEC MO-150B. Variation AH.</description>
 <circle x="-4.185" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -364,7 +364,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <wire x1="5.1" y1="-2.6" x2="5.1" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="5.1" y1="2.6" x2="-5.05" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -413,7 +413,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -478,7 +478,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-16">
+<package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -523,7 +523,7 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-24">
+<package name="SSOP-24-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 24 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JEDEC MO-150B. Variation AG.</description>
 <circle x="-3.535" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -1029,7 +1029,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <gate name="P" symbol="VDDVSS" x="-25.4" y="2.54"/>
 </gates>
 <devices>
-<device name="J" package="DIP-300-14">
+<device name="J" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="!TX_EN_L!" pad="12"/>
 <connect gate="A" pin="D0" pad="4"/>
@@ -1049,7 +1049,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="A" pin="!TX_EN_L!" pad="14"/>
 <connect gate="A" pin="D0" pad="4"/>
@@ -1078,7 +1078,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <gate name="P" symbol="VDDVSS" x="-33.02" y="12.7"/>
 </gates>
 <devices>
-<device name="TN" package="SSOP-65P-440W-780L-120H-100F-24">
+<device name="TN" package="SSOP-24-65P-440W-780L-120H-100F">
 <connects>
 <connect gate="A" pin="!RX_TONE_DEC!" pad="13"/>
 <connect gate="A" pin="D0" pad="10"/>
@@ -1109,7 +1109,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="!RX_TONE_DEC!" pad="13"/>
 <connect gate="A" pin="D0" pad="10"/>
@@ -1140,7 +1140,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-600-24">
+<device name="P" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!RX_TONE_DEC!" pad="13"/>
 <connect gate="A" pin="D0" pad="10"/>
@@ -1181,7 +1181,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <gate name="P" symbol="VDDVSS" x="-35.56" y="17.78"/>
 </gates>
 <devices>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="!CS!" pad="6"/>
 <connect gate="A" pin="!IRQ!" pad="7"/>
@@ -1212,7 +1212,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-600-24">
+<device name="P" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CS!" pad="6"/>
 <connect gate="A" pin="!IRQ!" pad="7"/>
@@ -1243,7 +1243,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DS" package="SSOP-065-530-24">
+<device name="DS" package="SSOP-24-65P-530W">
 <connects>
 <connect gate="A" pin="!CS!" pad="6"/>
 <connect gate="A" pin="!IRQ!" pad="7"/>
@@ -1283,7 +1283,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <gate name="P" symbol="VDDVSS" x="-38.1" y="17.78"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-24">
+<device name="P" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CS!" pad="6"/>
 <connect gate="A" pin="!IRQ!" pad="7"/>
@@ -1314,7 +1314,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="!CS!" pad="6"/>
 <connect gate="A" pin="!IRQ!" pad="7"/>
@@ -1345,7 +1345,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DS" package="SSOP-065-530-24">
+<device name="DS" package="SSOP-24-65P-530W">
 <connects>
 <connect gate="A" pin="!CS!" pad="6"/>
 <connect gate="A" pin="!IRQ!" pad="7"/>
@@ -1384,7 +1384,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <gate name="G$1" symbol="CMX639D4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!POWERSAVE!" pad="10"/>
 <connect gate="G$1" pin="ALGORITHM" pad="13"/>
@@ -1415,7 +1415,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <gate name="G$1" symbol="CMX589A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D5" package="SSOP-065-530-24">
+<device name="D5" package="SSOP-24-65P-530W">
 <connects>
 <connect gate="G$1" pin="!RXHOLD!" pad="5"/>
 <connect gate="G$1" pin="BT" pad="15"/>
@@ -1446,7 +1446,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D2" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D2" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RXHOLD!" pad="5"/>
 <connect gate="G$1" pin="BT" pad="15"/>
@@ -1477,7 +1477,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="P4" package="DIP-600-24">
+<device name="P4" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!RXHOLD!" pad="5"/>
 <connect gate="G$1" pin="BT" pad="15"/>
@@ -1508,7 +1508,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="E2" package="SSOP-65P-440W-780L-120H-100F-24">
+<device name="E2" package="SSOP-24-65P-440W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!RXHOLD!" pad="5"/>
 <connect gate="G$1" pin="BT" pad="15"/>
@@ -1548,7 +1548,7 @@ Digitally Controlled</description>
 <gate name="G$1" symbol="FX019" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DW" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!LOAD!/LATCH" pad="3"/>
 <connect gate="G$1" pin="CS" pad="14"/>
@@ -1580,7 +1580,7 @@ with Audio Scrambler</description>
 <gate name="G$1" symbol="CMX138" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E1" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="E1" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!CSN!" pad="8"/>
 <connect gate="G$1" pin="!IRQN!" pad="4"/>
@@ -1623,7 +1623,7 @@ with Audio Scrambler</description>
 <gate name="G$1" symbol="CMX823" x="0" y="0"/>
 </gates>
 <devices>
-<device name="E4" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="E4" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!CSN!" pad="4"/>
 <connect gate="G$1" pin="!IRQN!" pad="5"/>
@@ -1646,7 +1646,7 @@ with Audio Scrambler</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P3" package="DIP-300-16">
+<device name="P3" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CSN!" pad="4"/>
 <connect gate="G$1" pin="!IRQN!" pad="5"/>
@@ -1678,7 +1678,7 @@ for PMR and Trunked Radios</description>
 <gate name="G$1" symbol="CMX881" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D6" package="SSOP-065-530-28">
+<device name="D6" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="!CSN!" pad="8"/>
 <connect gate="G$1" pin="!IRQN!" pad="3"/>
@@ -1713,7 +1713,7 @@ for PMR and Trunked Radios</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="E1" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="E1" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!CSN!" pad="8"/>
 <connect gate="G$1" pin="!IRQN!" pad="3"/>
@@ -1757,7 +1757,7 @@ for 'Leisure Radios'</description>
 <gate name="G$1" symbol="CMX883" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D6" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="D6" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!CSN!" pad="8"/>
 <connect gate="G$1" pin="!IRQN!" pad="3"/>
@@ -1792,7 +1792,7 @@ for 'Leisure Radios'</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="E1" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="E1" package="SSOP-28-65P-440W-970L-120H-100F">
 <technologies>
 <technology name=""/>
 </technologies>
@@ -1805,7 +1805,7 @@ for 'Leisure Radios'</description>
 <gate name="G$1" symbol="FX465" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D5" package="SSOP-065-530-24">
+<device name="D5" package="SSOP-24-65P-530W">
 <connects>
 <connect gate="G$1" pin="!RX_TONE_DEC!" pad="13"/>
 <connect gate="G$1" pin="D0" pad="10"/>
@@ -1846,7 +1846,7 @@ FRS, MURS, PMR446 and GMRS Leisure Radios</description>
 <gate name="G$1" symbol="CMX882" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D6" package="SSOP-065-530-28">
+<device name="D6" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="!CSN!" pad="8"/>
 <connect gate="G$1" pin="!IRQN!" pad="3"/>
@@ -1881,7 +1881,7 @@ FRS, MURS, PMR446 and GMRS Leisure Radios</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="E1" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="E1" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!CSN!" pad="8"/>
 <connect gate="G$1" pin="!IRQN!" pad="3"/>

--- a/crystal.lbr
+++ b/crystal.lbr
@@ -2371,7 +2371,7 @@ ABS10 Series, 4.9 x 1.8mm</description>
 <text x="-2.8575" y="1.5875" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2.8575" y="-2.2225" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-530W-1030L-210H-125F-14">
+<package name="SOP-14-127P-530W-1030L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -5181,7 +5181,7 @@ ABM3 Series</description>
 <gate name="G$1" symbol="QG" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-530W-1030L-210H-125F-14">
+<device name="" package="SOP-14-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="G$1" pin="GND" pad="14"/>
 <connect gate="G$1" pin="OUT" pad="2"/>

--- a/cypressmicro.lbr
+++ b/cypressmicro.lbr
@@ -94,7 +94,7 @@ All information to create this library was taken from the datasheet version 3.13
 &lt;b&gt;*- &lt;u&gt;DISCLAIMER:&lt;/u&gt; CadSoft and the author do not warrant that this library is free from error
 or will meet your specific requirements.&lt;/b&gt;</description>
 <packages>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -114,7 +114,7 @@ or will meet your specific requirements.&lt;/b&gt;</description>
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -154,7 +154,7 @@ or will meet your specific requirements.&lt;/b&gt;</description>
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -186,7 +186,7 @@ or will meet your specific requirements.&lt;/b&gt;</description>
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-48">
+<package name="DIP-48-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-29.845" y1="-5.715" x2="29.845" y2="-5.715" width="0.2032" layer="21"/>
@@ -734,7 +734,7 @@ or will meet your specific requirements.&lt;/b&gt;</description>
 <vertex x="4.2598" y="-2.0008"/>
 </polygon>
 </package>
-<package name="SSOP-065-530-28">
+<package name="SSOP-28-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 28 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JEDEC MO-150B. Variation AH.</description>
 <circle x="-4.185" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -801,7 +801,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <wire x1="5.1" y1="-2.6" x2="5.1" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="5.1" y1="2.6" x2="-5.05" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-20">
+<package name="SSOP-20-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 20 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JEDEC MO-150B. Variation AE.</description>
 <circle x="-2.885" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -852,7 +852,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <wire x1="3.8" y1="-2.6" x2="3.8" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.6" x2="-3.75" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1000W-1000L-245H-160F-44">
+<package name="QFP-44-80P-1000W-1000L-245H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-022B, variation AB, PQFP-G.
@@ -954,7 +954,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-700W-700L-120H-48">
+<package name="TQFP-48-50P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
@@ -2000,7 +2000,7 @@ from micro-philips.lbr</description>
 <vertex x="1.5928" y="-0.4768"/>
 </polygon>
 </package>
-<package name="TQFP-80P-1000W-1000L-120H-44">
+<package name="TQFP-44-80P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
@@ -2102,7 +2102,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -2159,7 +2159,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -2744,7 +2744,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <gate name="G$3" symbol="VCC" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="PI" package="DIP-300-8">
+<device name="PI" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="P0-2" pad="6"/>
 <connect gate="G$1" pin="P0-4" pad="7"/>
@@ -2772,7 +2772,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <gate name="G$3" symbol="VCC" x="-38.1" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="PVI" package="SSOP-065-530-28">
+<device name="PVI" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="P0(0)" pad="24"/>
 <connect gate="G$1" pin="P0(1)" pad="4"/>
@@ -2807,7 +2807,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PI" package="DIP-300-28">
+<device name="PI" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="P0(0)" pad="24"/>
 <connect gate="G$1" pin="P0(1)" pad="4"/>
@@ -2842,7 +2842,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SI" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SI" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="P0(0)" pad="24"/>
 <connect gate="G$1" pin="P0(1)" pad="4"/>
@@ -2890,7 +2890,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <gate name="G$3" symbol="VCC" x="-43.18" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="PI" package="DIP-600-48">
+<device name="PI" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="P0-0" pad="44"/>
 <connect gate="G$1" pin="P0-1" pad="4"/>
@@ -3013,7 +3013,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <gate name="G$3" symbol="VCC" x="-38.1" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="PI" package="DIP-300-20">
+<device name="PI" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="P0(0)" pad="16"/>
 <connect gate="G$1" pin="P0(1)" pad="4"/>
@@ -3040,7 +3040,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PVI" package="SSOP-065-530-20">
+<device name="PVI" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="P0(0)" pad="16"/>
 <connect gate="G$1" pin="P0(1)" pad="4"/>
@@ -3067,7 +3067,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SI" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="SI" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="P0(0)" pad="16"/>
 <connect gate="G$1" pin="P0(1)" pad="4"/>
@@ -3107,7 +3107,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <gate name="G$3" symbol="VCC" x="-43.18" y="-20.32" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="P0-0" pad="35"/>
 <connect gate="G$1" pin="P0-1" pad="43"/>
@@ -3166,7 +3166,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <gate name="G$1" symbol="EZ-USB-2121S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="QFP-80P-1000W-1000L-245H-160F-44">
+<device name="" package="QFP-44-80P-1000W-1000L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!DISCON!" pad="43"/>
 <connect gate="G$1" pin="!WAKEUP!" pad="37"/>
@@ -3227,7 +3227,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <gate name="G$1" symbol="EZ-USB-2125S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="QFP-80P-1000W-1000L-245H-160F-44">
+<device name="" package="QFP-44-80P-1000W-1000L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!DISCON!" pad="43"/>
 <connect gate="G$1" pin="!WAKEUP!" pad="37"/>
@@ -3289,7 +3289,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <gate name="G$1" symbol="EZ-USB-2122T" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-700W-700L-120H-48">
+<device name="" package="TQFP-48-50P-700W-700L-120H">
 <connects>
 <connect gate="G$1" pin="!DISCON!" pad="47"/>
 <connect gate="G$1" pin="!WAKEUP!" pad="40"/>
@@ -3352,7 +3352,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <gate name="G$1" symbol="EZ-USB-2126T" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-700W-700L-120H-48">
+<device name="" package="TQFP-48-50P-700W-700L-120H">
 <connects>
 <connect gate="G$1" pin="!DISCON!" pad="47"/>
 <connect gate="G$1" pin="!WAKEUP!" pad="40"/>

--- a/diode.lbr
+++ b/diode.lbr
@@ -4041,7 +4041,7 @@ Philips SC01_Mounting_1996.pdf</description>
 <rectangle x1="0.75" y1="-1.5" x2="1.15" y2="-0.95" layer="51"/>
 <rectangle x1="-0.2" y1="0.95" x2="0.2" y2="1.5" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -5649,7 +5649,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <rectangle x1="0.4318" y1="-0.4318" x2="0.8382" y2="0.4318" layer="51"/>
 <rectangle x1="-0.8382" y1="-0.4318" x2="-0.4318" y2="0.4318" layer="51"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -17008,7 +17008,7 @@ Semtech</description>
 <gate name="G$1" symbol="SLVU2.8-4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
@@ -17031,7 +17031,7 @@ Semtech</description>
 <gate name="G$1" symbol="CDNBS08-SLVU2.8-4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
@@ -17833,7 +17833,7 @@ Semtech</description>
 <gate name="G$1" symbol="SLVU2.8-4_S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>

--- a/diodes-inc.lbr
+++ b/diodes-inc.lbr
@@ -94,7 +94,7 @@
 </layers>
 <library>
 <packages>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -259,7 +259,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="G$1" symbol="AP2176" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!FLAGA!" pad="2"/>
 <connect gate="G$1" pin="!FLAGB" pad="3"/>
@@ -298,7 +298,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="G$1" symbol="AP2166" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!ENA!" pad="1"/>
 <connect gate="G$1" pin="!ENB!" pad="4"/>
@@ -337,7 +337,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="G$1" symbol="AP2192A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!FLAGA!" pad="8"/>
 <connect gate="G$1" pin="!FLAGB" pad="5"/>

--- a/dvs-inc.lbr
+++ b/dvs-inc.lbr
@@ -72,7 +72,7 @@
 </layers>
 <library>
 <packages>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -378,7 +378,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="-PWR" symbol="AMBE-2020-10-PWR" x="58.42" y="-15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="-PWR" pin="GND@1" pad="1"/>
 <connect gate="-PWR" pin="GND@10" pad="10"/>

--- a/ecl.lbr
+++ b/ecl.lbr
@@ -72,7 +72,7 @@
 <description>&lt;b&gt;ECL Logic Devices&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -100,7 +100,7 @@
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -136,7 +136,7 @@
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -1429,7 +1429,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="4"/>
@@ -1461,7 +1461,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!O" pad="3"/>
 <connect gate="A" pin="A0" pad="4"/>
@@ -1493,7 +1493,7 @@
 <gate name="P" symbol="VCCVEEGN" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A1" pin="!O0" pad="4"/>
 <connect gate="A1" pin="!O1" pad="3"/>
@@ -1525,7 +1525,7 @@
 <gate name="A" symbol="MC10128" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="10"/>
 <connect gate="A" pin="CNTL0" pad="13"/>
@@ -1557,7 +1557,7 @@
 <gate name="P" symbol="2PWR2GND" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A1" pin="CLK" pad="11"/>
 <connect gate="A1" pin="CONTROL" pad="5"/>
@@ -1591,7 +1591,7 @@
 <gate name="C" symbol="CLK" x="-10.16" y="-10.16" addlevel="must"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="14"/>
 <connect gate="A" pin="CE" pad="11"/>
@@ -1623,7 +1623,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CE@1" pad="4"/>
 <connect gate="A" pin="CE@2" pad="12"/>
@@ -1657,7 +1657,7 @@
 <gate name="A1" symbol="CLK" x="-7.62" y="12.7" addlevel="must"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="3"/>
 <connect gate="A" pin="A-SEL" pad="6"/>
@@ -1691,7 +1691,7 @@
 <gate name="B" symbol="MC10135" x="-2.54" y="-15.24" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q" pad="3"/>
 <connect gate="A" pin="J" pad="7"/>
@@ -1723,7 +1723,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CIN" pad="10"/>
 <connect gate="A" pin="CLK" pad="13"/>
@@ -1755,7 +1755,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q0" pad="14"/>
 <connect gate="A" pin="!Q3" pad="3"/>
@@ -1787,7 +1787,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="4"/>
 <connect gate="A" pin="D0" pad="12"/>
@@ -1819,7 +1819,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!Q0" pad="14"/>
 <connect gate="A" pin="!Q3" pad="3"/>
@@ -1851,7 +1851,7 @@
 <gate name="P" symbol="1VCC1VEE" x="-22.86" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D00" pad="6"/>
 <connect gate="A" pin="D01" pad="5"/>
@@ -1882,7 +1882,7 @@
 <gate name="P" symbol="1VCC1VEE" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D00" pad="6"/>
 <connect gate="A" pin="D01" pad="5"/>
@@ -1914,7 +1914,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="I1" pad="3"/>
 <connect gate="A" pin="I10" pad="13"/>
@@ -1946,7 +1946,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-22.86" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="7"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -1978,7 +1978,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-22.86" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="7"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -2010,7 +2010,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="B0" pad="9"/>
 <connect gate="A" pin="B1" pad="7"/>
@@ -2042,7 +2042,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="7"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -2074,7 +2074,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="4"/>
 <connect gate="A" pin="D0" pad="5"/>
@@ -2106,7 +2106,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!EN" pad="15"/>
 <connect gate="A" pin="A0" pad="5"/>
@@ -2138,7 +2138,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="13"/>
 <connect gate="A" pin="D0" pad="3"/>
@@ -2170,7 +2170,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D0" pad="3"/>
 <connect gate="A" pin="D1" pad="4"/>
@@ -2202,7 +2202,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="7"/>
@@ -2234,7 +2234,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="7"/>
@@ -2266,7 +2266,7 @@
 <gate name="P" symbol="1VCC1VEE" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="D00" pad="6"/>
@@ -2298,7 +2298,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="7"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -2330,7 +2330,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK0" pad="6"/>
 <connect gate="A" pin="CLK1" pad="7"/>
@@ -2362,7 +2362,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="D0" pad="5"/>
@@ -2394,7 +2394,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-27.94" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CN" pad="11"/>
 <connect gate="A" pin="CN+2" pad="6"/>
@@ -2428,7 +2428,7 @@
 <gate name="A1" symbol="SELAB" x="-5.08" y="10.16" addlevel="must"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!S" pad="2"/>
 <connect gate="A" pin="A" pad="5"/>
@@ -2460,7 +2460,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-33.02" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="21"/>
 <connect gate="A" pin="A1" pad="18"/>
@@ -2500,7 +2500,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="5"/>
 <connect gate="A" pin="A1" pad="12"/>
@@ -2532,7 +2532,7 @@
 <gate name="P" symbol="1VCC1VEE" x="-25.4" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="D0" pad="5"/>
@@ -2564,7 +2564,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="AI" pad="5"/>
 <connect gate="A" pin="AO" pad="2"/>
@@ -2596,7 +2596,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="AI" pad="5"/>
 <connect gate="A" pin="AO" pad="2"/>
@@ -2628,7 +2628,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-25.4" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B1" pad="5"/>
@@ -2660,7 +2660,7 @@
 <gate name="P" symbol="1VCC1VEE" x="-25.4" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="10"/>
 <connect gate="G$1" pin="A1" pad="11"/>
@@ -2692,7 +2692,7 @@
 <gate name="P" symbol="3VCC1VEE" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="14"/>
 <connect gate="G$1" pin="A1" pad="15"/>
@@ -2732,7 +2732,7 @@
 <gate name="P" symbol="1VCC1VEE" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -2764,7 +2764,7 @@
 <gate name="P" symbol="1VCC1VEE" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="10"/>
 <connect gate="G$1" pin="A1" pad="9"/>
@@ -2796,7 +2796,7 @@
 <gate name="P" symbol="1VCC1VEE" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="3"/>
@@ -2828,7 +2828,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-27.94" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="3"/>
@@ -2860,7 +2860,7 @@
 <gate name="P" symbol="2VCC1VEE" x="-27.94" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="3"/>
@@ -2892,7 +2892,7 @@
 <gate name="P" symbol="2PWR4GND" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="A1" pad="24"/>
 <connect gate="G$1" pin="A2" pad="23"/>
@@ -2932,7 +2932,7 @@
 <gate name="P" symbol="2PWR4GND" x="-33.02" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="A1" pad="24"/>
 <connect gate="G$1" pin="A2" pad="23"/>
@@ -2972,7 +2972,7 @@
 <gate name="P" symbol="2PWR4GND" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="A1" pad="24"/>
 <connect gate="G$1" pin="A2" pad="23"/>
@@ -3012,7 +3012,7 @@
 <gate name="P" symbol="2PWR4GND" x="-33.02" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="A1" pad="24"/>
 <connect gate="G$1" pin="A2" pad="23"/>
@@ -3052,7 +3052,7 @@
 <gate name="P" symbol="2PWR4GND" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="A1" pad="24"/>
 <connect gate="G$1" pin="A2" pad="23"/>
@@ -3092,7 +3092,7 @@
 <gate name="P" symbol="2PWR4GND" x="-33.02" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="1D" pad="24"/>
 <connect gate="G$1" pin="1Q" pad="1"/>
@@ -3132,7 +3132,7 @@
 <gate name="P" symbol="2PWR4GND" x="-33.02" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="1D" pad="24"/>
 <connect gate="G$1" pin="1Q" pad="1"/>
@@ -3172,7 +3172,7 @@
 <gate name="P" symbol="2PWR4GND" x="-33.02" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="1D" pad="24"/>
 <connect gate="G$1" pin="1Q" pad="1"/>
@@ -3212,7 +3212,7 @@
 <gate name="P" symbol="2PWR4GND" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="A1" pad="24"/>
 <connect gate="G$1" pin="A2" pad="23"/>

--- a/exar.lbr
+++ b/exar.lbr
@@ -95,7 +95,7 @@ http://www.exar.com&lt;p&gt;
 <text x="-12.7" y="2.159" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2.54" y="2.159" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="PLCC-127P-1150W-1150L-457H-28">
+<package name="PLCC-28-127P-1150W-1150L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 11.51mm length, 11.51mm width, 4.57mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 11.51mm body length, 11.51mm body width, 4.57mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AB.&lt;/p&gt;
@@ -173,7 +173,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <wire x1="5.7531" y1="4.475" x2="5.7531" y2="5.7531" width="0.2032" layer="21"/>
 <wire x1="5.7531" y1="5.7531" x2="4.475" y2="5.7531" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1658W-1658L-457H-44">
+<package name="PLCC-44-127P-1658W-1658L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 16.59mm length, 16.59mm width, 4.57mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body width, 4.57mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AC.&lt;/p&gt;
@@ -283,7 +283,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <wire x1="8.2931" y1="7.015" x2="8.2931" y2="8.2931" width="0.2032" layer="21"/>
 <wire x1="8.2931" y1="8.2931" x2="7.015" y2="8.2931" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-530W-530L-210H-125F-8">
+<package name="SOP-8-127P-530W-530L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -316,7 +316,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="2.625" y1="-2.625" x2="-2.625" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="2.625" x2="-2.625" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="PLCC-127P-896W-896L-457H-20">
+<package name="PLCC-20-127P-896W-896L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 8.97mm length, 8.97mm width, 4.57mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 8.97mm body length, 8.97mm body width, 4.57mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AA.&lt;/p&gt;
@@ -378,7 +378,7 @@ JEDEC MS-018A, variation AA.&lt;/p&gt;
 <wire x1="4.4831" y1="3.205" x2="4.4831" y2="4.4831" width="0.2032" layer="21"/>
 <wire x1="4.4831" y1="4.4831" x2="3.205" y2="4.4831" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-840W-1540L-254H-180F-24">
+<package name="SOP-24-127P-840W-1540L-254H-180F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 15.40mm length, 8.40mm width, 2.54mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body length,
 8.40mm body width, 2.54mm max height, 24 leads.
@@ -440,7 +440,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body l
 <wire x1="7.6" y1="-4.1" x2="7.6" y2="4.1" width="0.2032" layer="21"/>
 <wire x1="7.6" y1="4.1" x2="-7.6" y2="4.1" width="0.2032" layer="21"/>&gt;
 </package>
-<package name="PLCC-127P-2423W-2423L-457H-68">
+<package name="PLCC-68-127P-2423W-2423L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 24.23mm length, 24.23mm width, 4.57mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body width, 4.57mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AE.&lt;/p&gt;
@@ -598,7 +598,7 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <wire x1="12.1158" y1="10.825" x2="12.1158" y2="12.1158" width="0.2032" layer="21"/>
 <wire x1="12.1158" y1="12.1158" x2="10.825" y2="12.1158" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1912W-1912L-457H-52">
+<package name="PLCC-52-127P-1912W-1912L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 19.13mm length, 19.13mm width, 4.57mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 19.13mm body length, 19.13mm body width, 4.57mm max height, 52 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AD.&lt;/p&gt;
@@ -1216,7 +1216,7 @@ JEDEC MS-018A, variation AD.&lt;/p&gt;
 <rectangle x1="-5.15" y1="2.25" x2="-3.15" y2="2.55" layer="51"/>
 <rectangle x1="-5.15" y1="3.05" x2="-3.15" y2="3.35" layer="51"/>
 </package>
-<package name="SOP-127P-530W-1030L-210H-125F-16">
+<package name="SOP-16-127P-530W-1030L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -1265,7 +1265,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="5.125" y1="-2.625" x2="-5.125" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="2.625" x2="-5.125" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-840W-1280L-254H-180F-20">
+<package name="SOP-20-127P-840W-1280L-254H-180F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 12.80mm length, 8.40mm width, 2.54mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body length,
 8.40mm body width, 2.54mm max height, 20 leads.
@@ -1319,7 +1319,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <wire x1="6.3" y1="-4.1" x2="6.3" y2="4.1" width="0.2032" layer="21"/>
 <wire x1="6.3" y1="4.1" x2="-6.3" y2="4.1" width="0.2032" layer="21"/>&gt;
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -1339,7 +1339,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -1365,7 +1365,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -1393,7 +1393,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -1423,7 +1423,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -1455,7 +1455,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-32">
+<package name="DIP-32-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="20.32" y1="5.715" x2="-20.32" y2="5.715" width="0.2032" layer="21"/>
@@ -1499,7 +1499,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <text x="-20.955" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-17.145" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -1551,7 +1551,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-48">
+<package name="DIP-48-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-29.845" y1="-5.715" x2="29.845" y2="-5.715" width="0.2032" layer="21"/>
@@ -1611,7 +1611,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <text x="-30.48" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -1651,7 +1651,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -1687,7 +1687,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-22">
+<package name="DIP-22-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="-14.605" y1="-0.635" x2="-14.605" y2="-1.905" width="0.2032" layer="21"/>
@@ -1721,7 +1721,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <text x="-15.24" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.795" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-42">
+<package name="DIP-42-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-27.6225" y1="-0.9525" x2="-27.6225" y2="-5.715" width="0.2032" layer="21"/>
@@ -1775,7 +1775,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <text x="-28.575" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-22.225" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -1809,7 +1809,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -1858,7 +1858,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -1915,7 +1915,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -5402,7 +5402,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-35.56" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="D" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AMSI" pad="1"/>
 <connect gate="G$1" pin="BIAS" pad="10"/>
@@ -5425,7 +5425,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="AMSI" pad="1"/>
 <connect gate="G$1" pin="BIAS" pad="10"/>
@@ -5457,7 +5457,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-33.02" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="BIAS" pad="11"/>
 <connect gate="G$1" pin="C1" pad="2"/>
@@ -5486,7 +5486,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-8038" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="C" pad="10"/>
 <connect gate="G$1" pin="D_ADJ@1" pad="4"/>
@@ -5515,7 +5515,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2208" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="COMMON" pad="4"/>
 <connect gate="G$1" pin="COMP" pad="12"/>
@@ -5546,7 +5546,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2228" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+VCC" pad="15"/>
 <connect gate="G$1" pin="-VEE" pad="10"/>
@@ -5578,7 +5578,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWR+/-" x="-35.56" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1" pad="13"/>
 <connect gate="G$1" pin="C2" pad="14"/>
@@ -5610,7 +5610,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-35.56" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1" pad="13"/>
 <connect gate="G$1" pin="C2" pad="14"/>
@@ -5639,7 +5639,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-35.56" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1" pad="13"/>
 <connect gate="G$1" pin="C2" pad="14"/>
@@ -5671,7 +5671,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CSO" pad="1"/>
 <connect gate="G$1" pin="IN_V" pad="7"/>
@@ -5686,7 +5686,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="MD" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="MD" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CSO" pad="1"/>
 <connect gate="G$1" pin="IN_V" pad="7"/>
@@ -5709,7 +5709,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2209" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="BIAS" pad="5"/>
 <connect gate="G$1" pin="C1" pad="2"/>
@@ -5733,7 +5733,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWR+/-" x="-33.02" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="BIAS" pad="5"/>
 <connect gate="G$1" pin="C1" pad="13"/>
@@ -5789,7 +5789,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T56L22" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="ALBO1" pad="2"/>
 <connect gate="G$1" pin="ALBO2" pad="3"/>
@@ -5822,7 +5822,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T5681" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!DATA+O/P" pad="12"/>
 <connect gate="G$1" pin="!DATAO/P" pad="10"/>
@@ -5855,7 +5855,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T5683" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="DECOUPLING" pad="1"/>
 <connect gate="G$1" pin="L-CBIAS" pad="5"/>
@@ -5888,7 +5888,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T5684" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="CLKDS" pad="10"/>
 <connect gate="G$1" pin="DPM" pad="11"/>
@@ -5931,7 +5931,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T5684" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1150W-1150L-457H-28">
+<device name="" package="PLCC-28-127P-1150W-1150L-457H">
 <connects>
 <connect gate="G$1" pin="CLKDS" pad="10"/>
 <connect gate="G$1" pin="DPM" pad="11"/>
@@ -5974,7 +5974,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T56L85" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="BIAS" pad="5"/>
 <connect gate="G$1" pin="CPEAK" pad="1"/>
@@ -6007,7 +6007,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T6164" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="GNDA" pad="4"/>
 <connect gate="G$1" pin="GNDD" pad="7"/>
@@ -6038,7 +6038,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T6165" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="ALARM" pad="22"/>
 <connect gate="G$1" pin="ALARMIN" pad="13"/>
@@ -6075,7 +6075,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T6166" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALARM" pad="1"/>
 <connect gate="G$1" pin="ALARMIN" pad="16"/>
@@ -6118,7 +6118,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T7295" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!ICT" pad="17"/>
 <connect gate="G$1" pin="EXCLK" pad="13"/>
@@ -6153,7 +6153,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T7296" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!ICT" pad="26"/>
 <connect gate="G$1" pin="BPV" pad="13"/>
@@ -6196,7 +6196,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T5670" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!+B8ZSIN" pad="11"/>
 <connect gate="G$1" pin="!-B8ZSIN" pad="13"/>
@@ -6227,7 +6227,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T5690" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="17"/>
 <connect gate="G$1" pin="!INT" pad="14"/>
@@ -6282,7 +6282,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T5690J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!CS" pad="19"/>
 <connect gate="G$1" pin="!INT" pad="16"/>
@@ -6341,7 +6341,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T5691" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!ALN" pad="15"/>
 <connect gate="G$1" pin="!SIGH" pad="1"/>
@@ -6380,7 +6380,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T5691J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1150W-1150L-457H-28">
+<device name="" package="PLCC-28-127P-1150W-1150L-457H">
 <connects>
 <connect gate="G$1" pin="!ALN" pad="17"/>
 <connect gate="G$1" pin="!SIGH" pad="1"/>
@@ -6423,7 +6423,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T2713" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="COMP1IN" pad="13"/>
 <connect gate="G$1" pin="COMP1OUT" pad="12"/>
@@ -6454,7 +6454,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T3588" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="BIAS" pad="8"/>
 <connect gate="G$1" pin="GND" pad="1"/>
@@ -6487,7 +6487,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T3589" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="1"/>
 <connect gate="G$1" pin="I/P1A" pad="13"/>
@@ -6516,7 +6516,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="T66100" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CDLY" pad="7"/>
 <connect gate="G$1" pin="CHOLD" pad="6"/>
@@ -6548,7 +6548,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWR+/-" x="-33.02" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-530W-1030L-210H-125F-16">
+<device name="" package="SOP-16-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="G$1" pin="C1" pad="13"/>
 <connect gate="G$1" pin="C2" pad="14"/>
@@ -6580,7 +6580,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="C" pad="5"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -6604,7 +6604,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="C" pad="5"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -6627,7 +6627,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2567" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="C_A" pad="1"/>
 <connect gate="G$1" pin="C_B" pad="8"/>
@@ -6658,7 +6658,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-205" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+VCC" pad="16"/>
 <connect gate="G$1" pin="-VEE" pad="9"/>
@@ -6689,7 +6689,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-C277" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="6"/>
 <connect gate="G$1" pin="ALBO_OUT" pad="1"/>
@@ -6720,7 +6720,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2100" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="9"/>
 <connect gate="G$1" pin="!RD" pad="8"/>
@@ -6755,7 +6755,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2135A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="BIT1" pad="11"/>
 <connect gate="G$1" pin="BIT2" pad="10"/>
@@ -6784,7 +6784,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2321" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="9"/>
 <connect gate="G$1" pin="!RD" pad="8"/>
@@ -6819,7 +6819,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2321" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-896W-896L-457H-20">
+<device name="" package="PLCC-20-127P-896W-896L-457H">
 <connects>
 <connect gate="G$1" pin="!CS" pad="9"/>
 <connect gate="G$1" pin="!RD" pad="8"/>
@@ -6854,7 +6854,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2321D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1540L-254H-180F-24">
+<device name="" package="SOP-24-127P-840W-1540L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="10"/>
 <connect gate="G$1" pin="!RD" pad="9"/>
@@ -6893,7 +6893,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2401" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!BIO" pad="9"/>
 <connect gate="G$1" pin="!DEN" pad="32"/>
@@ -6948,7 +6948,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2401J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!BIO" pad="10"/>
 <connect gate="G$1" pin="!DEN" pad="36"/>
@@ -7066,7 +7066,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2402" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="9"/>
 <connect gate="G$1" pin="!DEN" pad="38"/>
@@ -7129,7 +7129,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2402J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1912W-1912L-457H-52">
+<device name="" package="PLCC-52-127P-1912W-1912L-457H">
 <connects>
 <connect gate="G$1" pin="!CS" pad="12"/>
 <connect gate="G$1" pin="!DEN" pad="41"/>
@@ -7263,7 +7263,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2403" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!EA" pad="31"/>
 <connect gate="G$1" pin="!INT0" pad="12"/>
@@ -7318,7 +7318,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2403J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="35"/>
 <connect gate="G$1" pin="!PSEN" pad="32"/>
@@ -7436,7 +7436,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2403" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!EA" pad="31"/>
 <connect gate="G$1" pin="!INT0" pad="12"/>
@@ -7491,7 +7491,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2442J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="35"/>
 <connect gate="G$1" pin="!INT0" pad="14"/>
@@ -7609,7 +7609,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2403" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!EA" pad="31"/>
 <connect gate="G$1" pin="!INT0" pad="12"/>
@@ -7723,7 +7723,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2442J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="35"/>
 <connect gate="G$1" pin="!INT0" pad="14"/>
@@ -7782,7 +7782,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2901" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!BIO" pad="9"/>
 <connect gate="G$1" pin="!DEN" pad="32"/>
@@ -7837,7 +7837,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2901J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!BIO" pad="10"/>
 <connect gate="G$1" pin="!DEN" pad="36"/>
@@ -7955,7 +7955,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2902" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS0" pad="9"/>
 <connect gate="G$1" pin="!DEN" pad="39"/>
@@ -8018,7 +8018,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2902J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1912W-1912L-457H-52">
+<device name="" package="PLCC-52-127P-1912W-1912L-457H">
 <connects>
 <connect gate="G$1" pin="!CS0" pad="12"/>
 <connect gate="G$1" pin="!DEN" pad="42"/>
@@ -8152,7 +8152,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2403" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!EA" pad="31"/>
 <connect gate="G$1" pin="!INT0" pad="12"/>
@@ -8207,7 +8207,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2403J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="35"/>
 <connect gate="G$1" pin="!PSEN" pad="32"/>
@@ -8325,7 +8325,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2403" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!EA" pad="31"/>
 <connect gate="G$1" pin="!INT0" pad="12"/>
@@ -8380,7 +8380,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-2403J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="35"/>
 <connect gate="G$1" pin="!PSEN" pad="32"/>
@@ -8498,7 +8498,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="16C450" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="28"/>
 <connect gate="G$1" pin="A1" pad="27"/>
@@ -8553,7 +8553,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="16C450J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="A0" pad="31"/>
 <connect gate="G$1" pin="A1" pad="30"/>
@@ -8613,7 +8613,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="3VCC6GND" x="-30.48" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="A0" pad="35"/>
 <connect gate="G$1" pin="A1" pad="34"/>
@@ -8697,7 +8697,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-30.48" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="28"/>
 <connect gate="G$1" pin="A1" pad="27"/>
@@ -8753,7 +8753,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$2" symbol="16C550J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$2" pin="A0" pad="31"/>
 <connect gate="G$2" pin="A1" pad="30"/>
@@ -8813,7 +8813,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="3VCC3GND" x="-22.86" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="A0" pad="35"/>
 <connect gate="G$1" pin="A1" pad="34"/>
@@ -8897,7 +8897,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-27.94" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -8957,7 +8957,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="4"/>
@@ -9017,7 +9017,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="3"/>
@@ -9073,7 +9073,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -9129,7 +9129,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -9173,7 +9173,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="A1" pad="35"/>
 <connect gate="G$1" pin="A2" pad="34"/>
@@ -9232,7 +9232,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-532AD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!AMD" pad="19"/>
 <connect gate="G$1" pin="!RD" pad="4"/>
@@ -9275,7 +9275,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-532AJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1150W-1150L-457H-28">
+<device name="" package="PLCC-28-127P-1150W-1150L-457H">
 <connects>
 <connect gate="G$1" pin="!AMD" pad="19"/>
 <connect gate="G$1" pin="!RD" pad="4"/>
@@ -9366,7 +9366,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="P" symbol="PWRN" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="A0" pad="35"/>
 <connect gate="G$1" pin="A1" pad="34"/>
@@ -9425,7 +9425,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4610R4CD" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1280L-254H-180F-20">
+<device name="" package="SOP-20-127P-840W-1280L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="20"/>
 <connect gate="G$1" pin="!WDI" pad="12"/>
@@ -9460,7 +9460,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4610R2CD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-530W-1030L-210H-125F-16">
+<device name="" package="SOP-16-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="16"/>
 <connect gate="G$1" pin="!WDI" pad="9"/>
@@ -9491,7 +9491,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4610R4CD" x="0" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1280L-254H-180F-20">
+<device name="" package="SOP-20-127P-840W-1280L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="20"/>
 <connect gate="G$1" pin="!WDI" pad="12"/>
@@ -9526,7 +9526,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4610R2CD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-530W-1030L-210H-125F-16">
+<device name="" package="SOP-16-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="16"/>
 <connect gate="G$1" pin="!WDI" pad="9"/>
@@ -9557,7 +9557,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-9050" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1150W-1150L-457H-28">
+<device name="" package="PLCC-28-127P-1150W-1150L-457H">
 <connects>
 <connect gate="G$1" pin="!AMD" pad="14"/>
 <connect gate="G$1" pin="!DRD" pad="22"/>
@@ -9600,7 +9600,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-9050" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!AMD" pad="14"/>
 <connect gate="G$1" pin="!DRD" pad="22"/>
@@ -9710,7 +9710,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1001" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="5"/>
 <connect gate="G$1" pin="CLKIN" pad="1"/>
@@ -9733,7 +9733,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1010" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="50/100/PD" pad="12"/>
 <connect gate="G$1" pin="AGND" pad="15"/>
@@ -9768,7 +9768,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1010" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="50/100/PD" pad="12"/>
 <connect gate="G$1" pin="AGND" pad="15"/>
@@ -9803,7 +9803,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1015" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="5/!10" pad="1"/>
 <connect gate="G$1" pin="ANAREF" pad="7"/>
@@ -9826,7 +9826,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1016" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="5/!10" pad="1"/>
 <connect gate="G$1" pin="A+IN" pad="7"/>
@@ -9855,7 +9855,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1016D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="5/10" pad="1"/>
 <connect gate="G$1" pin="A+IN" pad="8"/>
@@ -9886,7 +9886,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1020" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="3"/>
 <connect gate="G$1" pin="!S" pad="2"/>
@@ -9929,7 +9929,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1091" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK/2" pad="15"/>
 <connect gate="G$1" pin="CLKC" pad="13"/>
@@ -9960,7 +9960,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1092" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="18"/>
 <connect gate="G$1" pin="AUX1" pad="17"/>
@@ -9995,7 +9995,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1093" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="10K/!16K" pad="5"/>
 <connect gate="G$1" pin="CLK/2" pad="13"/>
@@ -10024,7 +10024,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1094" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="10K/!16K" pad="16"/>
 <connect gate="G$1" pin="A1" pad="1"/>
@@ -10071,7 +10071,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1095" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-42">
+<device name="" package="DIP-42-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A10" pad="13"/>
@@ -10128,7 +10128,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1096" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A10" pad="10"/>
@@ -10175,7 +10175,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1097" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="AUX1" pad="7"/>
 <connect gate="G$1" pin="AUX2" pad="6"/>
@@ -10204,7 +10204,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="XR-1071" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALLPASS" pad="8"/>
 <connect gate="G$1" pin="ALLPASS@1" pad="25"/>

--- a/fairchild-semi.lbr
+++ b/fairchild-semi.lbr
@@ -175,7 +175,7 @@ Thin shrink small outline transistor package (also known as SOT363). 0.65mm pitc
 <wire x1="1.1" y1="-0.525" x2="-1.1" y2="-0.525" width="0.2032" layer="51"/>
 <wire x1="1.1" y1="0.525" x2="1.1" y2="-0.525" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-230W-200L-100H-40F-8">
+<package name="SSOP-8-50P-230W-200L-100H-40F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.40mm lead length, 2.0mm length, 2.3mm width, 1.00mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.50mm pitch, 0.40mm lead length 2.0mm length, 2.3mm width, 1.00mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation CA, VSR-PDSO.&lt;/p&gt;
@@ -238,7 +238,7 @@ body 3x3mm, pitch 0.95mm</description>
 <rectangle x1="-1.125" y1="-0.625" x2="1.125" y2="0.625" layer="31"/>
 <rectangle x1="-2.125" y1="-1.625" x2="-1.75" y2="-1.25" layer="21"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -1188,7 +1188,7 @@ Non-Inverting</description>
 <gate name="G$1" symbol="NC7NZ34" x="0" y="0"/>
 </gates>
 <devices>
-<device name="K8X" package="SSOP-50P-230W-200L-100H-40F-8">
+<device name="K8X" package="SSOP-8-50P-230W-200L-100H-40F">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -1376,7 +1376,7 @@ Non-Inverting with Open Drain</description>
 <gate name="G$1" symbol="FAN8303" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BS" pad="1"/>
 <connect gate="G$1" pin="COMP" pad="6"/>

--- a/fifo.lbr
+++ b/fifo.lbr
@@ -72,7 +72,7 @@
 <description>&lt;b&gt;First In First Out Memories&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="PLCC-127P-2423W-2423L-457H-68">
+<package name="PLCC-68-127P-2423W-2423L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 24.23mm length, 24.23mm width, 4.57mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body width, 4.57mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AE.&lt;/p&gt;
@@ -230,7 +230,7 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <wire x1="12.1158" y1="10.825" x2="12.1158" y2="12.1158" width="0.2032" layer="21"/>
 <wire x1="12.1158" y1="12.1158" x2="10.825" y2="12.1158" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1658W-1658L-457H-44">
+<package name="PLCC-44-127P-1658W-1658L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 16.59mm length, 16.59mm width, 4.57mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body width, 4.57mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AC.&lt;/p&gt;
@@ -340,7 +340,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <wire x1="8.2931" y1="7.015" x2="8.2931" y2="8.2931" width="0.2032" layer="21"/>
 <wire x1="8.2931" y1="8.2931" x2="7.015" y2="8.2931" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -368,7 +368,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -398,7 +398,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -430,7 +430,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -470,7 +470,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -1042,7 +1042,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-33.02" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="D0" pad="6"/>
 <connect gate="G$1" pin="D1" pad="5"/>
@@ -1086,7 +1086,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-30.48" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="C/!D" pad="23"/>
 <connect gate="G$1" pin="D0" pad="6"/>
@@ -1130,7 +1130,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="PWR2GND" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="C/!D!/A" pad="1"/>
 <connect gate="G$1" pin="C/!D!/B" pad="15"/>
@@ -1174,7 +1174,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="2PWR4GND" x="-38.1" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="A0" pad="4"/>
 <connect gate="G$1" pin="A1" pad="5"/>
@@ -1232,7 +1232,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="9PWR10GN" x="-43.18" y="17.78" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="AF/AE" pad="33"/>
 <connect gate="G$1" pin="D0" pad="26"/>
@@ -1316,7 +1316,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="9PWR10GN" x="-43.18" y="17.78" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="AF/AE" pad="33"/>
 <connect gate="G$1" pin="D0" pad="26"/>
@@ -1396,7 +1396,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-30.48" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="D0" pad="5"/>
 <connect gate="G$1" pin="D1" pad="6"/>
@@ -1432,7 +1432,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="D0" pad="4"/>
 <connect gate="G$1" pin="D1" pad="5"/>
@@ -1464,7 +1464,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-30.48" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="D0" pad="5"/>
 <connect gate="G$1" pin="D1" pad="6"/>
@@ -1500,7 +1500,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="D0" pad="4"/>
 <connect gate="G$1" pin="D1" pad="5"/>
@@ -1532,7 +1532,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="1/2_FULL" pad="2"/>
 <connect gate="G$1" pin="D0" pad="5"/>
@@ -1568,7 +1568,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-30.48" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="D0" pad="4"/>
 <connect gate="G$1" pin="D1" pad="5"/>
@@ -1599,7 +1599,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="D0" pad="4"/>
 <connect gate="G$1" pin="D1" pad="5"/>
@@ -1632,7 +1632,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="D0" pad="4"/>
 <connect gate="G$1" pin="D1" pad="5"/>
@@ -1666,7 +1666,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="D0" pad="2"/>
 <connect gate="G$1" pin="D1" pad="3"/>

--- a/fox-electronics.lbr
+++ b/fox-electronics.lbr
@@ -101,7 +101,7 @@ http://www.foxonline.com/</description>
 <text x="-2.5" y="2.24" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2.4" y="-2.9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -183,7 +183,7 @@ http://www.foxonline.com/72421.htm</description>
 <gate name="G$1" symbol="RTC72412" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="4"/>
 <connect gate="G$1" pin="A1" pad="5"/>

--- a/freescale-semi.lbr
+++ b/freescale-semi.lbr
@@ -72,7 +72,7 @@
 </layers>
 <library>
 <packages>
-<package name="SSOP-65P-440W-500L-120H-100F-16">
+<package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -117,7 +117,7 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1000W-1000L-120H-44">
+<package name="TQFP-44-80P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
@@ -983,7 +983,7 @@ MC9S08QG4?4 Kbytes FLASH, 256 bytes RAM</description>
 <gate name="G$1" symbol="MC9S08QG8" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="DT" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="DT" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="PTA0/KBIP0/TPMCH0/ADP0/ACMP+" pad="16"/>
 <connect gate="G$1" pin="PTA1/KBIP1/ADP1/ACMP?" pad="15"/>
@@ -1014,7 +1014,7 @@ MC9S08QG4?4 Kbytes FLASH, 256 bytes RAM</description>
 <gate name="G$1" symbol="MC9S08SH4CTG" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="PTA0/PIA0/TPM1CH0/ADP0/ACMP+" pad="16"/>
 <connect gate="G$1" pin="PTA1/PIA1/TPM2CH0/ADP1/ACMP-" pad="15"/>
@@ -1045,7 +1045,7 @@ MC9S08QG4?4 Kbytes FLASH, 256 bytes RAM</description>
 <gate name="G$1" symbol="MC9S08AC8CFG" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="3"/>
 <connect gate="G$1" pin="BKGD/MS" pad="36"/>

--- a/ftdi-chip.lbr
+++ b/ftdi-chip.lbr
@@ -89,7 +89,7 @@ Based on the following sources:
 &lt;author&gt;Revised 4 March 2003 by Scott Alfter (corrected package dimensions)&lt;/author&gt;
 &lt;/p&gt;</description>
 <packages>
-<package name="LQFP-80P-700W-700L-160H-32">
+<package name="LQFP-32-80P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.
@@ -167,7 +167,7 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-28">
+<package name="SSOP-28-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 28 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JEDEC MO-150B. Variation AH.</description>
 <circle x="-4.185" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -295,7 +295,7 @@ pitch 0.5 mm, body 5x5 mm</description>
 <rectangle x1="0.75" y1="-1.25" x2="1.25" y2="-0.75" layer="31"/>
 <rectangle x1="-1.25" y1="-1.25" x2="-0.75" y2="-0.75" layer="31"/>
 </package>
-<package name="TQFP-50P-1000W-1000L-120H-64">
+<package name="TQFP-64-50P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.
@@ -1190,7 +1190,7 @@ pitch 0.025" (0.154", 3.90mm Width)</description>
 <gate name="A" symbol="FT232BM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-80P-700W-700L-160H-32">
+<device name="" package="LQFP-32-80P-700W-700L-160H">
 <connects>
 <connect gate="A" pin="!CTS!" pad="22"/>
 <connect gate="A" pin="!DCD!" pad="19"/>
@@ -1241,7 +1241,7 @@ pitch 0.025" (0.154", 3.90mm Width)</description>
 <gate name="P" symbol="2VCC2GND" x="-45.72" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="LQFP-80P-700W-700L-160H-32">
+<device name="" package="LQFP-32-80P-700W-700L-160H">
 <connects>
 <connect gate="A" pin="!PWREN!" pad="10"/>
 <connect gate="A" pin="!RD!" pad="16"/>
@@ -1292,7 +1292,7 @@ pitch 0.025" (0.154", 3.90mm Width)</description>
 <gate name="P" symbol="3VCC2GND" x="-45.72" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="LQFP-80P-700W-700L-160H-32">
+<device name="" package="LQFP-32-80P-700W-700L-160H">
 <connects>
 <connect gate="A" pin="!CTS!" pad="22"/>
 <connect gate="A" pin="!DCD!" pad="19"/>
@@ -1343,7 +1343,7 @@ pitch 0.025" (0.154", 3.90mm Width)</description>
 <gate name="P" symbol="3VCC2GND" x="-45.72" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="LQFP-80P-700W-700L-160H-32">
+<device name="" package="LQFP-32-80P-700W-700L-160H">
 <connects>
 <connect gate="A" pin="!EEGNT!" pad="10"/>
 <connect gate="A" pin="!EEREQ!" pad="11"/>
@@ -1390,7 +1390,7 @@ pitch 0.025" (0.154", 3.90mm Width)</description>
 <gate name="G$1" symbol="FT232RL" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-28">
+<device name="" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="!CTS!" pad="11"/>
 <connect gate="G$1" pin="!DCD!" pad="10"/>
@@ -1552,7 +1552,7 @@ MULTIPURPOSE UART/MPSSE IC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="HL" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="HL" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!PWREN!" pad="60"/>
 <connect gate="G$1" pin="!RESET!" pad="14"/>

--- a/hittite.lbr
+++ b/hittite.lbr
@@ -330,7 +330,7 @@ ST89 (E) – 4 LEAD PLASTIC</description>
 <wire x1="1.4" y1="1.3" x2="2.3" y2="1.3" width="0.2032" layer="21"/>
 <wire x1="2.3" y1="1.3" x2="2.3" y2="-1.2" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -454,7 +454,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <gate name="P" symbol="RFS_CTRL" x="0" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="RF1" pad="5"/>
 <connect gate="A" pin="RF2" pad="8"/>

--- a/honeywell.lbr
+++ b/honeywell.lbr
@@ -135,7 +135,7 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <text x="-1.905" y="6.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-1.905" y="-6" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -509,7 +509,7 @@ body 4x4mm</description>
 <gate name="G$1" symbol="HCM1501" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND1" pad="2"/>
 <connect gate="G$1" pin="GND2" pad="7"/>
@@ -529,7 +529,7 @@ body 4x4mm</description>
 <gate name="G$1" symbol="HCM1512" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND-A" pad="8"/>
 <connect gate="G$1" pin="GND-B" pad="7"/>

--- a/hp-motion.lbr
+++ b/hp-motion.lbr
@@ -72,7 +72,7 @@
 </layers>
 <library>
 <packages>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -100,7 +100,7 @@
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -197,7 +197,7 @@
 <gate name="P" symbol="PWRN" x="-27.94" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="CHA" pad="9"/>
 <connect gate="A" pin="CHB" pad="8"/>
@@ -232,7 +232,7 @@
 <gate name="A" symbol="HCTL-2016" x="0" y="0" addlevel="must"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CHA" pad="7"/>
 <connect gate="A" pin="CHB" pad="6"/>

--- a/ic-package.lbr
+++ b/ic-package.lbr
@@ -72,7 +72,7 @@
 <description>&lt;b&gt;IC Packages an Sockeds&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="DIP-300-4">
+<package name="DIP-4-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="2.54" y1="1.905" x2="-2.54" y2="1.905" width="0.2032" layer="21"/>
@@ -88,7 +88,7 @@
 <text x="4.445" y="-2.8575" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 <text x="-3.175" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 </package>
-<package name="DIP-300-6">
+<package name="DIP-6-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="3.81" y1="1.905" x2="-3.81" y2="1.905" width="0.2032" layer="21"/>
@@ -106,7 +106,7 @@
 <text x="-2.54" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-4.445" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -126,7 +126,7 @@
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -152,7 +152,7 @@
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -180,7 +180,7 @@
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -210,7 +210,7 @@
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -242,7 +242,7 @@
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -278,7 +278,7 @@
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -314,7 +314,7 @@
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -354,7 +354,7 @@
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-32">
+<package name="DIP-32-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="20.32" y1="5.715" x2="-20.32" y2="5.715" width="0.2032" layer="21"/>
@@ -398,7 +398,7 @@
 <text x="-20.955" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-17.145" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -505,7 +505,7 @@
 <text x="-9.525" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.3025" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-48">
+<package name="DIP-48-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-29.845" y1="-5.715" x2="29.845" y2="-5.715" width="0.2032" layer="21"/>
@@ -565,7 +565,7 @@
 <text x="-30.48" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -605,7 +605,7 @@
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-22">
+<package name="DIP-22-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="-14.605" y1="-0.635" x2="-14.605" y2="-1.905" width="0.2032" layer="21"/>
@@ -1181,7 +1181,7 @@ Source: MC68020UM.pdf</description>
 <text x="-5.715" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-7.62" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-2">
+<package name="DIP-2-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="-0.635" y1="-1.905" x2="0.635" y2="-1.905" width="0.2032" layer="21"/>
@@ -1769,7 +1769,7 @@ Source: MC68020UM.pdf</description>
 <text x="-7.62" y="-4.445" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-3.81" y="2.54" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 </package>
-<package name="DIP-400-28">
+<package name="DIP-28-254P-1016W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 400 mil row spacing, JEDEC MS-010C</description>
 <wire x1="17.78" y1="3.175" x2="-17.78" y2="3.175" width="0.2032" layer="21"/>
@@ -1809,7 +1809,7 @@ Source: MC68020UM.pdf</description>
 <text x="-18.415" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-400-22">
+<package name="DIP-22-254P-1016W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 400 mil row spacing, JEDEC MS-010C</description>
 <wire x1="13.97" y1="2.8575" x2="-13.97" y2="2.8575" width="0.2032" layer="21"/>
@@ -2525,7 +2525,7 @@ Source: MC68020UM.pdf</description>
 <text x="-15.494" y="-3.048" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.398" y="-0.762" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-400-24">
+<package name="DIP-24-254P-1016W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 400 mil row spacing, JEDEC MS-010C</description>
 <wire x1="15.5575" y1="-3.175" x2="15.5575" y2="3.175" width="0.2032" layer="21"/>
@@ -2561,7 +2561,7 @@ Source: MC68020UM.pdf</description>
 <text x="-15.875" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-12.065" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-900-24">
+<package name="DIP-24-254P-2286W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 900 mil row spacing, JEDEC MO-016D</description>
 <wire x1="-16.129" y1="-0.9525" x2="-16.129" y2="-9.4615" width="0.2032" layer="21"/>
@@ -2783,7 +2783,7 @@ Source: MC68020UM.pdf</description>
 <text x="-11.43" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.89" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-900-64">
+<package name="DIP-64-254P-2286W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 900 mil row spacing, JEDEC MO-016D</description>
 <wire x1="-41.275" y1="-0.9525" x2="-41.275" y2="-9.4615" width="0.2032" layer="21"/>
@@ -2859,7 +2859,7 @@ Source: MC68020UM.pdf</description>
 <text x="-42.545" y="-10.16" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-36.83" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-400-6">
+<package name="DIP-6-254P-1016W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 400 mil row spacing, JEDEC MS-010C</description>
 <wire x1="-4.445" y1="0.635" x2="-4.445" y2="2.8575" width="0.2032" layer="21"/>
@@ -3056,7 +3056,7 @@ Source: MC68020UM.pdf</description>
 <text x="-12.192" y="-3.429" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-11.176" y="2.286" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-42">
+<package name="DIP-42-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-27.6225" y1="-0.9525" x2="-27.6225" y2="-5.715" width="0.2032" layer="21"/>
@@ -4112,7 +4112,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-4">
+<device name="" package="DIP-4-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
@@ -4142,7 +4142,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL6" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
@@ -4155,7 +4155,7 @@ Source: MC68020UM.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/4" package="DIP-400-6">
+<device name="/4" package="DIP-6-254P-1016W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
@@ -4189,7 +4189,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL8" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
@@ -4252,7 +4252,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL14" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4302,7 +4302,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL16" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4356,7 +4356,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL18" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4406,7 +4406,7 @@ Source: MC68020UM.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="Y" package="DIP-300-18">
+<device name="Y" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4464,7 +4464,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL20" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4526,7 +4526,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL22" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-4" package="DIP-400-22">
+<device name="-4" package="DIP-22-254P-1016W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4555,7 +4555,7 @@ Source: MC68020UM.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-3" package="DIP-300-22">
+<device name="-3" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4621,7 +4621,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL24" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-3" package="DIP-300-24">
+<device name="-3" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4652,7 +4652,7 @@ Source: MC68020UM.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-4" package="DIP-400-24">
+<device name="-4" package="DIP-24-254P-1016W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4683,7 +4683,7 @@ Source: MC68020UM.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-6" package="DIP-600-24">
+<device name="-6" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4714,7 +4714,7 @@ Source: MC68020UM.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-9" package="DIP-900-24">
+<device name="-9" package="DIP-24-254P-2286W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4753,7 +4753,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL28" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4788,7 +4788,7 @@ Source: MC68020UM.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-3" package="DIP-300-28">
+<device name="-3" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4823,7 +4823,7 @@ Source: MC68020UM.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-4" package="DIP-400-28">
+<device name="-4" package="DIP-28-254P-1016W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4866,7 +4866,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL32" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -4913,7 +4913,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL40" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -5051,7 +5051,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL64" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-900-64">
+<device name="" package="DIP-64-254P-2286W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -5308,7 +5308,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL42" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-42">
+<device name="" package="DIP-42-254P-1524W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -5365,7 +5365,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL48" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -5531,7 +5531,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="DIL2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-2">
+<device name="" package="DIP-2-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>

--- a/idt.lbr
+++ b/idt.lbr
@@ -82,7 +82,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2015, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SSOP-065-530-20">
+<package name="SSOP-20-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 20 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JEDEC MO-150B. Variation AE.</description>
 <circle x="-2.885" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -177,7 +177,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWR_VCCGND" x="-30.48" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-20">
+<device name="" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="!OE1!" pad="1"/>
 <connect gate="G$1" pin="!OE2!" pad="19"/>

--- a/intersil.lbr
+++ b/intersil.lbr
@@ -98,7 +98,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -127,7 +127,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <wire x1="1.4" y1="-1.4" x2="1.4" y2="1.4" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="1.4" x2="-1.4" y2="1.4" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -161,7 +161,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-50P-300W-300L-110H-95F-10">
+<package name="SSOP-10-50P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
@@ -194,7 +194,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <wire x1="1.4" y1="-1.4" x2="1.4" y2="1.4" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="1.4" x2="-1.4" y2="1.4" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-300L-120H-100F-8">
+<package name="SSOP-8-65P-440W-300L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -416,7 +416,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="ISL1208" x="0" y="0"/>
 </gates>
 <devices>
-<device name="IU" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="IU" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!IRQ!" pad="7"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -431,7 +431,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="IB" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="IB" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!IRQ!" pad="7"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -454,7 +454,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="ISL3170E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="IUZ" package="SSOP-50P-300W-300L-110H-95F-10">
+<device name="IUZ" package="SSOP-10-50P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A" pad="9"/>
@@ -479,7 +479,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="ISL55110" x="0" y="0"/>
 </gates>
 <devices>
-<device name="IVZ" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="IVZ" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="GND" pad="7"/>
 <connect gate="G$1" pin="IN-A" pad="4"/>
@@ -502,7 +502,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="ISL32601E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FUZ" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="FUZ" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A/Y" pad="6"/>
@@ -517,7 +517,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="FBZ" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="FBZ" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A/Y" pad="6"/>
@@ -540,7 +540,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="ISL32600E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FUZ" package="SSOP-50P-300W-300L-110H-95F-10">
+<device name="FUZ" package="SSOP-10-50P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A" pad="9"/>
@@ -565,7 +565,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="ISL3171E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="IUZ" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="IUZ" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -580,7 +580,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="IBZ" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="IBZ" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -603,7 +603,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="ISL12022" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!IRQ!/FOUT" pad="7"/>
 <connect gate="G$1" pin="GND" pad="4"/>

--- a/isd-new.lbr
+++ b/isd-new.lbr
@@ -157,7 +157,7 @@ Winbond Electronics, Corp.&lt;p&gt;
 <rectangle x1="6.05" y1="-2.9" x2="6.7" y2="-2.6" layer="21"/>
 <rectangle x1="6.05" y1="-3.45" x2="6.7" y2="-3.15" layer="21"/>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -197,7 +197,7 @@ Winbond Electronics, Corp.&lt;p&gt;
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -584,7 +584,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$5" symbol="NC-LEFT" x="12.7" y="17.78" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -631,7 +631,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$5" symbol="NC-LEFT" x="15.24" y="20.32" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -675,7 +675,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="IC1" symbol="ISD2560" x="15.24" y="12.7"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="IC1" pin="A0" pad="1"/>
 <connect gate="IC1" pin="A1" pad="2"/>
@@ -713,7 +713,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="90"/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="IC1" pin="A0" pad="1"/>
 <connect gate="IC1" pin="A1" pad="2"/>
@@ -808,7 +808,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$11" symbol="NC-RIGHT" x="12.7" y="-20.32" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="22"/>
@@ -846,7 +846,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="16"/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="22"/>
@@ -884,7 +884,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="16"/>
 </technologies>
 </device>
-<device name="SI" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SI" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="22"/>
@@ -1056,7 +1056,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$11" symbol="NC-RIGHT" x="12.7" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="21"/>
@@ -1094,7 +1094,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="08"/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="21"/>
@@ -1132,7 +1132,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="08"/>
 </technologies>
 </device>
-<device name="SI" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SI" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="21"/>
@@ -1304,7 +1304,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$11" symbol="NC-RIGHT" x="12.7" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="21"/>
@@ -1342,7 +1342,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="240"/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="21"/>
@@ -1380,7 +1380,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="240"/>
 </technologies>
 </device>
-<device name="SI" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SI" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="21"/>
@@ -1541,7 +1541,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <gate name="G$4" symbol="NC-LEFT" x="-17.78" y="-25.4" addlevel="request"/>
 </gates>
 <devices>
-<device name="16P" package="DIP-600-28">
+<device name="16P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$2" pin="NC" pad="7"/>
 <connect gate="G$3" pin="NC" pad="21"/>
@@ -1576,7 +1576,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="02S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="02S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$2" pin="NC" pad="7"/>
 <connect gate="G$3" pin="NC" pad="21"/>
@@ -1611,7 +1611,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="04S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="04S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$2" pin="NC" pad="7"/>
 <connect gate="G$3" pin="NC" pad="21"/>
@@ -1646,7 +1646,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="08S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="08S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$2" pin="NC" pad="7"/>
 <connect gate="G$3" pin="NC" pad="21"/>
@@ -1681,7 +1681,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="16S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="16S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$2" pin="NC" pad="7"/>
 <connect gate="G$3" pin="NC" pad="21"/>
@@ -1866,7 +1866,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <gate name="G$1" symbol="NC-LEFT" x="-10.16" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="32P" package="DIP-600-28">
+<device name="32P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="NC" pad="8"/>
 <connect gate="IC" pin="A0" pad="1"/>
@@ -1901,7 +1901,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="32S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="32S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="8"/>
 <connect gate="IC" pin="A0" pad="1"/>
@@ -1971,7 +1971,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="40P" package="DIP-600-28">
+<device name="40P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="NC" pad="8"/>
 <connect gate="IC" pin="A0" pad="1"/>
@@ -2006,7 +2006,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="40S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="40S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="8"/>
 <connect gate="IC" pin="A0" pad="1"/>
@@ -2076,7 +2076,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="48P" package="DIP-600-28">
+<device name="48P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="NC" pad="8"/>
 <connect gate="IC" pin="A0" pad="1"/>
@@ -2111,7 +2111,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="48S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="48S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="8"/>
 <connect gate="IC" pin="A0" pad="1"/>
@@ -2146,7 +2146,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="48E" package="DIP-600-28">
+<device name="48E" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="NC" pad="15"/>
 <connect gate="IC" pin="A0" pad="8"/>
@@ -2181,7 +2181,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="64P" package="DIP-600-28">
+<device name="64P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="NC" pad="8"/>
 <connect gate="IC" pin="A0" pad="1"/>
@@ -2216,7 +2216,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="64S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="64S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="8"/>
 <connect gate="IC" pin="A0" pad="1"/>

--- a/isd.lbr
+++ b/isd.lbr
@@ -76,7 +76,7 @@
 <description>&lt;b&gt;ISD Voice Recorder/Playback Devices&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -116,7 +116,7 @@
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -262,7 +262,7 @@ body 8 X 13.4mm, pitch 0.55mm</description>
 <rectangle x1="2.375" y1="6.275" x2="3.125" y2="6.575" layer="51" rot="R90"/>
 <rectangle x1="2.925" y1="6.275" x2="3.675" y2="6.575" layer="51" rot="R90"/>
 </package>
-<package name="LQFP-50P-700W-700L-160H-48">
+<package name="LQFP-48-50P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
@@ -599,7 +599,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC2VSS2" x="-33.02" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="23"/>
 <connect gate="A" pin="!EOM!" pad="25"/>
@@ -634,7 +634,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="!CE!" pad="23"/>
 <connect gate="A" pin="!EOM!" pad="25"/>
@@ -678,7 +678,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="G$1" symbol="ISD4002" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!INT!" pad="25"/>
 <connect gate="G$1" pin="!SS!" pad="1"/>
@@ -702,7 +702,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT!" pad="25"/>
 <connect gate="G$1" pin="!SS!" pad="1"/>
@@ -735,7 +735,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="G$1" symbol="ISD51XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT!" pad="25"/>
 <connect gate="G$1" pin="A0" pad="4"/>
@@ -770,7 +770,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!INT!" pad="25"/>
 <connect gate="G$1" pin="A0" pad="4"/>
@@ -849,7 +849,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="G$1" symbol="ISD17XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!ERASE!" pad="25"/>
 <connect gate="G$1" pin="!FT!" pad="22"/>
@@ -884,7 +884,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!ERASE!" pad="25"/>
 <connect gate="G$1" pin="!FT!" pad="22"/>
@@ -963,7 +963,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="G$1" symbol="ISD151XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="ANAIN/MIC+" pad="46"/>
 <connect gate="G$1" pin="ANAOUT/MIC-" pad="45"/>

--- a/jrc.lbr
+++ b/jrc.lbr
@@ -76,7 +76,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2010, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SSOP-65P-440W-500L-120H-100F-14">
+<package name="SSOP-14-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
@@ -145,7 +145,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="NJM2752" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="CNT1" pad="5"/>
 <connect gate="G$1" pin="GND" pad="12"/>

--- a/lattice.lbr
+++ b/lattice.lbr
@@ -77,7 +77,7 @@
 http://www.lattice.com&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="PLCC-127P-2931W-2931L-457H-84">
+<package name="PLCC-84-127P-2931W-2931L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 29.31mm length, 29.31mm width, 4.57mm max height, 84 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 29.31mm body length, 29.31mm body width, 4.57mm max height, 84 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AF.&lt;/p&gt;
@@ -267,7 +267,7 @@ JEDEC MS-018A, variation AF.&lt;/p&gt;
 <wire x1="14.6558" y1="13.365" x2="14.6558" y2="14.6558" width="0.2032" layer="21"/>
 <wire x1="14.6558" y1="14.6558" x2="13.365" y2="14.6558" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1658W-1658L-457H-44">
+<package name="PLCC-44-127P-1658W-1658L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 16.59mm length, 16.59mm width, 4.57mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body width, 4.57mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AC.&lt;/p&gt;
@@ -643,7 +643,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <rectangle x1="-5.91" y1="6.98" x2="-5.69" y2="8" layer="51"/>
 <rectangle x1="-6.31" y1="6.98" x2="-6.09" y2="8" layer="51"/>
 </package>
-<package name="TQFP-80P-1000W-1000L-120H-44">
+<package name="TQFP-44-80P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
@@ -745,7 +745,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -959,7 +959,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-2000W-2000L-120H-144">
+<package name="TQFP-144-50P-2000W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
@@ -1914,7 +1914,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="IO" symbol="LSI2064" x="45.72" y="-2.54" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2931W-2931L-457H-84">
+<device name="" package="PLCC-84-127P-2931W-2931L-457H">
 <connects>
 <connect gate="C" pin="!ISPEN!" pad="23"/>
 <connect gate="C" pin="!RESET!" pad="24"/>
@@ -2039,7 +2039,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="NC19" symbol="NC" x="-22.86" y="-20.32" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="C" pin="!ISPEN!" pad="14"/>
 <connect gate="C" pin="!RESET!" pad="15"/>
@@ -2180,7 +2180,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="NC11" symbol="NC" x="81.28" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="E" pin="!BSCAN!" pad="14"/>
 <connect gate="E" pin="!RESET!" pad="15"/>
@@ -2321,7 +2321,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="NC17" symbol="NC" x="83.82" y="-15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="C" pin="!BSCAN!" pad="15"/>
 <connect gate="C" pin="!RESET!" pad="11"/>
@@ -2441,7 +2441,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="C" symbol="LSI2064C" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="C" pin="!BSCAN!" pad="7"/>
 <connect gate="C" pin="GOE0/IN3" pad="40"/>
@@ -2505,7 +2505,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G2" symbol="GND" x="10.16" y="-27.94" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="C" pin="!BSCAN!" pad="13"/>
 <connect gate="C" pin="IN0/TDI" pad="14"/>
@@ -2569,7 +2569,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="C" symbol="LSI2064C" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="C" pin="!BSCAN!" pad="13"/>
 <connect gate="C" pin="GOE0/IN3" pad="2"/>
@@ -2628,7 +2628,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="1016J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!ISPEN!" pad="13"/>
 <connect gate="G$1" pin="GND" pad="1"/>
@@ -2687,7 +2687,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="1016EJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!ISPEN!" pad="13"/>
 <connect gate="G$1" pin="GND" pad="1"/>
@@ -2893,7 +2893,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="E" symbol="ICE40HX4K-SPI" x="71.12" y="-58.42" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-2000W-2000L-120H-144">
+<device name="" package="TQFP-144-50P-2000W-2000L-120H">
 <connects>
 <connect gate="A" pin="GBIN0/PIO0_00" pad="129"/>
 <connect gate="A" pin="GBIN1/PIO0_01" pad="128"/>

--- a/linear-technology.lbr
+++ b/linear-technology.lbr
@@ -265,7 +265,7 @@ http://www.linear-tech.com&lt;p&gt;
 <rectangle x1="2.032" y1="1.905" x2="3.048" y2="2.286" layer="51"/>
 <rectangle x1="3.302" y1="-1.27" x2="4.318" y2="2.286" layer="51"/>
 </package>
-<package name="SSOP-50P-300W-300L-110H-95F-10">
+<package name="SSOP-10-50P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
@@ -436,7 +436,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <wire x1="1.45" y1="-0.65" x2="1.45" y2="0.65" width="0.2032" layer="21"/>
 <wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -510,7 +510,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <text x="-8.4" y="-3.6" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="9.2" y="-3.6" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 </package>
-<package name="SSOP-065-530-16">
+<package name="SSOP-16-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 16 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 16 leads. JEDEC MO-150B. Variation AC.</description>
 <circle x="-2.235" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -675,7 +675,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <wire x1="3.25" y1="-1.75" x2="-3.25" y2="-1.75" width="0.2032" layer="21"/>
 <wire x1="3.25" y1="1.75" x2="3.25" y2="-1.75" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -695,7 +695,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -721,7 +721,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -755,7 +755,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -801,7 +801,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -850,7 +850,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -3755,7 +3755,7 @@ with shutdown</description>
 <gate name="G$2" symbol="NC" x="35.56" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="5"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -3820,7 +3820,7 @@ with shutdown</description>
 <gate name="G$1" symbol="LT1016" x="0" y="0"/>
 </gates>
 <devices>
-<device name="CS8" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="CS8" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!OUT" pad="8"/>
 <connect gate="G$1" pin="+IN" pad="2"/>
@@ -3835,7 +3835,7 @@ with shutdown</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="CN" package="DIP-300-8">
+<device name="CN" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!OUT" pad="8"/>
 <connect gate="G$1" pin="+IN" pad="2"/>
@@ -3858,7 +3858,7 @@ with shutdown</description>
 <gate name="G$1" symbol="LTC1658" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!CSLD" pad="3"/>
 <connect gate="G$1" pin="CLK" pad="1"/>
@@ -3881,7 +3881,7 @@ with shutdown</description>
 <gate name="G$1" symbol="LTC1440" x="2.54" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="GND" pad="1"/>
 <connect gate="G$1" pin="HYST" pad="5"/>
@@ -3904,7 +3904,7 @@ with shutdown</description>
 <gate name="P" symbol="PWRN" x="20.32" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3967,7 +3967,7 @@ Linear Technology, Digikey part #: LT1716IS5-ND</description>
 <gate name="G$1" symbol="LT1512" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FB" pad="2"/>
 <connect gate="G$1" pin="GND1@2" pad="7"/>
@@ -4032,7 +4032,7 @@ Linear Technology, Digikey part #: LT1716IS5-ND</description>
 <gate name="G$1" symbol="LT1025" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="K" pad="7"/>
@@ -4052,7 +4052,7 @@ Switched Capacitor Regulated</description>
 <gate name="G$1" symbol="LTC1261L" x="0" y="0"/>
 </gates>
 <devices>
-<device name="CMS8" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="CMS8" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="5"/>
 <connect gate="G$1" pin="C1+" pad="2"/>
@@ -4067,7 +4067,7 @@ Switched Capacitor Regulated</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="CS8" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="CS8" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="5"/>
 <connect gate="G$1" pin="C1+" pad="2"/>
@@ -4090,7 +4090,7 @@ Switched Capacitor Regulated</description>
 <gate name="G$1" symbol="LT1637" x="0" y="0"/>
 </gates>
 <devices>
-<device name="CMS8" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="CMS8" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4105,7 +4105,7 @@ Switched Capacitor Regulated</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="CS8" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="CS8" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4160,7 +4160,7 @@ Switched Capacitor Regulated</description>
 <gate name="G$1" symbol="LT1910" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!FAULT!" pad="3"/>
 <connect gate="G$1" pin="GATE" pad="5"/>
@@ -4200,7 +4200,7 @@ Switched Capacitor Regulated</description>
 <gate name="G$1" symbol="ITC137P" x="-15.24" y="20.32"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="B" pad="14"/>
 <connect gate="G$1" pin="BRG" pad="11"/>
@@ -4229,7 +4229,7 @@ Switched Capacitor Regulated</description>
 <gate name="G$1" symbol="LT117X" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="E" pad="6"/>
 <connect gate="G$1" pin="FB" pad="3"/>
@@ -4375,7 +4375,7 @@ fixed output with shutdown control</description>
 <gate name="G$1" symbol="LTC1155" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="DS1" pad="1"/>
 <connect gate="G$1" pin="DS2" pad="8"/>
@@ -4397,7 +4397,7 @@ fixed output with shutdown control</description>
 <gate name="G$1" symbol="LTC1732" x="0" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-300W-300L-110H-95F-10">
+<device name="" package="SSOP-10-50P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!ACPR!" pad="10"/>
 <connect gate="G$1" pin="!CHRG!" pad="3"/>
@@ -4421,7 +4421,7 @@ fixed output with shutdown control</description>
 <gate name="G$1" symbol="LT1735" x="0" y="-22.86"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BG" pad="11"/>
 <connect gate="G$1" pin="BOOST" pad="15"/>
@@ -4451,7 +4451,7 @@ fixed output with shutdown control</description>
 <gate name="G$1" symbol="LTC1877" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="ITH" pad="2"/>
@@ -4499,7 +4499,7 @@ fixed output with shutdown control</description>
 <gate name="G$1" symbol="LT1620IS8" x="0" y="-10.16"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="AVG" pad="8"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -4581,7 +4581,7 @@ High-Voltage Synchronous Current Mode</description>
 <gate name="G$1" symbol="LT1676" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FB" pad="7"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -4740,7 +4740,7 @@ adjustable output with shutdown control</description>
 <gate name="G$1" symbol="LT1791" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="3"/>
 <connect gate="G$1" pin="A" pad="12"/>
@@ -4758,7 +4758,7 @@ adjustable output with shutdown control</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="S" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="3"/>
 <connect gate="G$1" pin="A" pad="12"/>
@@ -4787,7 +4787,7 @@ adjustable output with shutdown control</description>
 <gate name="P" symbol="PWR+-" x="7.62" y="-7.62"/>
 </gates>
 <devices>
-<device name="S8" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S8" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4811,7 +4811,7 @@ Digitally Controlled, 10kHz to 150kHz and 4-Bit P.G.A.</description>
 <gate name="G$1" symbol="LTC1564" x="20.32" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-16">
+<device name="" package="SSOP-16-65P-530W">
 <connects>
 <connect gate="G$1" pin="!EN!" pad="3"/>
 <connect gate="G$1" pin="!RST!" pad="13"/>
@@ -4911,7 +4911,7 @@ Series Reference Family</description>
 <gate name="G$1" symbol="LTC1966" x="0" y="0"/>
 </gates>
 <devices>
-<device name="MS8" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MS8" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!EN!" pad="8"/>
 <connect gate="G$1" pin="GND" pad="1"/>
@@ -5030,7 +5030,7 @@ Switched Capacitor Voltage Convertor</description>
 <gate name="G$1" symbol="LT1054" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S8" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S8" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CAP+" pad="2"/>
 <connect gate="G$1" pin="CAP-" pad="4"/>
@@ -5045,7 +5045,7 @@ Switched Capacitor Voltage Convertor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N8" package="DIP-300-8">
+<device name="N8" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CAP+" pad="2"/>
 <connect gate="G$1" pin="CAP-" pad="4"/>
@@ -5069,7 +5069,7 @@ Ultralow Power with Shutdown</description>
 <gate name="G$1" symbol="LTC1481" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N8" package="DIP-300-8">
+<device name="N8" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!RE" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -5084,7 +5084,7 @@ Ultralow Power with Shutdown</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S8" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S8" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -5264,7 +5264,7 @@ Power Tracking 2A for Solar Power</description>
 <gate name="G$1" symbol="LT1763" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="5"/>
 <connect gate="G$1" pin="BYP" pad="4"/>
@@ -5288,7 +5288,7 @@ Positive High Voltage Ideal Diode Controller</description>
 <gate name="G$1" symbol="LTC4357" x="0" y="0"/>
 </gates>
 <devices>
-<device name="MS8" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MS8" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="GATE" pad="4"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -5322,7 +5322,7 @@ Positive High Voltage Ideal Diode Controller</description>
 <gate name="G$1" symbol="LTC485" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S8" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S8" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -5337,7 +5337,7 @@ Positive High Voltage Ideal Diode Controller</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N8" package="DIP-300-8">
+<device name="N8" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!RE" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -5427,7 +5427,7 @@ Precision Zero Drift</description>
 <gate name="G$1" symbol="LTC6102" x="0" y="0"/>
 </gates>
 <devices>
-<device name="MS8" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MS8" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="-INF" pad="2"/>
@@ -5923,7 +5923,7 @@ with Power-Fail Output, Selectable Thresholds</description>
 <gate name="G$1" symbol="LT1762-ADJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="5"/>
 <connect gate="G$1" pin="ADJ" pad="2"/>
@@ -6053,7 +6053,7 @@ Adjustable1.1A Single Resistor Low Dropout Regulator</description>
 <gate name="G$1" symbol="LT1962" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!SHDN" pad="5"/>
 <connect gate="G$1" pin="BYP" pad="3"/>

--- a/linear.lbr
+++ b/linear.lbr
@@ -897,7 +897,7 @@ National Semiconductor</description>
 <text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-1.27" y="1.27" size="0.254" layer="250">NS Z03A</text>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -1110,7 +1110,7 @@ TS-003</description>
 <vertex x="2.5654" y="3.937"/>
 </polygon>
 </package>
-<package name="PLCC-127P-896W-896L-457H-20">
+<package name="PLCC-20-127P-896W-896L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 8.97mm length, 8.97mm width, 4.57mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 8.97mm body length, 8.97mm body width, 4.57mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AA.&lt;/p&gt;
@@ -1172,7 +1172,7 @@ JEDEC MS-018A, variation AA.&lt;/p&gt;
 <wire x1="4.4831" y1="3.205" x2="4.4831" y2="4.4831" width="0.2032" layer="21"/>
 <wire x1="4.4831" y1="4.4831" x2="3.205" y2="4.4831" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1150W-1150L-457H-28">
+<package name="PLCC-28-127P-1150W-1150L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 11.51mm length, 11.51mm width, 4.57mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 11.51mm body length, 11.51mm body width, 4.57mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AB.&lt;/p&gt;
@@ -1298,7 +1298,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <wire x1="1" y1="-0.625" x2="-1" y2="-0.625" width="0.2032" layer="51"/>
 <wire x1="1" y1="0.625" x2="1" y2="-0.625" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -1327,7 +1327,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <wire x1="1.4" y1="-1.4" x2="1.4" y2="1.4" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="1.4" x2="-1.4" y2="1.4" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-300L-120H-100F-8">
+<package name="SSOP-8-65P-440W-300L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -1356,7 +1356,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <wire x1="1.4" y1="-2.1" x2="1.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="2.1" x2="-1.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-14">
+<package name="SSOP-14-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
@@ -1436,7 +1436,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <vertex x="5.1054" y="7.267"/>
 </polygon>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -1456,7 +1456,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -1482,7 +1482,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -1510,7 +1510,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -1540,7 +1540,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -1593,7 +1593,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <text x="-6.985" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-4.7625" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -1629,7 +1629,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -1712,7 +1712,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <rectangle x1="3" y1="-10.995" x2="3.8" y2="-7.045" layer="21"/>
 <hole x="0" y="5.455" drill="3.175"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -1746,7 +1746,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -1792,7 +1792,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-900L-265H-140F-14">
+<package name="SOP-14-127P-750W-900L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads.&lt;/p&gt;
 
@@ -1837,7 +1837,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length,
 <wire x1="4.475" y1="-3.725" x2="-4.475" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="4.475" y1="3.725" x2="-4.475" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -1894,7 +1894,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -1959,7 +1959,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -2032,7 +2032,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1155L-265H-140F-18">
+<package name="SOP-18-127P-750W-1155L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
@@ -2085,7 +2085,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -4606,7 +4606,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2CMP" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4620,7 +4620,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4642,7 +4642,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL2CMP" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4657,7 +4657,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4680,7 +4680,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4695,7 +4695,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4718,7 +4718,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4733,7 +4733,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4756,7 +4756,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="OPAMP+-" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4768,7 +4768,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4790,7 +4790,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4805,7 +4805,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4832,7 +4832,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4853,7 +4853,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4886,7 +4886,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="17.78" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -4907,7 +4907,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -4940,7 +4940,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="17.78" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -4961,7 +4961,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -5004,7 +5004,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5018,7 +5018,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5040,7 +5040,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2CMP" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5054,7 +5054,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5113,7 +5113,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5136,7 +5136,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL2CMP" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="H" package="DIP-300-8">
+<device name="H" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5151,7 +5151,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5174,7 +5174,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL2CMP" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5190,7 +5190,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="UA"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5229,7 +5229,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5267,7 +5267,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5305,7 +5305,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5320,7 +5320,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5358,7 +5358,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5373,7 +5373,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5396,7 +5396,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL2CMP" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5411,7 +5411,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5449,7 +5449,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5487,7 +5487,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5525,7 +5525,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5567,7 +5567,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="E"/>
 </technologies>
 </device>
-<device name="R" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5582,7 +5582,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="C"/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5601,7 +5601,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="Z"/>
 </technologies>
 </device>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5643,7 +5643,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5658,7 +5658,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="Z" package="DIP-300-8">
+<device name="Z" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5681,7 +5681,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="Z" package="DIP-300-8">
+<device name="Z" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5696,7 +5696,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5734,7 +5734,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5749,7 +5749,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="Z" package="DIP-300-8">
+<device name="Z" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5772,7 +5772,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5787,7 +5787,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5810,7 +5810,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5825,7 +5825,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5848,7 +5848,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5863,7 +5863,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LM"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5901,7 +5901,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5939,7 +5939,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5962,7 +5962,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5978,7 +5978,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="UA"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6002,7 +6002,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6017,7 +6017,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6040,7 +6040,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6055,7 +6055,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6078,7 +6078,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6093,7 +6093,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6116,7 +6116,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6131,7 +6131,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6154,7 +6154,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6169,7 +6169,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6192,7 +6192,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6207,7 +6207,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6253,7 +6253,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6268,7 +6268,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6291,7 +6291,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6306,7 +6306,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6329,7 +6329,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6344,7 +6344,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6367,7 +6367,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6382,7 +6382,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6405,7 +6405,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6420,7 +6420,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6443,7 +6443,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6458,7 +6458,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6481,7 +6481,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="Z" package="DIP-300-8">
+<device name="Z" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6496,7 +6496,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6519,7 +6519,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6534,7 +6534,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6557,7 +6557,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6572,7 +6572,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6595,7 +6595,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6610,7 +6610,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6633,7 +6633,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6648,7 +6648,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6671,7 +6671,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6686,7 +6686,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6709,7 +6709,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6724,7 +6724,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6749,7 +6749,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6764,7 +6764,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6789,7 +6789,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6804,7 +6804,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6829,7 +6829,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6844,7 +6844,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6869,7 +6869,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6884,7 +6884,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6909,7 +6909,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6924,7 +6924,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6949,7 +6949,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6964,7 +6964,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6989,7 +6989,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7004,7 +7004,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7029,7 +7029,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7044,7 +7044,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7069,7 +7069,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7084,7 +7084,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7109,7 +7109,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7124,7 +7124,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7149,7 +7149,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7164,7 +7164,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7189,7 +7189,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7204,7 +7204,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7229,7 +7229,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7244,7 +7244,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LM"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7269,7 +7269,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7284,7 +7284,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7309,7 +7309,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7324,7 +7324,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7349,7 +7349,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7364,7 +7364,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7389,7 +7389,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7404,7 +7404,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7429,7 +7429,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7444,7 +7444,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7469,7 +7469,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7494,7 +7494,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7509,7 +7509,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7534,7 +7534,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7549,7 +7549,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7574,7 +7574,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7589,7 +7589,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7614,7 +7614,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7629,7 +7629,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7654,7 +7654,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7669,7 +7669,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7694,7 +7694,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7709,7 +7709,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7734,7 +7734,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7749,7 +7749,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LM"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7776,7 +7776,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="17.78" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -7797,7 +7797,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -7830,7 +7830,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR+-" x="17.78" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -7851,7 +7851,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -7886,7 +7886,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7907,7 +7907,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="DIP-300-16">
+<device name="S" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7928,7 +7928,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TC" package="PLCC-127P-1150W-1150L-457H-28">
+<device name="TC" package="PLCC-28-127P-1150W-1150L-457H">
 <connects>
 <connect gate="A" pin="+IN" pad="6"/>
 <connect gate="A" pin="-IN" pad="3"/>
@@ -7949,7 +7949,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7982,7 +7982,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8003,7 +8003,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8036,7 +8036,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8057,7 +8057,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8090,7 +8090,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8111,7 +8111,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8144,7 +8144,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8165,7 +8165,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8198,7 +8198,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8219,7 +8219,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8252,7 +8252,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8273,7 +8273,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8306,7 +8306,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8327,7 +8327,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8360,7 +8360,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8381,7 +8381,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8414,7 +8414,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8435,7 +8435,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8468,7 +8468,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8489,7 +8489,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8522,7 +8522,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8543,7 +8543,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8576,7 +8576,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8597,7 +8597,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8630,7 +8630,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -8651,7 +8651,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -8684,7 +8684,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8705,7 +8705,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8738,7 +8738,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8759,7 +8759,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8792,7 +8792,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8813,7 +8813,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8846,7 +8846,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8867,7 +8867,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8901,7 +8901,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <gate name="D" symbol="COMPARATOR-OC" x="43.18" y="-10.16" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -8922,7 +8922,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -8943,7 +8943,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -8976,7 +8976,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <gate name="P" symbol="PWR+-" x="17.78" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -8997,7 +8997,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -9030,7 +9030,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <gate name="P" symbol="PWR+-" x="17.78" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -9051,7 +9051,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -9084,7 +9084,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <gate name="P" symbol="PWR+-" x="17.78" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -9105,7 +9105,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -9207,7 +9207,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <gate name="A" symbol="555" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="CV" pad="5"/>
 <connect gate="A" pin="DIS" pad="7"/>
@@ -9225,7 +9225,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name="UA"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="CV" pad="5"/>
 <connect gate="A" pin="DIS" pad="7"/>
@@ -9469,7 +9469,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <gate name="P" symbol="PWR+G" x="5.08" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="1"/>
 <connect gate="A" pin="-IN" pad="6"/>
@@ -9490,7 +9490,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="1"/>
 <connect gate="A" pin="-IN" pad="6"/>
@@ -9636,7 +9636,7 @@ current output</description>
 <gate name="A" symbol="OPAMP+-" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -9648,7 +9648,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -9669,7 +9669,7 @@ current output</description>
 <gate name="B" symbol="556" x="27.94" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="CV" pad="3"/>
 <connect gate="A" pin="DIS" pad="1"/>
@@ -9692,7 +9692,7 @@ current output</description>
 <technology name="SE"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CV" pad="3"/>
 <connect gate="A" pin="DIS" pad="1"/>
@@ -9749,7 +9749,7 @@ current output</description>
 <gate name="A" symbol="567" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="CT" pad="6"/>
 <connect gate="A" pin="GND" pad="7"/>
@@ -9765,7 +9765,7 @@ current output</description>
 <technology name="NE"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="CT" pad="6"/>
 <connect gate="A" pin="GND" pad="7"/>
@@ -9864,7 +9864,7 @@ current output</description>
 <gate name="A" symbol="3524" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="+CL" pad="4"/>
 <connect gate="A" pin="+IN" pad="2"/>
@@ -9887,7 +9887,7 @@ current output</description>
 <technology name="LM"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="+CL" pad="4"/>
 <connect gate="A" pin="+IN" pad="2"/>
@@ -9922,7 +9922,7 @@ current output</description>
 <gate name="P" symbol="PWR+-GSS" x="22.86" y="30.48" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -9944,7 +9944,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -9978,7 +9978,7 @@ current output</description>
 <gate name="P" symbol="PWR+-GSS" x="22.86" y="30.48" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10000,7 +10000,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10034,7 +10034,7 @@ current output</description>
 <gate name="P" symbol="PWR+-GSS" x="22.86" y="30.48" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10056,7 +10056,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10091,7 +10091,7 @@ current output</description>
 <gate name="VL" symbol="VL_PIN" x="35.56" y="22.86" addlevel="must"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10114,7 +10114,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10150,7 +10150,7 @@ current output</description>
 <gate name="VL" symbol="VL_PIN" x="35.56" y="25.4" addlevel="must"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10173,7 +10173,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10209,7 +10209,7 @@ current output</description>
 <gate name="\WR" symbol="WR_PIN" x="35.56" y="25.4" addlevel="must"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10232,7 +10232,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10268,7 +10268,7 @@ current output</description>
 <gate name="VL" symbol="VL_PIN" x="35.56" y="25.4" addlevel="must"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10291,7 +10291,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10326,7 +10326,7 @@ current output</description>
 <gate name="P" symbol="PWR+-GSS" x="22.86" y="30.48" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10348,7 +10348,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10382,7 +10382,7 @@ current output</description>
 <gate name="P" symbol="PWR+-GSS" x="22.86" y="30.48" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10404,7 +10404,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10439,7 +10439,7 @@ current output</description>
 <gate name="VL" symbol="VL_PIN" x="35.56" y="25.4" addlevel="must"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10462,7 +10462,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10498,7 +10498,7 @@ current output</description>
 <gate name="\WR" symbol="WR_PIN" x="35.56" y="25.4" addlevel="must"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10521,7 +10521,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10557,7 +10557,7 @@ current output</description>
 <gate name="VL" symbol="VL_PIN" x="35.56" y="25.4" addlevel="must"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10580,7 +10580,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10614,7 +10614,7 @@ current output</description>
 <gate name="VL" symbol="VL_PIN" x="33.02" y="30.48" addlevel="must"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D1" pad="1"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -10635,7 +10635,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="1"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -10667,7 +10667,7 @@ current output</description>
 <gate name="VL" symbol="VL_PIN" x="33.02" y="30.48" addlevel="must"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D1" pad="1"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -10688,7 +10688,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="1"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -10719,7 +10719,7 @@ current output</description>
 <gate name="P" symbol="PWR+-GSS" x="20.32" y="17.78" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="9"/>
 <connect gate="A" pin="IN" pad="14"/>
@@ -10735,7 +10735,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="9"/>
 <connect gate="A" pin="IN" pad="14"/>
@@ -10762,7 +10762,7 @@ current output</description>
 <gate name="VL" symbol="VL_PIN" x="33.02" y="10.16" addlevel="must"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="9"/>
 <connect gate="A" pin="IN" pad="14"/>
@@ -10779,7 +10779,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="9"/>
 <connect gate="A" pin="IN" pad="14"/>
@@ -10809,7 +10809,7 @@ current output</description>
 <gate name="VL" symbol="VL_PIN" x="33.02" y="30.48" addlevel="must"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10832,7 +10832,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10865,7 +10865,7 @@ current output</description>
 <gate name="VL" symbol="VL_PIN" x="30.48" y="20.32" addlevel="must"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="1"/>
 <connect gate="A" pin="IN" pad="6"/>
@@ -10880,7 +10880,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="1"/>
 <connect gate="A" pin="IN" pad="6"/>
@@ -10903,7 +10903,7 @@ current output</description>
 <gate name="A" symbol="DG425" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!RS!" pad="7"/>
 <connect gate="A" pin="!WR!" pad="2"/>
@@ -10926,7 +10926,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!RS!" pad="7"/>
 <connect gate="A" pin="!WR!" pad="2"/>
@@ -10958,7 +10958,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="DG528" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="!RS!" pad="18"/>
 <connect gate="A" pin="!WR!" pad="1"/>
@@ -10996,7 +10996,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="VL" symbol="VL_PIN" x="35.56" y="22.86" addlevel="must"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="16"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -11019,7 +11019,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="16"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -11054,7 +11054,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="D" symbol="SD5000" x="58.42" y="-20.32" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="D" pad="1"/>
 <connect gate="A" pin="G" pad="3"/>
@@ -11074,7 +11074,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="1"/>
 <connect gate="A" pin="G" pad="3"/>
@@ -11102,7 +11102,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="NE5205" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="GND@1" pad="3"/>
 <connect gate="A" pin="GND@2" pad="4"/>
@@ -11117,7 +11117,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="3"/>
 <connect gate="A" pin="GND@2" pad="4"/>
@@ -11208,7 +11208,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="GND" pad="4"/>
 <connect gate="A" pin="OPT" pad="3"/>
@@ -11220,7 +11220,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="Z" package="DIP-300-8">
+<device name="Z" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="GND" pad="4"/>
 <connect gate="A" pin="OPT" pad="3"/>
@@ -11252,7 +11252,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="GND" pad="4"/>
 <connect gate="A" pin="OPT" pad="3"/>
@@ -11264,7 +11264,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="Z" package="DIP-300-8">
+<device name="Z" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="GND" pad="4"/>
 <connect gate="A" pin="OPT" pad="3"/>
@@ -11302,7 +11302,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="LM311" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="3"/>
@@ -11317,7 +11317,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="3"/>
@@ -11550,7 +11550,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWR+G" x="17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="1"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -11565,7 +11565,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="1"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -11590,7 +11590,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWR+G" x="17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="1"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -11605,7 +11605,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="1"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -11630,7 +11630,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWR+G" x="17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="M" package="DIP-300-8">
+<device name="M" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="7"/>
 <connect gate="A" pin="-IN" pad="8"/>
@@ -11645,7 +11645,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="7"/>
 <connect gate="A" pin="-IN" pad="8"/>
@@ -11670,7 +11670,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWR+G" x="5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="M" package="DIP-300-8">
+<device name="M" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="7"/>
 <connect gate="A" pin="-IN" pad="8"/>
@@ -11685,7 +11685,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="7"/>
 <connect gate="A" pin="-IN" pad="8"/>
@@ -11708,7 +11708,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="DAC08" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!IO!" pad="2"/>
 <connect gate="A" pin="+VR" pad="14"/>
@@ -11731,7 +11731,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!IO!" pad="2"/>
 <connect gate="A" pin="+VR" pad="14"/>
@@ -11762,7 +11762,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="78XX" x="20.32" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="GND" pad="3"/>
 <connect gate="A" pin="VI" pad="1"/>
@@ -11781,7 +11781,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="LM3914" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="ADJ" pad="8"/>
 <connect gate="A" pin="L1" pad="1"/>
@@ -11814,7 +11814,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="G$1" symbol="NE5534" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -11826,7 +11826,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -11846,7 +11846,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="NE5539" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="1"/>
 <connect gate="A" pin="-IN" pad="14"/>
@@ -11861,7 +11861,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="1"/>
 <connect gate="A" pin="-IN" pad="14"/>
@@ -11884,7 +11884,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="NE592N8" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="G1A" pad="7"/>
 <connect gate="A" pin="G1B" pad="2"/>
@@ -11899,7 +11899,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="G1A" pad="7"/>
 <connect gate="A" pin="G1B" pad="2"/>
@@ -11966,7 +11966,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="D" symbol="NPN-R" x="7.62" y="-10.16" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="Y" package="DIP-300-14">
+<device name="Y" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -11985,7 +11985,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -12046,7 +12046,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="GND" pad="4"/>
 <connect gate="A" pin="OPT" pad="3"/>
@@ -12058,7 +12058,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="Z" package="DIP-300-8">
+<device name="Z" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="GND" pad="4"/>
 <connect gate="A" pin="OPT" pad="3"/>
@@ -12078,7 +12078,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="MC1648" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="AGC" pad="5"/>
 <connect gate="A" pin="BS" pad="10"/>
@@ -12093,7 +12093,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="AGC" pad="5"/>
 <connect gate="A" pin="BS" pad="10"/>
@@ -12117,7 +12117,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="LM1871" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="5"/>
 <connect gate="A" pin="B" pad="6"/>
@@ -12151,7 +12151,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="LM1872" x="22.86" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="AGC" pad="16"/>
 <connect gate="A" pin="GND@1" pad="3"/>
@@ -12184,7 +12184,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="723" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -12203,7 +12203,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name="UA"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -12231,7 +12231,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="AGND" pad="8"/>
 <connect gate="A" pin="CLK" pad="4"/>
@@ -12267,7 +12267,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-28">
+<device name="N" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="25"/>
 <connect gate="A" pin="A1" pad="24"/>
@@ -12302,7 +12302,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="25"/>
 <connect gate="A" pin="A1" pad="24"/>
@@ -12345,7 +12345,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="DAC0800" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!IOUT!" pad="2"/>
 <connect gate="A" pin="+V" pad="13"/>
@@ -12368,7 +12368,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!IOUT!" pad="2"/>
 <connect gate="A" pin="+V" pad="13"/>
@@ -12400,7 +12400,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P1" symbol="DAC0808" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="P" pin="GND" pad="2"/>
 <connect gate="P" pin="VCC" pad="13"/>
@@ -12422,7 +12422,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="P" pin="GND" pad="2"/>
 <connect gate="P" pin="VCC" pad="13"/>
@@ -12453,7 +12453,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWRN" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="P" pin="GND" pad="10"/>
 <connect gate="P" pin="VCC" pad="20"/>
@@ -12503,7 +12503,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12526,7 +12526,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="Z" package="DIP-300-8">
+<device name="Z" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12541,7 +12541,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12564,7 +12564,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="A" symbol="2NUL" x="5.08" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12579,7 +12579,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12618,7 +12618,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name="2"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12657,7 +12657,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12682,7 +12682,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWR+-" x="7.62" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12697,7 +12697,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12737,7 +12737,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12760,7 +12760,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="G$1" symbol="DAC700" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="+VCC" pad="23"/>
 <connect gate="G$1" pin="-VCC" pad="19"/>
@@ -12792,7 +12792,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name="02"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+VCC" pad="23"/>
 <connect gate="G$1" pin="-VCC" pad="19"/>
@@ -12831,7 +12831,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="G$1" symbol="DAC701" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-600-24">
+<device name="N" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="+VCC" pad="23"/>
 <connect gate="G$1" pin="-VCC" pad="19"/>
@@ -12863,7 +12863,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name="3"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+VCC" pad="23"/>
 <connect gate="G$1" pin="-VCC" pad="19"/>
@@ -12985,7 +12985,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="G$1" symbol="AD524" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="2"/>
 <connect gate="G$1" pin="-IN" pad="1"/>
@@ -13008,7 +13008,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="2"/>
 <connect gate="G$1" pin="-IN" pad="1"/>
@@ -13063,7 +13063,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWR+-GR" x="0" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="S" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="A" pin="CTL" pad="2"/>
 <connect gate="A" pin="IN" pad="4"/>
@@ -13079,7 +13079,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="CTL" pad="2"/>
 <connect gate="A" pin="IN" pad="4"/>
@@ -13125,7 +13125,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="G$1" symbol="2NUL" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13140,7 +13140,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13163,7 +13163,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="G$1" symbol="2NUL" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13178,7 +13178,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13253,7 +13253,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="17" symbol="NC_PIN" x="38.1" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-896W-896L-457H-20">
+<device name="" package="PLCC-20-127P-896W-896L-457H">
 <connects>
 <connect gate="1" pin="NC" pad="1"/>
 <connect gate="11" pin="NC" pad="11"/>
@@ -13288,7 +13288,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="G$1" symbol="AD22050" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="+VS" pad="6"/>
@@ -13303,7 +13303,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="+VS" pad="6"/>
@@ -13328,7 +13328,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWR+-" x="0" y="12.7" addlevel="always"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13343,7 +13343,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13368,7 +13368,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWR+-" x="0" y="10.16" addlevel="always"/>
 </gates>
 <devices>
-<device name="HRU" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="HRU" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13383,7 +13383,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13410,7 +13410,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWR+-" x="-10.16" y="10.16" addlevel="always"/>
 </gates>
 <devices>
-<device name="GS" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="GS" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13431,7 +13431,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="GP" package="DIP-300-14">
+<device name="GP" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13452,7 +13452,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="HRU" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="HRU" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13534,7 +13534,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="G$1" symbol="LF198" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!SH!" pad="8"/>
 <connect gate="G$1" pin="CHOLD" pad="6"/>
@@ -13549,7 +13549,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!SH!" pad="8"/>
 <connect gate="G$1" pin="CHOLD" pad="6"/>
@@ -13597,7 +13597,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="NC5" symbol="NC" x="30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND@1" pad="2"/>
 <connect gate="G$1" pin="GND@2" pad="3"/>
@@ -13626,7 +13626,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="G$1" symbol="ADC08031" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="7"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13641,7 +13641,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="7"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13664,7 +13664,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="G$1" symbol="ADC08038" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="11"/>
 <connect gate="G$1" pin="CH0" pad="1"/>
@@ -13691,7 +13691,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="11"/>
 <connect gate="G$1" pin="CH0" pad="1"/>
@@ -13726,7 +13726,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="G$1" symbol="ADC08034" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="8"/>
 <connect gate="G$1" pin="CH0" pad="3"/>
@@ -13747,7 +13747,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="8"/>
 <connect gate="G$1" pin="CH0" pad="3"/>
@@ -13776,7 +13776,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="G$1" symbol="ADC08032" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CH0" pad="2"/>
 <connect gate="G$1" pin="CH1" pad="3"/>
@@ -13791,7 +13791,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CH0" pad="2"/>
 <connect gate="G$1" pin="CH1" pad="3"/>
@@ -13806,7 +13806,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-750W-900L-265H-140F-14">
+<device name="S" package="SOP-14-127P-750W-900L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CH0" pad="3"/>
 <connect gate="G$1" pin="CH1" pad="5"/>
@@ -13835,7 +13835,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="13" symbol="NC" x="-33.02" y="-15.24" addlevel="request" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="11" pin="NC" pad="11"/>
 <connect gate="13" pin="NC" pad="13"/>
@@ -13866,7 +13866,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="VCCVSS" x="27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="T" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="T" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="-(B-Y)" pad="3"/>
 <connect gate="G$1" pin="-(R-Y)" pad="1"/>
@@ -13897,7 +13897,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="-(B-Y)" pad="3"/>
 <connect gate="G$1" pin="-(R-Y)" pad="1"/>
@@ -13938,7 +13938,7 @@ Philips Semiconductors</description>
 <gate name="P" symbol="VDDVSS" x="22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="T" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="T" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="BK" pad="16"/>
 <connect gate="G$1" pin="CB" pad="17"/>
@@ -13973,7 +13973,7 @@ Philips Semiconductors</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="BK" pad="16"/>
 <connect gate="G$1" pin="CB" pad="17"/>
@@ -14016,7 +14016,7 @@ Philips Semiconductors</description>
 <gate name="G$1" symbol="MC34119" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CD" pad="1"/>
 <connect gate="G$1" pin="FC1" pad="3"/>
@@ -14031,7 +14031,7 @@ Philips Semiconductors</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CD" pad="1"/>
 <connect gate="G$1" pin="FC1" pad="3"/>
@@ -14046,7 +14046,7 @@ Philips Semiconductors</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DTB" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="DTB" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="CD" pad="1"/>
 <connect gate="G$1" pin="FC1" pad="3"/>
@@ -14073,7 +14073,7 @@ Philips Semiconductors</description>
 <gate name="P" symbol="PWR+-" x="17.78" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14094,7 +14094,7 @@ Philips Semiconductors</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14124,7 +14124,7 @@ with ±0.03% Typical Linearity (f = 10 Hz to 11 kHz)</description>
 <gate name="G$1" symbol="LM331" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="COMP" pad="7"/>
 <connect gate="G$1" pin="F-OUT" pad="3"/>
@@ -14215,7 +14215,7 @@ http://onsemi.com tl494-d.pdf</description>
 <gate name="G$1" symbol="TL494" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="+I1" pad="1"/>
 <connect gate="G$1" pin="+I2" pad="16"/>
@@ -14239,7 +14239,7 @@ http://onsemi.com tl494-d.pdf</description>
 <technology name="I"/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+I1" pad="1"/>
 <connect gate="G$1" pin="+I2" pad="16"/>
@@ -14271,7 +14271,7 @@ http://onsemi.com tl494-d.pdf</description>
 <gate name="G$1" symbol="UC38XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="COMP" pad="1"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -14294,7 +14294,7 @@ http://onsemi.com tl494-d.pdf</description>
 <gate name="G$1" symbol="IR4426" x="-2.54" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="INA" pad="2"/>
@@ -14339,7 +14339,7 @@ http://onsemi.com tl494-d.pdf</description>
 <gate name="G$1" symbol="BA6220" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
@@ -14363,7 +14363,7 @@ http://onsemi.com tl494-d.pdf</description>
 <gate name="G$1" symbol="LM3916" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-18">
+<device name="N" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="8"/>
 <connect gate="G$1" pin="L1" pad="1"/>
@@ -14398,7 +14398,7 @@ cm8870.pdf</description>
 <gate name="P" symbol="VDDVSS" x="-25.4" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-18">
+<device name="P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="EST" pad="16"/>
 <connect gate="A" pin="GS" pad="3"/>
@@ -14423,7 +14423,7 @@ cm8870.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="S" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="A" pin="EST" pad="16"/>
 <connect gate="A" pin="GS" pad="3"/>
@@ -14474,7 +14474,7 @@ Microchip</description>
 <gate name="P" symbol="VDDVSS" x="-17.78" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14489,7 +14489,7 @@ Microchip</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14504,7 +14504,7 @@ Microchip</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="ST" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="ST" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14532,7 +14532,7 @@ Microchip</description>
 <gate name="P" symbol="VDDVSS" x="-27.94" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14553,7 +14553,7 @@ Microchip</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="SN" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14574,7 +14574,7 @@ Microchip</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="ST" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="ST" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14622,7 +14622,7 @@ Microchip</description>
 <gate name="G$1" symbol="MIC4429" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="GND2" pad="5"/>
@@ -14668,7 +14668,7 @@ National Overture Series&lt;p&gt;High-Performance 68W Audio Power Amplifier w/Mu
 <gate name="G$1" symbol="LM386" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14683,7 +14683,7 @@ National Overture Series&lt;p&gt;High-Performance 68W Audio Power Amplifier w/Mu
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14698,7 +14698,7 @@ National Overture Series&lt;p&gt;High-Performance 68W Audio Power Amplifier w/Mu
 <technology name=""/>
 </technologies>
 </device>
-<device name="MM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14724,7 +14724,7 @@ dual with linearizing diodes and buffers</description>
 <gate name="P" symbol="PWR+-" x="-38.1" y="15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="M" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -14747,7 +14747,7 @@ dual with linearizing diodes and buffers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="DIP-300-16">
+<device name="D" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="14"/>
 <connect gate="A" pin="-IN" pad="13"/>
@@ -14778,7 +14778,7 @@ dual with linearizing diodes and buffers</description>
 <gate name="G$1" symbol="LMH6551" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="-IN" pad="1"/>
@@ -14792,7 +14792,7 @@ dual with linearizing diodes and buffers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="X" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="X" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="-IN" pad="1"/>
@@ -14815,7 +14815,7 @@ dual with linearizing diodes and buffers</description>
 <gate name="P" symbol="PWR+-" x="17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14827,7 +14827,7 @@ dual with linearizing diodes and buffers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14847,7 +14847,7 @@ dual with linearizing diodes and buffers</description>
 <gate name="G$1" symbol="OPAMP+-" x="0" y="0" addlevel="must"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14859,7 +14859,7 @@ dual with linearizing diodes and buffers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14879,7 +14879,7 @@ dual with linearizing diodes and buffers</description>
 <gate name="G$1" symbol="TLE2426" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COM" pad="2"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -14917,7 +14917,7 @@ dual with linearizing diodes and buffers</description>
 <gate name="G$1" symbol="IRS2011" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COM" pad="7"/>
 <connect gate="G$1" pin="HIN" pad="5"/>
@@ -14940,7 +14940,7 @@ dual with linearizing diodes and buffers</description>
 <gate name="G$1" symbol="NE5534_C" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14954,7 +14954,7 @@ dual with linearizing diodes and buffers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14976,7 +14976,7 @@ dual with linearizing diodes and buffers</description>
 <gate name="G$1" symbol="NE5534_CB" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14991,7 +14991,7 @@ dual with linearizing diodes and buffers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>

--- a/luminary-arm.lbr
+++ b/luminary-arm.lbr
@@ -83,7 +83,7 @@ THIS LIBRARY IS PROVIDED AS IS WITHOUT WARRANTY OF ANY KIND, EXPRESSED OR IMPLIE
 &lt;author&gt;Copyright (C) 2012, Bob Starr&lt;br&gt;
 http://www.bobstarr.net&lt;/author&gt;</description>
 <packages>
-<package name="LQFP-50P-700W-700L-160H-48">
+<package name="LQFP-48-50P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
@@ -249,7 +249,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <text x="-5.715" y="3.175" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-5.715" y="-3.81" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="LQFP-50P-1400W-1400L-160H-100">
+<package name="LQFP-100-50P-1400W-1400L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BED, L-PQFP-G.
@@ -463,7 +463,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -2729,7 +2729,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S628" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="ADC0" pad="1"/>
@@ -2792,7 +2792,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S102" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="32KHZ/PB1" pad="20"/>
@@ -2835,7 +2835,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S310" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="C0O/PD7" pad="48"/>
@@ -2898,7 +2898,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S315" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="ADC0" pad="1"/>
@@ -2961,7 +2961,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S316" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="ADC0" pad="1"/>
@@ -3024,7 +3024,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S328" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="ADC0" pad="1"/>
@@ -3087,7 +3087,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S601" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="C0O/PC5" pad="13"/>
@@ -3150,7 +3150,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S613" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="ADC0" pad="1"/>
@@ -3213,7 +3213,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S610" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="ADC0" pad="1"/>
@@ -3276,7 +3276,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S615" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="ADC0" pad="1"/>
@@ -3339,7 +3339,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S801" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="C0O/PC5" pad="13"/>
@@ -3402,7 +3402,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S811" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="ADC0" pad="1"/>
@@ -3465,7 +3465,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S812" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="ADC0" pad="1"/>
@@ -3528,7 +3528,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S815" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="ADC0" pad="1"/>
@@ -3591,7 +3591,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S828" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="ADC0" pad="1"/>
@@ -3654,7 +3654,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S101" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="32KHZ/PB1" pad="20"/>
@@ -3722,7 +3722,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S301" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="ADC0" pad="1"/>
@@ -3785,7 +3785,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S8962" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!HIB!" pad="51"/>
 <connect gate="G$1" pin="!RST!" pad="64"/>
@@ -3900,7 +3900,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S6918" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!HIB!" pad="51"/>
 <connect gate="G$1" pin="!RST!" pad="64"/>
@@ -4015,7 +4015,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S6911" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!HIB!" pad="51"/>
 <connect gate="G$1" pin="!RST!" pad="64"/>
@@ -4130,7 +4130,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S6938" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!HIB!" pad="51"/>
 <connect gate="G$1" pin="!RST!" pad="64"/>
@@ -4245,7 +4245,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S6950" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!HIB!" pad="51"/>
 <connect gate="G$1" pin="!RST!" pad="64"/>
@@ -4360,7 +4360,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S6952" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!HIB!" pad="51"/>
 <connect gate="G$1" pin="!RST!" pad="64"/>
@@ -4475,7 +4475,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S6965" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!HIB!" pad="51"/>
 <connect gate="G$1" pin="!RST!" pad="64"/>
@@ -4625,7 +4625,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S9B90" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!HIB!" pad="51"/>
 <connect gate="G$1" pin="!RST!" pad="64"/>
@@ -4740,7 +4740,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S9997" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!HIB!" pad="51"/>
 <connect gate="G$1" pin="!RST!" pad="64"/>
@@ -4855,7 +4855,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S6432" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="64"/>
 <connect gate="G$1" pin="ADC0" pad="1"/>

--- a/maxim.lbr
+++ b/maxim.lbr
@@ -93,7 +93,7 @@
 <text x="-2.54" y="3.175" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2.54" y="-4.572" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="PLCC-127P-1658W-1658L-457H-44">
+<package name="PLCC-44-127P-1658W-1658L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 16.59mm length, 16.59mm width, 4.57mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body width, 4.57mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AC.&lt;/p&gt;
@@ -233,7 +233,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <text x="-2.54" y="3.175" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2.032" y="-4.572" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -298,7 +298,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="PLCC-127P-1150W-1150L-457H-28">
+<package name="PLCC-28-127P-1150W-1150L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 11.51mm length, 11.51mm width, 4.57mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 11.51mm body length, 11.51mm body width, 4.57mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AB.&lt;/p&gt;
@@ -416,7 +416,7 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <wire x1="2.095" y1="-1.631" x2="2.4247" y2="-1.0918" width="0.2032" layer="21" curve="13.609443" cap="flat"/>
 <wire x1="2.413" y1="-1.1359" x2="2.413" y2="1.1359" width="0.2032" layer="51" curve="50.416655" cap="flat"/>
 </package>
-<package name="SSOP-065-530-20">
+<package name="SSOP-20-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 20 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JEDEC MO-150B. Variation AE.</description>
 <circle x="-2.885" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -648,7 +648,7 @@ body 5 x 5 mm, pitch 0.8 mm</description>
 <rectangle x1="0.1" y1="-0.6" x2="0.6" y2="-0.1" layer="31"/>
 <rectangle x1="-0.6" y1="-0.6" x2="-0.1" y2="-0.1" layer="31"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -880,7 +880,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <rectangle x1="-0.8" y1="-1.2" x2="-0.5" y2="-0.7" layer="51"/>
 <rectangle x1="0.2" y1="-1.2" x2="0.8" y2="-0.7" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-970L-120H-100F-28">
+<package name="SSOP-28-65P-440W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 4.4mm width, 1.20mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 4.4mm width, 1.20mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
@@ -971,7 +971,7 @@ Thin shrink small outline transistor package (also known as SOT323). 0.65mm pitc
 <wire x1="1" y1="0.425" x2="1" y2="-0.425" width="0.2032" layer="21"/>
 <wire x1="1" y1="0.625" x2="1" y2="0.425" width="0.2032" layer="51"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -1018,7 +1018,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <wire x1="3.25" y1="-1.75" x2="-3.25" y2="-1.75" width="0.2032" layer="21"/>
 <wire x1="3.25" y1="1.75" x2="3.25" y2="-1.75" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -1048,7 +1048,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -1080,7 +1080,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-32">
+<package name="DIP-32-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="20.32" y1="5.715" x2="-20.32" y2="5.715" width="0.2032" layer="21"/>
@@ -1124,7 +1124,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-20.955" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-17.145" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -1176,7 +1176,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -1212,7 +1212,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -1252,7 +1252,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -1288,7 +1288,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="TQFP-50P-500W-500L-120H-32">
+<package name="TQFP-32-50P-500W-500L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.20mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AAA, T-PQFP-G.
@@ -1366,7 +1366,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm 
 <wire x1="2.4" y1="-2.4" x2="2.4" y2="2.4" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -1415,7 +1415,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -1472,7 +1472,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1155L-265H-140F-18">
+<package name="SOP-18-127P-750W-1155L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
@@ -1525,7 +1525,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -1598,7 +1598,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-065-530-16">
+<package name="SSOP-16-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 16 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 16 leads. JEDEC MO-150B. Variation AC.</description>
 <circle x="-2.235" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -1671,7 +1671,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 16 leads. JED
 <rectangle x1="-0.627" y1="1.6256" x2="-0.373" y2="2.5654" layer="51"/>
 <rectangle x1="-1.127" y1="1.6256" x2="-0.873" y2="2.5654" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-780L-120H-100F-24">
+<package name="SSOP-24-65P-440W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
@@ -1872,7 +1872,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <rectangle x1="-2.3725" y1="1.8" x2="-2.0725" y2="3.1" layer="51"/>
 <rectangle x1="-3.0075" y1="1.8" x2="-2.7075" y2="3.1" layer="51"/>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -1918,7 +1918,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -1968,7 +1968,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-16">
+<package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -2013,7 +2013,7 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-650L-120H-100F-20">
+<package name="SSOP-20-65P-440W-650L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
@@ -2066,7 +2066,7 @@ JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.15" y1="-2.1" x2="3.15" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.1" x2="-3.15" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -2100,7 +2100,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -2120,7 +2120,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -2146,7 +2146,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -2329,7 +2329,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <wire x1="1.45" y1="-0.65" x2="1.45" y2="0.65" width="0.2032" layer="21"/>
 <wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
 </package>
-<package name="SSOP-50P-440W-970L-120H-100F-38">
+<package name="SSOP-38-50P-440W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 9.7mm length, 4.4mm width, 1.20mm max height, 38 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 9.7mm length, 4.4mm width, 1.20mm max height, 38 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation BD-1, R-PDSO-G.&lt;/p&gt;
@@ -2640,7 +2640,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <wire x1="1.45" y1="-0.65" x2="1.45" y2="0.65" width="0.2032" layer="21"/>
 <wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
 </package>
-<package name="SSOP-065-530-28">
+<package name="SSOP-28-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 28 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JEDEC MO-150B. Variation AH.</description>
 <circle x="-4.185" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -13531,7 +13531,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX130" x="0" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A/Z" pad="29"/>
 <connect gate="G$1" pin="A1" pad="5"/>
@@ -13586,7 +13586,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX133" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="1,11M" pad="17"/>
 <connect gate="G$1" pin="101K" pad="18"/>
@@ -13641,7 +13641,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX136" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A/Z" pad="29"/>
 <connect gate="G$1" pin="A1" pad="5"/>
@@ -13696,7 +13696,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX138" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A/Z" pad="29"/>
 <connect gate="G$1" pin="A1" pad="5"/>
@@ -13751,7 +13751,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX150" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="CS" pad="13"/>
 <connect gate="G$1" pin="DB0" pad="2"/>
@@ -13786,7 +13786,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX154" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="22"/>
 <connect gate="G$1" pin="A1" pad="21"/>
@@ -13825,7 +13825,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX158" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="25"/>
 <connect gate="G$1" pin="A1" pad="24"/>
@@ -13868,7 +13868,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX160" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="5"/>
 <connect gate="G$1" pin="AIN" pad="4"/>
@@ -13901,7 +13901,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX161" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="18"/>
@@ -13944,7 +13944,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX162" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="3"/>
 <connect gate="G$1" pin="AIN" pad="1"/>
@@ -13983,7 +13983,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX578" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="10V-IN" pad="27"/>
 <connect gate="G$1" pin="20V-IN" pad="28"/>
@@ -14030,7 +14030,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ADC0820" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="CS" pad="13"/>
 <connect gate="G$1" pin="DB0" pad="2"/>
@@ -14065,7 +14065,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7106" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A/Z" pad="29"/>
 <connect gate="G$1" pin="A1" pad="5"/>
@@ -14120,7 +14120,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7109" x="0" y="10.16"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AZ" pad="31"/>
 <connect gate="G$1" pin="B1" pad="16"/>
@@ -14175,7 +14175,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7116" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A/Z" pad="29"/>
 <connect gate="G$1" pin="A1" pad="5"/>
@@ -14230,7 +14230,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7135" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ANA-COM" pad="3"/>
 <connect gate="G$1" pin="AZ-IN" pad="5"/>
@@ -14273,7 +14273,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX565A" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="10V-SPAN" pad="10"/>
 <connect gate="G$1" pin="20V-SPAN" pad="11"/>
@@ -14312,7 +14312,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX7224" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="4"/>
 <connect gate="G$1" pin="CS" pad="14"/>
@@ -14345,7 +14345,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX7225" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="19"/>
 <connect gate="G$1" pin="A1" pad="18"/>
@@ -14384,7 +14384,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX7520" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="BIT1" pad="4"/>
 <connect gate="G$1" pin="BIT10" pad="13"/>
@@ -14415,7 +14415,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX7523" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="BIT1" pad="4"/>
 <connect gate="G$1" pin="BIT2" pad="5"/>
@@ -14446,7 +14446,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX7524" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CS" pad="12"/>
 <connect gate="G$1" pin="DB0" pad="11"/>
@@ -14477,7 +14477,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX7528" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="1"/>
 <connect gate="G$1" pin="CS" pad="15"/>
@@ -14512,7 +14512,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX7530" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="BIT1" pad="4"/>
 <connect gate="G$1" pin="BIT10" pad="13"/>
@@ -14543,7 +14543,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX7531" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="BIT1" pad="4"/>
 <connect gate="G$1" pin="BIT10" pad="13"/>
@@ -14576,7 +14576,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX7542" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="10"/>
 <connect gate="G$1" pin="A1" pad="11"/>
@@ -14607,7 +14607,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX7543" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="3"/>
 <connect gate="G$1" pin="CLR" pad="13"/>
@@ -14638,7 +14638,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX7545" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="2"/>
 <connect gate="G$1" pin="CS" pad="16"/>
@@ -14673,7 +14673,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX670" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+15V" pad="11"/>
 <connect gate="G$1" pin="FADJ" pad="12"/>
@@ -14702,7 +14702,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX672" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="NC" pad="1"/>
@@ -14725,7 +14725,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX580CS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+2,5V" pad="1"/>
 <connect gate="G$1" pin="+VS" pad="8"/>
@@ -14766,7 +14766,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX584N" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+VS" pad="8"/>
 <connect gate="G$1" pin="10,0V" pad="1"/>
@@ -14789,7 +14789,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX2700" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+15V" pad="11"/>
 <connect gate="G$1" pin="10V-OUT" pad="13"/>
@@ -14818,7 +14818,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX2701" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="-10V-OUT" pad="13"/>
 <connect gate="G$1" pin="-15V" pad="11"/>
@@ -14847,7 +14847,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="REF01" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="NC" pad="1"/>
@@ -14870,7 +14870,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="REF02" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="NC" pad="1"/>
@@ -14893,7 +14893,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX536A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+VS" pad="14"/>
 <connect gate="G$1" pin="-VS" pad="3"/>
@@ -14922,7 +14922,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX400" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14945,7 +14945,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX420" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14968,7 +14968,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX421" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="CEXTA" pad="2"/>
 <connect gate="G$1" pin="CEXTB" pad="1"/>
@@ -14997,7 +14997,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="OPAMP2NC" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -15020,7 +15020,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX450" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="1"/>
 <connect gate="G$1" pin="-IN" pad="14"/>
@@ -15049,7 +15049,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="OPAMP2NC" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="5"/>
 <connect gate="G$1" pin="-IN" pad="7"/>
@@ -15072,7 +15072,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX453" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="-IN" pad="7"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -15095,7 +15095,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX454" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="-IN" pad="13"/>
 <connect gate="G$1" pin="A0" pad="2"/>
@@ -15124,7 +15124,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX454" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="-IN" pad="13"/>
 <connect gate="G$1" pin="A0" pad="2"/>
@@ -15153,7 +15153,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX455" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="-IN" pad="19"/>
 <connect gate="G$1" pin="A0" pad="3"/>
@@ -15188,7 +15188,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="OP2OFF+-" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -15212,7 +15212,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="B" symbol="OPAMP" x="2.54" y="-20.32"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -15237,7 +15237,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="B" symbol="OPOFF" x="2.54" y="-22.86"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -15266,7 +15266,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7650" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -15289,7 +15289,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7650/" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="5"/>
 <connect gate="G$1" pin="-IN" pad="4"/>
@@ -15318,7 +15318,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX600" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="AC1" pad="7"/>
 <connect gate="G$1" pin="AC2" pad="1"/>
@@ -15341,7 +15341,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX601" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="AC1" pad="7"/>
 <connect gate="G$1" pin="NC" pad="1"/>
@@ -15364,7 +15364,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX630" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+VS" pad="5"/>
 <connect gate="G$1" pin="CX" pad="2"/>
@@ -15387,7 +15387,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX630" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+VS" pad="5"/>
 <connect gate="G$1" pin="CX" pad="2"/>
@@ -15410,7 +15410,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX631" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="COMP" pad="8"/>
 <connect gate="G$1" pin="CP" pad="6"/>
@@ -15433,7 +15433,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX634" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+VS" pad="6"/>
 <connect gate="G$1" pin="CX" pad="3"/>
@@ -15456,7 +15456,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX634" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+VS" pad="6"/>
 <connect gate="G$1" pin="CX" pad="3"/>
@@ -15479,7 +15479,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX635" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+VS" pad="6"/>
 <connect gate="G$1" pin="-VOUT" pad="1"/>
@@ -15502,7 +15502,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX635" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+VS" pad="6"/>
 <connect gate="G$1" pin="-VOUT" pad="1"/>
@@ -15525,7 +15525,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX638" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+VS" pad="6"/>
 <connect gate="G$1" pin="COMP" pad="8"/>
@@ -15548,7 +15548,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX638" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+VS" pad="6"/>
 <connect gate="G$1" pin="COMP" pad="8"/>
@@ -15571,7 +15571,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX641" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="COMP" pad="8"/>
 <connect gate="G$1" pin="EXT" pad="6"/>
@@ -15594,7 +15594,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX641" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COMP" pad="8"/>
 <connect gate="G$1" pin="EXT" pad="6"/>
@@ -15617,7 +15617,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX663" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SENSE" pad="1"/>
@@ -15640,7 +15640,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX663" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SENSE" pad="1"/>
@@ -15663,7 +15663,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX664" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="8"/>
 <connect gate="G$1" pin="SENSE" pad="2"/>
@@ -15686,7 +15686,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX664" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="8"/>
 <connect gate="G$1" pin="SENSE" pad="2"/>
@@ -15709,7 +15709,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX666" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="LBI" pad="3"/>
@@ -15732,7 +15732,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX666" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="LBI" pad="3"/>
@@ -15756,7 +15756,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="7"/>
 <connect gate="G$1" pin="C1-" pad="1"/>
@@ -15780,7 +15780,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="7"/>
 <connect gate="G$1" pin="C1-" pad="1"/>
@@ -15804,7 +15804,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="22.86" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="PFI" pad="4"/>
 <connect gate="G$1" pin="PFO" pad="5"/>
@@ -15828,7 +15828,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="27.94" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="BATT-ON" pad="5"/>
 <connect gate="G$1" pin="CE-IN" pad="13"/>
@@ -15860,7 +15860,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="22.86" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="BATT-ON" pad="5"/>
 <connect gate="G$1" pin="LLIN" pad="13"/>
@@ -15892,7 +15892,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="25.4" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CE-IN" pad="13"/>
 <connect gate="G$1" pin="CE-OUT" pad="12"/>
@@ -15923,7 +15923,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX8211" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="5"/>
 <connect gate="G$1" pin="HYSTER" pad="2"/>
@@ -15946,7 +15946,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX8211" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="5"/>
 <connect gate="G$1" pin="HYSTER" pad="2"/>
@@ -15969,7 +15969,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7660" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CAP+" pad="2"/>
 <connect gate="G$1" pin="CAP-" pad="4"/>
@@ -15992,7 +15992,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7660" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CAP+" pad="2"/>
 <connect gate="G$1" pin="CAP-" pad="4"/>
@@ -16015,7 +16015,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7663" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="OUT1" pad="3"/>
@@ -16038,7 +16038,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7663" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="OUT1" pad="3"/>
@@ -16061,7 +16061,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7664" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="8"/>
 <connect gate="G$1" pin="OUT1" pad="7"/>
@@ -16084,7 +16084,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7664" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="8"/>
 <connect gate="G$1" pin="OUT1" pad="7"/>
@@ -16107,7 +16107,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7665" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="HYST1" pad="2"/>
@@ -16130,7 +16130,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7665" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="HYST1" pad="2"/>
@@ -16153,7 +16153,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX7231" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="1X" pad="8"/>
 <connect gate="G$1" pin="1Y" pad="7"/>
@@ -16208,7 +16208,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX7232" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="10X" pad="35"/>
 <connect gate="G$1" pin="10Y" pad="34"/>
@@ -16263,7 +16263,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX7233" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="1U" pad="11"/>
 <connect gate="G$1" pin="1V" pad="10"/>
@@ -16318,7 +16318,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX7234" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="1U" pad="11"/>
 <connect gate="G$1" pin="1V" pad="10"/>
@@ -16373,7 +16373,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7211" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A1" pad="37"/>
 <connect gate="G$1" pin="A2" pad="6"/>
@@ -16428,7 +16428,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7211M" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A1" pad="37"/>
 <connect gate="G$1" pin="A2" pad="6"/>
@@ -16483,7 +16483,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7212M" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A1" pad="37"/>
 <connect gate="G$1" pin="A2" pad="6"/>
@@ -16538,7 +16538,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7217A" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="BCD1S" pad="7"/>
 <connect gate="G$1" pin="BCD2S" pad="6"/>
@@ -16581,7 +16581,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7217A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="BCD1S" pad="7"/>
 <connect gate="G$1" pin="BCD2S" pad="6"/>
@@ -16624,7 +16624,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7218A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="DIG-1" pad="15"/>
 <connect gate="G$1" pin="DIG-2" pad="16"/>
@@ -16667,7 +16667,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7218A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="DIG-1" pad="4"/>
 <connect gate="G$1" pin="DIG-2" pad="25"/>
@@ -16710,7 +16710,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7218C" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="DA0" pad="5"/>
 <connect gate="G$1" pin="DA1" pad="6"/>
@@ -16753,7 +16753,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7218D" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="DA0" pad="5"/>
 <connect gate="G$1" pin="DA1" pad="6"/>
@@ -16796,7 +16796,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7224" x="2.54" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="(BRT)BP" pad="5"/>
 <connect gate="G$1" pin="1/2-DIG" pad="27"/>
@@ -16852,7 +16852,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="33.02" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A1" pad="37"/>
 <connect gate="G$1" pin="A2" pad="6"/>
@@ -16907,7 +16907,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7242" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="128/256" pad="3"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -16930,7 +16930,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7240" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="128" pad="8"/>
@@ -16961,7 +16961,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7556" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="CV1" pad="3"/>
 <connect gate="G$1" pin="CV2" pad="11"/>
@@ -16990,7 +16990,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7555" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CV" pad="5"/>
 <connect gate="G$1" pin="DISCH" pad="7"/>
@@ -17013,7 +17013,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7126" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A/Z" pad="29"/>
 <connect gate="G$1" pin="A1" pad="5"/>
@@ -17068,7 +17068,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7129" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AGD1" pad="5"/>
 <connect gate="G$1" pin="AGD2" pad="8"/>
@@ -17123,7 +17123,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX260" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="15"/>
 <connect gate="G$1" pin="A1" pad="13"/>
@@ -17162,7 +17162,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX261" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="14"/>
 <connect gate="G$1" pin="A1" pad="13"/>
@@ -17201,7 +17201,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX263" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="BPA" pad="3"/>
 <connect gate="G$1" pin="BPB" pad="27"/>
@@ -17244,7 +17244,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX267" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="BPA" pad="2"/>
 <connect gate="G$1" pin="BPB" pad="24"/>
@@ -17283,7 +17283,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MF10" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="50/100/C" pad="12"/>
 <connect gate="G$1" pin="AGND" pad="15"/>
@@ -17318,7 +17318,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX310" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="13"/>
 <connect gate="G$1" pin="A1" pad="14"/>
@@ -17349,7 +17349,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX311" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="13"/>
 <connect gate="G$1" pin="A1" pad="14"/>
@@ -17380,7 +17380,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX358" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -17411,7 +17411,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX359" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -17442,7 +17442,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG506A" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -17485,7 +17485,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG507AC" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -17528,7 +17528,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG508A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -17559,7 +17559,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG509A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -17590,7 +17590,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG201" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="2"/>
 <connect gate="G$1" pin="D2" pad="15"/>
@@ -17621,7 +17621,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX333" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="COM1" pad="3"/>
 <connect gate="G$1" pin="COM2" pad="8"/>
@@ -17656,7 +17656,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX341" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A1" pad="15"/>
 <connect gate="G$1" pin="A2" pad="10"/>
@@ -17687,7 +17687,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX343" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A1" pad="15"/>
 <connect gate="G$1" pin="A2" pad="10"/>
@@ -17718,7 +17718,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG200" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="9"/>
 <connect gate="G$1" pin="D2" pad="6"/>
@@ -17748,7 +17748,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="25.4" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -17771,7 +17771,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -17794,7 +17794,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -17817,7 +17817,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -17849,7 +17849,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="25.4" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="2"/>
 <connect gate="G$1" pin="C1-" pad="4"/>
@@ -17883,7 +17883,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="8"/>
 <connect gate="G$1" pin="C1-" pad="10"/>
@@ -17919,7 +17919,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="C+" pad="1"/>
 <connect gate="G$1" pin="C-" pad="2"/>
@@ -17949,7 +17949,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="PWR2GND" x="30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="8"/>
 <connect gate="G$1" pin="C1-" pad="13"/>
@@ -17985,7 +17985,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="27.94" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="7"/>
 <connect gate="G$1" pin="C1-" pad="9"/>
@@ -18017,7 +18017,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="25.4" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="EN" pad="20"/>
 <connect gate="G$1" pin="R1IN" pad="10"/>
@@ -18057,7 +18057,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="27.94" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="10"/>
 <connect gate="G$1" pin="C1-" pad="12"/>
@@ -18097,7 +18097,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="27.94" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="10"/>
 <connect gate="G$1" pin="C1-" pad="12"/>
@@ -18137,7 +18137,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="25.4" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="10"/>
 <connect gate="G$1" pin="C1-" pad="12"/>
@@ -18177,7 +18177,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX239" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="C+" pad="6"/>
 <connect gate="G$1" pin="C-" pad="7"/>
@@ -18217,7 +18217,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="25.4" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -18249,7 +18249,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="33.02" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="C1+" pad="21"/>
 <connect gate="G$1" pin="C1-" pad="23"/>
@@ -18309,7 +18309,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="30.48" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ENR" pad="1"/>
 <connect gate="G$1" pin="ENT" pad="39"/>
@@ -18365,7 +18365,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="30.48" y="-15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ENRA" pad="11"/>
 <connect gate="G$1" pin="ENRB" pad="30"/>
@@ -18421,7 +18421,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="33.02" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ENA" pad="1"/>
 <connect gate="G$1" pin="ENB" pad="39"/>
@@ -18477,7 +18477,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="30.48" y="-22.86" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="C1+" pad="21"/>
 <connect gate="G$1" pin="C1-" pad="23"/>
@@ -18537,7 +18537,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="30.48" y="-22.86" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="C1+" pad="21"/>
 <connect gate="G$1" pin="C1-" pad="23"/>
@@ -18596,7 +18596,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX910" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="CMP_GND" pad="18"/>
 <connect gate="G$1" pin="CMP_OUT" pad="17"/>
@@ -18636,7 +18636,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="CE" pad="8"/>
 <connect gate="G$1" pin="D1" pad="23"/>
@@ -18668,7 +18668,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX639" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="LBI" pad="3"/>
@@ -18691,7 +18691,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX665" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CAP+" pad="2"/>
 <connect gate="G$1" pin="CAP-" pad="4"/>
@@ -18715,7 +18715,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="PWR+-" x="27.94" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="1"/>
 <connect gate="G$1" pin="GND" pad="6"/>
@@ -18738,7 +18738,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="OPAMP1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -18784,7 +18784,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="OPAMP2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -18804,7 +18804,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICM7212" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A1" pad="37"/>
 <connect gate="G$1" pin="A2" pad="6"/>
@@ -18859,7 +18859,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX358" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -18890,7 +18890,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX359" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -18921,7 +18921,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX7219" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="13"/>
 <connect gate="G$1" pin="DIG0" pad="2"/>
@@ -18960,7 +18960,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX260" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="15"/>
 <connect gate="G$1" pin="A1" pad="13"/>
@@ -18999,7 +18999,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX261" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="14"/>
 <connect gate="G$1" pin="A1" pad="13"/>
@@ -19039,7 +19039,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="22.86" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="PFI" pad="4"/>
 <connect gate="G$1" pin="PFO" pad="5"/>
@@ -19063,7 +19063,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="27.94" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BATT-ON" pad="5"/>
 <connect gate="G$1" pin="CE-IN" pad="13"/>
@@ -19094,7 +19094,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG201" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="2"/>
 <connect gate="G$1" pin="D2" pad="15"/>
@@ -19125,7 +19125,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="1" symbol="DG508A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="1" pin="A0" pad="1"/>
 <connect gate="1" pin="A1" pad="16"/>
@@ -19156,7 +19156,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="A" symbol="MAX151" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="AGND" pad="23"/>
 <connect gate="A" pin="BUSY" pad="11"/>
@@ -19195,7 +19195,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="A" symbol="MAX764" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="AV+" pad="6"/>
 <connect gate="A" pin="FB" pad="2"/>
@@ -19218,7 +19218,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="A" symbol="MAX471" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="BATT" pad="2"/>
 <connect gate="A" pin="GND" pad="4"/>
@@ -19241,7 +19241,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="OPOFF+-" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -19263,7 +19263,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="A" symbol="MAX505" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="19"/>
 <connect gate="A" pin="A1" pad="18"/>
@@ -19303,7 +19303,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="B" symbol="OP" x="0" y="-17.78"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -19326,7 +19326,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX368" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="17"/>
@@ -19359,7 +19359,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX369" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="17"/>
@@ -19392,7 +19392,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX329" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -19423,7 +19423,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX378" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -19454,7 +19454,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX379" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -19485,7 +19485,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX220" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -19516,7 +19516,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX222" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="2"/>
 <connect gate="G$1" pin="C1-" pad="4"/>
@@ -19548,7 +19548,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX250" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="2"/>
 <connect gate="G$1" pin="D2" pad="13"/>
@@ -19577,7 +19577,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX251" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="AC" pad="1"/>
 <connect gate="G$1" pin="BYP" pad="7"/>
@@ -19606,7 +19606,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX252" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AC" pad="40"/>
 <connect gate="G$1" pin="BYP" pad="31"/>
@@ -19661,7 +19661,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX406" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -19685,7 +19685,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="B" symbol="OP" x="0" y="-15.24"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -19708,7 +19708,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="A" symbol="MAX620" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="C1+" pad="11"/>
 <connect gate="A" pin="C1-" pad="10"/>
@@ -19740,7 +19740,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX622" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="7"/>
@@ -19763,7 +19763,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX623" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="7"/>
 <connect gate="G$1" pin="GND@1" pad="8"/>
@@ -19784,7 +19784,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX654" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="CTL" pad="13"/>
 <connect gate="G$1" pin="GND" pad="7"/>
@@ -19812,7 +19812,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX656" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="CTL" pad="13"/>
 <connect gate="G$1" pin="D" pad="12"/>
@@ -19839,7 +19839,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX660" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="C+" pad="2"/>
 <connect gate="G$1" pin="C-" pad="4"/>
@@ -19862,7 +19862,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX667" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="DD" pad="1"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -19885,7 +19885,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX742" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="100/200" pad="5"/>
 <connect gate="G$1" pin="12/15" pad="6"/>
@@ -19920,7 +19920,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX743" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="12/15" pad="11"/>
 <connect gate="G$1" pin="AGND" pad="2"/>
@@ -19951,7 +19951,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX1232" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="PBRST" pad="1"/>
@@ -19974,7 +19974,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX687" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="BASE" pad="7"/>
 <connect gate="G$1" pin="BLIM" pad="6"/>
@@ -19997,7 +19997,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX699" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="8"/>
 <connect gate="G$1" pin="GND@1" pad="4"/>
@@ -20019,7 +20019,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX700" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CTL" pad="7"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -20042,7 +20042,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX701" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="MR" pad="1"/>
@@ -20062,7 +20062,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX702" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="MR" pad="1"/>
@@ -20081,7 +20081,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX270" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="12"/>
 <connect gate="G$1" pin="CS" pad="11"/>
@@ -20116,7 +20116,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX271" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="16"/>
 <connect gate="G$1" pin="A1" pad="15"/>
@@ -20155,7 +20155,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX280" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="2"/>
 <connect gate="G$1" pin="BOUT" pad="8"/>
@@ -20178,7 +20178,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX171" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="AIN" pad="4"/>
 <connect gate="G$1" pin="CK+" pad="13"/>
@@ -20208,7 +20208,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX174" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="10VIN" pad="13"/>
 <connect gate="G$1" pin="12/8" pad="2"/>
@@ -20251,7 +20251,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX178" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="5"/>
 <connect gate="G$1" pin="AIN" pad="2"/>
@@ -20289,7 +20289,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX180" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="37"/>
 <connect gate="G$1" pin="A1" pad="38"/>
@@ -20344,7 +20344,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX182" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="24"/>
 <connect gate="G$1" pin="A1" pad="25"/>
@@ -20387,7 +20387,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX183" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="3"/>
 <connect gate="G$1" pin="AIN1" pad="1"/>
@@ -20426,7 +20426,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX404" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -20448,7 +20448,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX405" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="2"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -20472,7 +20472,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="B" symbol="OP" x="0" y="-20.32"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -20499,7 +20499,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="PWR1" x="58.42" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -20538,7 +20538,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="PWR1" x="58.42" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -20571,7 +20571,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="PWR1" x="20.32" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -20599,7 +20599,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="PWR1" x="25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="3"/>
@@ -20622,7 +20622,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX500" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="5"/>
 <connect gate="G$1" pin="DGND" pad="6"/>
@@ -20653,7 +20653,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX516" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="10"/>
 <connect gate="G$1" pin="A1" pad="9"/>
@@ -20692,7 +20692,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX543" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="7"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -20718,7 +20718,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="D" symbol="OP" x="22.86" y="-15.24"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -20747,7 +20747,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG401" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="1"/>
 <connect gate="G$1" pin="D2" pad="8"/>
@@ -20772,7 +20772,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG403" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="1"/>
 <connect gate="G$1" pin="D2" pad="8"/>
@@ -20801,7 +20801,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG406" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -20841,7 +20841,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG407" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -20881,7 +20881,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG408" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -20912,7 +20912,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG409" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -20943,7 +20943,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG411" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="2"/>
 <connect gate="G$1" pin="D2" pad="15"/>
@@ -20974,7 +20974,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG417" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="8"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -20996,7 +20996,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG417" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="1"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -21018,7 +21018,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG419" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="1"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -21041,7 +21041,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG441" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="2"/>
 <connect gate="G$1" pin="D2" pad="15"/>
@@ -21072,7 +21072,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="B" symbol="OP" x="0" y="-15.24" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -21095,7 +21095,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX905" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="2"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -21121,7 +21121,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="1" symbol="MAX906" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="1" pin="+INA" pad="2"/>
 <connect gate="1" pin="+INB" pad="7"/>
@@ -21152,7 +21152,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="1" symbol="MAX911" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="1" pin="CMP_GND" pad="18"/>
 <connect gate="1" pin="D0" pad="21"/>
@@ -21191,7 +21191,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="1" symbol="MAX662" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PA" package="DIP-300-8">
+<device name="PA" package="DIP-8-254P-762W">
 <connects>
 <connect gate="1" pin="C1+" pad="2"/>
 <connect gate="1" pin="C1-" pad="1"/>
@@ -21206,7 +21206,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="SA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="1" pin="C1+" pad="2"/>
 <connect gate="1" pin="C1-" pad="1"/>
@@ -21229,7 +21229,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="1" symbol="MAX714" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="1" pin="AGND" pad="16"/>
 <connect gate="1" pin="B1" pad="6"/>
@@ -21260,7 +21260,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="1" symbol="MAX715" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="1" pin="AGND" pad="2"/>
 <connect gate="1" pin="B1" pad="8"/>
@@ -21299,7 +21299,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="1" symbol="MAX716" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="1" pin="AGND" pad="2"/>
 <connect gate="1" pin="B1" pad="10"/>
@@ -21341,7 +21341,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX722" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="3/5" pad="3"/>
 <connect gate="G$1" pin="AGND" pad="6"/>
@@ -21372,7 +21372,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX730" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CC" pad="4"/>
 <connect gate="G$1" pin="GND" pad="6"/>
@@ -21395,7 +21395,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX730" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CC" pad="4"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -21418,7 +21418,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX736" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="CC" pad="7"/>
 <connect gate="G$1" pin="DRV-" pad="9"/>
@@ -21445,7 +21445,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX741" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="CSA" pad="15"/>
 <connect gate="G$1" pin="CSB" pad="14"/>
@@ -21480,7 +21480,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX705" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="MR" pad="1"/>
@@ -21503,7 +21503,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX707" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="MR" pad="1"/>
@@ -21525,7 +21525,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX274" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="BPIA" pad="3"/>
 <connect gate="G$1" pin="BPIB" pad="10"/>
@@ -21564,7 +21564,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX275" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="BPIA" pad="7"/>
 <connect gate="G$1" pin="BPIB" pad="15"/>
@@ -21597,7 +21597,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX120" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="6"/>
 <connect gate="G$1" pin="AIN" pad="4"/>
@@ -21636,7 +21636,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX132" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="16"/>
 <connect gate="G$1" pin="BUFOUT" pad="23"/>
@@ -21675,7 +21675,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX135" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="18"/>
 <connect gate="G$1" pin="AGND@" pad="20"/>
@@ -21718,7 +21718,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX155" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="23"/>
 <connect gate="G$1" pin="AIN0" pad="4"/>
@@ -21761,7 +21761,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX156" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="21"/>
 <connect gate="G$1" pin="AIN0" pad="2"/>
@@ -21800,7 +21800,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX165" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="15"/>
 <connect gate="G$1" pin="AIN" pad="16"/>
@@ -21833,7 +21833,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX166" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="16"/>
 <connect gate="G$1" pin="AIN+" pad="18"/>
@@ -21868,7 +21868,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX190" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="2"/>
 <connect gate="G$1" pin="AGND@" pad="7"/>
@@ -21907,7 +21907,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX440" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="24"/>
 <connect gate="G$1" pin="A1" pad="25"/>
@@ -21950,7 +21950,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX441" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="18"/>
 <connect gate="G$1" pin="A1" pad="19"/>
@@ -21983,7 +21983,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX442" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="8"/>
 <connect gate="G$1" pin="GND" pad="2"/>
@@ -22006,7 +22006,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX456" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="6"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -22061,7 +22061,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX502" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="18"/>
 <connect gate="G$1" pin="CS" pad="16"/>
@@ -22100,7 +22100,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX501" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="18"/>
 <connect gate="G$1" pin="CLR" pad="4"/>
@@ -22139,7 +22139,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX506" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -22174,7 +22174,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX507" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="4"/>
 <connect gate="G$1" pin="CLR" pad="21"/>
@@ -22213,7 +22213,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX508" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="4"/>
 <connect gate="G$1" pin="CSLSB" pad="15"/>
@@ -22248,7 +22248,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX514" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="21"/>
 <connect gate="G$1" pin="CLK@" pad="16"/>
@@ -22287,7 +22287,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX526" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="18"/>
 <connect gate="G$1" pin="A1" pad="17"/>
@@ -22326,7 +22326,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX528" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="9"/>
 <connect gate="G$1" pin="CS" pad="12"/>
@@ -22361,7 +22361,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX872" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="COMP" pad="8"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -22384,7 +22384,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX200" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="8"/>
 <connect gate="G$1" pin="C1-" pad="10"/>
@@ -22418,7 +22418,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX201" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="C+" pad="1"/>
 <connect gate="G$1" pin="C-" pad="2"/>
@@ -22447,7 +22447,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX201" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C+" pad="1"/>
 <connect gate="G$1" pin="C-" pad="2"/>
@@ -22476,7 +22476,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX202" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -22507,7 +22507,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX306" x="2.54" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -22550,7 +22550,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX307" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -22593,7 +22593,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX307" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1150W-1150L-457H-28">
+<device name="" package="PLCC-28-127P-1150W-1150L-457H">
 <connects>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -22636,7 +22636,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX308" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -22667,7 +22667,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX309" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -22698,7 +22698,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX317" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="COM" pad="1"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -22721,7 +22721,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX318" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="COM" pad="1"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -22744,7 +22744,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX318" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COM" pad="1"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -22767,7 +22767,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX317" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COM" pad="1"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -22790,7 +22790,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX306" x="2.54" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -22833,7 +22833,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX306" x="2.54" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1150W-1150L-457H-28">
+<device name="" package="PLCC-28-127P-1150W-1150L-457H">
 <connects>
 <connect gate="G$2" pin="A0" pad="17"/>
 <connect gate="G$2" pin="A1" pad="16"/>
@@ -22876,7 +22876,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$3" symbol="MAX307" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$3" pin="A0" pad="17"/>
 <connect gate="G$3" pin="A1" pad="16"/>
@@ -22919,7 +22919,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX308" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="A0" pad="1"/>
 <connect gate="G$4" pin="A1" pad="16"/>
@@ -22950,7 +22950,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX309" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -22981,7 +22981,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX333" x="2.54" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="COM1" pad="3"/>
 <connect gate="G$1" pin="COM2" pad="8"/>
@@ -23016,7 +23016,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX335" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="24"/>
 <connect gate="G$1" pin="COM0" pad="6"/>
@@ -23055,7 +23055,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX335" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="24"/>
 <connect gate="G$1" pin="COM0" pad="6"/>
@@ -23094,7 +23094,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX338" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -23125,7 +23125,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX338" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="A0" pad="1"/>
 <connect gate="G$2" pin="A1" pad="16"/>
@@ -23156,7 +23156,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$3" symbol="MAX339" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$3" pin="A0" pad="1"/>
 <connect gate="G$3" pin="A1" pad="16"/>
@@ -23187,7 +23187,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX339" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="A0" pad="1"/>
 <connect gate="G$4" pin="A1" pad="16"/>
@@ -23218,7 +23218,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX351" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="COM1" pad="2"/>
 <connect gate="G$1" pin="COM2" pad="15"/>
@@ -23249,7 +23249,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX351" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="COM1" pad="2"/>
 <connect gate="G$2" pin="COM2" pad="15"/>
@@ -23280,7 +23280,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$3" symbol="MAX352" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$3" pin="COM1" pad="2"/>
 <connect gate="G$3" pin="COM2" pad="15"/>
@@ -23311,7 +23311,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX352" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="COM1" pad="2"/>
 <connect gate="G$4" pin="COM2" pad="15"/>
@@ -23342,7 +23342,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$5" symbol="MAX353" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$5" pin="COM1" pad="2"/>
 <connect gate="G$5" pin="COM2" pad="15"/>
@@ -23373,7 +23373,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$6" symbol="MAX353" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$6" pin="COM1" pad="2"/>
 <connect gate="G$6" pin="COM2" pad="15"/>
@@ -23404,7 +23404,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX361" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="COM1" pad="2"/>
 <connect gate="G$1" pin="COM2" pad="15"/>
@@ -23435,7 +23435,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX361" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="COM1" pad="2"/>
 <connect gate="G$2" pin="COM2" pad="15"/>
@@ -23466,7 +23466,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX362" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="COM1" pad="2"/>
 <connect gate="G$1" pin="COM2" pad="15"/>
@@ -23497,7 +23497,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX362" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="COM1" pad="2"/>
 <connect gate="G$2" pin="COM2" pad="15"/>
@@ -23528,7 +23528,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX351" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="COM1" pad="2"/>
 <connect gate="G$1" pin="COM2" pad="15"/>
@@ -23559,7 +23559,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX351" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="COM1" pad="2"/>
 <connect gate="G$2" pin="COM2" pad="15"/>
@@ -23590,7 +23590,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$3" symbol="MAX352" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$3" pin="COM1" pad="2"/>
 <connect gate="G$3" pin="COM2" pad="15"/>
@@ -23621,7 +23621,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX352" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="COM1" pad="2"/>
 <connect gate="G$4" pin="COM2" pad="15"/>
@@ -23652,7 +23652,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX366" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="IN1" pad="1"/>
 <connect gate="G$1" pin="IN2" pad="2"/>
@@ -23675,7 +23675,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX366" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$2" pin="IN1" pad="1"/>
 <connect gate="G$2" pin="IN2" pad="2"/>
@@ -23698,7 +23698,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX367" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="IN1" pad="1"/>
 <connect gate="G$1" pin="IN2" pad="2"/>
@@ -23731,7 +23731,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX367" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$2" pin="IN1" pad="1"/>
 <connect gate="G$2" pin="IN2" pad="2"/>
@@ -23764,7 +23764,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX381" x="2.54" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="COM1" pad="1"/>
 <connect gate="G$1" pin="COM2" pad="8"/>
@@ -23795,7 +23795,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX381" x="2.54" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="COM1" pad="1"/>
 <connect gate="G$2" pin="COM2" pad="8"/>
@@ -23826,7 +23826,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$3" symbol="MAX383" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$3" pin="COM1" pad="1"/>
 <connect gate="G$3" pin="COM2" pad="8"/>
@@ -23857,7 +23857,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX383" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="COM1" pad="1"/>
 <connect gate="G$4" pin="COM2" pad="8"/>
@@ -23888,7 +23888,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$6" symbol="MAX385" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$6" pin="COM1" pad="1"/>
 <connect gate="G$6" pin="COM2" pad="8"/>
@@ -23919,7 +23919,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX391" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="COM1" pad="2"/>
 <connect gate="G$1" pin="COM2" pad="15"/>
@@ -23950,7 +23950,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX391" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="COM1" pad="2"/>
 <connect gate="G$2" pin="COM2" pad="15"/>
@@ -23981,7 +23981,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$3" symbol="MAX392" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$3" pin="COM1" pad="2"/>
 <connect gate="G$3" pin="COM2" pad="15"/>
@@ -24012,7 +24012,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX392" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="COM1" pad="2"/>
 <connect gate="G$4" pin="COM2" pad="15"/>
@@ -24043,7 +24043,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$5" symbol="MAX393" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$5" pin="COM1" pad="2"/>
 <connect gate="G$5" pin="COM2" pad="15"/>
@@ -24074,7 +24074,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$6" symbol="MAX393" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$6" pin="COM1" pad="2"/>
 <connect gate="G$6" pin="COM2" pad="15"/>
@@ -24105,7 +24105,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX398" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -24136,7 +24136,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX398" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="A0" pad="1"/>
 <connect gate="G$2" pin="A1" pad="16"/>
@@ -24167,7 +24167,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$3" symbol="MAX399" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$3" pin="A0" pad="1"/>
 <connect gate="G$3" pin="A1" pad="16"/>
@@ -24198,7 +24198,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX399" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="A0" pad="1"/>
 <connect gate="G$4" pin="A1" pad="16"/>
@@ -24229,7 +24229,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG401" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="D1" pad="1"/>
 <connect gate="G$1" pin="D2" pad="8"/>
@@ -24254,7 +24254,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="DG403" x="0" y="-7.62"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$2" pin="D1" pad="1"/>
 <connect gate="G$2" pin="D2" pad="8"/>
@@ -24283,7 +24283,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$3" symbol="DG403" x="0" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$3" pin="D1" pad="1"/>
 <connect gate="G$3" pin="D2" pad="8"/>
@@ -24312,7 +24312,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="DG403" x="0" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$4" pin="D1" pad="1"/>
 <connect gate="G$4" pin="D2" pad="8"/>
@@ -24341,7 +24341,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$5" symbol="DG403" x="0" y="-7.62"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$5" pin="D1" pad="1"/>
 <connect gate="G$5" pin="D2" pad="8"/>
@@ -24370,7 +24370,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG406" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -24410,7 +24410,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="DG408" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="A0" pad="1"/>
 <connect gate="G$2" pin="A1" pad="16"/>
@@ -24441,7 +24441,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG411" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="2"/>
 <connect gate="G$1" pin="D2" pad="15"/>
@@ -24472,7 +24472,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="DG409" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="A0" pad="1"/>
 <connect gate="G$2" pin="A1" pad="16"/>
@@ -24503,7 +24503,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="DG411" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="D1" pad="2"/>
 <connect gate="G$2" pin="D2" pad="15"/>
@@ -24534,7 +24534,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX388" x="0" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!RS!" pad="18"/>
 <connect gate="G$1" pin="!WR!" pad="1"/>
@@ -24567,7 +24567,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX389" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!RS!" pad="18"/>
 <connect gate="G$1" pin="!WR!" pad="1"/>
@@ -24600,7 +24600,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX516" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="10"/>
 <connect gate="G$1" pin="A1" pad="9"/>
@@ -24639,7 +24639,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX752" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="1"/>
 <connect gate="G$1" pin="CC" pad="4"/>
@@ -24662,7 +24662,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX765" x="0" y="-1.27"/>
 </gates>
 <devices>
-<device name="PA" package="DIP-300-8">
+<device name="PA" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="FB" pad="2"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -24682,7 +24682,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name="6E"/>
 </technologies>
 </device>
-<device name="SA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FB" pad="2"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -24711,7 +24711,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="IN" pad="1"/>
 <connect gate="G$1" pin="TAP1" pad="7"/>
@@ -24735,7 +24735,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="VCC-GND" x="33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN" pad="1"/>
 <connect gate="G$1" pin="TAP1" pad="7"/>
@@ -24765,7 +24765,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="13" symbol="NC" x="48.26" y="-17.78" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="11" pin="NC" pad="11"/>
 <connect gate="13" pin="NC" pad="13"/>
@@ -24803,7 +24803,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="15" symbol="NC" x="45.72" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="10" pin="NC" pad="10"/>
 <connect gate="12" pin="NC" pad="12"/>
@@ -24835,7 +24835,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="28"/>
 <connect gate="G$1" pin="C1-" pad="25"/>
@@ -24879,7 +24879,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="35.56" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="28"/>
 <connect gate="G$1" pin="C1-" pad="24"/>
@@ -24923,7 +24923,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="2"/>
 <connect gate="G$1" pin="C1-" pad="4"/>
@@ -24957,7 +24957,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="WE" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="WE" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -24981,7 +24981,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name="E"/>
 </technologies>
 </device>
-<device name="PE" package="DIP-300-16">
+<device name="PE" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -25005,7 +25005,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name="E"/>
 </technologies>
 </device>
-<device name="AE" package="SSOP-065-530-16">
+<device name="AE" package="SSOP-16-65P-530W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -25029,7 +25029,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name="E"/>
 </technologies>
 </device>
-<device name="SE" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SE" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -25062,7 +25062,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="OPOFF" x="0" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -25086,7 +25086,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -25134,7 +25134,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="CSA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="CSA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -25149,7 +25149,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="CPD" package="DIP-300-8">
+<device name="CPD" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -25191,7 +25191,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="PWR2GND" x="27.94" y="-15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="1" pin="NC" pad="1"/>
 <connect gate="13" pin="NC" pad="13"/>
@@ -25268,7 +25268,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX705" x="0" y="0"/>
 </gates>
 <devices>
-<device name="CSA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="CSA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="MR" pad="1"/>
@@ -25283,7 +25283,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="CUA" package="DIP-300-8">
+<device name="CUA" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="MR" pad="1"/>
@@ -25329,7 +25329,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX705" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="MR" pad="1"/>
@@ -25353,7 +25353,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -25368,7 +25368,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -25395,7 +25395,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="PWR2GND" x="22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="12"/>
 <connect gate="G$1" pin="B" pad="11"/>
@@ -25428,7 +25428,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="NC3" symbol="NC" x="30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -25471,7 +25471,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gates>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <technologies>
 <technology name=""/>
 </technologies>
@@ -25484,7 +25484,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="NC1" symbol="MAX4137" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="NC1" pin="!SEL1!" pad="23"/>
 <connect gate="NC1" pin="!SEL2!" pad="22"/>
@@ -25523,7 +25523,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="NC1" symbol="MAX4138" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="NC1" pin="!SEL1!" pad="23"/>
 <connect gate="NC1" pin="!SEL2!" pad="22"/>
@@ -25563,7 +25563,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="25.4" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -25595,7 +25595,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="35.56" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -25627,7 +25627,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="PWR2GND" x="33.02" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="13"/>
 <connect gate="G$1" pin="C1-" pad="14"/>
@@ -25663,7 +25663,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX236" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="10"/>
 <connect gate="G$1" pin="C1-" pad="12"/>
@@ -25703,7 +25703,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="33.02" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="EN" pad="20"/>
 <connect gate="G$1" pin="R1IN" pad="10"/>
@@ -25743,7 +25743,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="33.02" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="10"/>
 <connect gate="G$1" pin="C1-" pad="12"/>
@@ -25783,7 +25783,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="10"/>
 <connect gate="G$1" pin="C1-" pad="12"/>
@@ -25823,7 +25823,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="30.48" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="12"/>
 <connect gate="G$1" pin="C1-" pad="14"/>
@@ -25867,7 +25867,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="12"/>
 <connect gate="G$1" pin="C1-" pad="14"/>
@@ -25911,7 +25911,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="12"/>
 <connect gate="G$1" pin="C1-" pad="14"/>
@@ -25957,7 +25957,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="2" symbol="BUFF3P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="1" pin="NC" pad="1"/>
 <connect gate="2" pin="GND" pad="2"/>
@@ -26029,7 +26029,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="8" symbol="NC" x="22.86" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="1" pin="NC" pad="1"/>
 <connect gate="5" pin="NC" pad="5"/>
@@ -26099,7 +26099,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!LOWLINE!" pad="7"/>
 <connect gate="G$1" pin="!MR!" pad="6"/>
@@ -26131,7 +26131,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="PWR2GND" x="25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="13"/>
 <connect gate="G$1" pin="C1-" pad="14"/>
@@ -26167,7 +26167,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="BATT-ON" pad="5"/>
 <connect gate="G$1" pin="CE-IN" pad="13"/>
@@ -26198,7 +26198,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX038" x="0" y="0"/>
 </gates>
 <devices>
-<device name="WP" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="WP" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="3"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -26226,7 +26226,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name="E"/>
 </technologies>
 </device>
-<device name="PP" package="DIP-300-20">
+<device name="PP" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="3"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -26318,7 +26318,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX712" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PE" package="DIP-300-16">
+<device name="PE" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!FASTCHG!" pad="8"/>
 <connect gate="G$1" pin="BATT+" pad="2"/>
@@ -26344,7 +26344,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name="3E"/>
 </technologies>
 </device>
-<device name="SE" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="SE" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!FASTCHG!" pad="8"/>
 <connect gate="G$1" pin="BATT+" pad="2"/>
@@ -26497,7 +26497,7 @@ with I/O Buffers</description>
 <gate name="N19" symbol="VDD" x="22.86" y="17.78" addlevel="request"/>
 </gates>
 <devices>
-<device name="ECQ" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="ECQ" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!AOUT!" pad="30"/>
 <connect gate="G$1" pin="!CE!" pad="32"/>
@@ -26628,7 +26628,7 @@ High-Speed, Low-Power, Single-Supply, Multichannel</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="ESA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="ESA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="N1" pin="!SHDN!" pad="2"/>
 <connect gate="N1" pin="A0" pad="1"/>
@@ -26667,7 +26667,7 @@ High-Speed, Low-Power, Single-Supply, Multichannel</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="EUA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="EUA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="N1" pin="!SHDN!" pad="2"/>
 <connect gate="N1" pin="A0" pad="1"/>
@@ -26691,7 +26691,7 @@ High-Speed, Low-Power, Single-Supply, Multichannel</description>
 <gate name="N1" symbol="MAX4311" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="ESD" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="ESD" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="N1" pin="!SHDN!" pad="12"/>
 <connect gate="N1" pin="A0" pad="2"/>
@@ -26736,7 +26736,7 @@ High-Speed, Low-Power, Single-Supply, Multichannel</description>
 <gate name="N1" symbol="MAX4312" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="ESE" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="ESE" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="N1" pin="!SHDN!" pad="14"/>
 <connect gate="N1" pin="A0" pad="3"/>
@@ -26791,7 +26791,7 @@ High-Speed, Low-Power, Single-Supply, Multichannel</description>
 <gate name="N1" symbol="MAX4314" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="ESD" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="ESD" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="N1" pin="!SHDN!" pad="12"/>
 <connect gate="N1" pin="A0" pad="3"/>
@@ -26838,7 +26838,7 @@ High-Speed, Low-Power, Single-Supply, Multichannel</description>
 <gate name="N1" symbol="MAX4315" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="ESE" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="ESE" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="N1" pin="!SHDN!" pad="14"/>
 <connect gate="N1" pin="A0" pad="3"/>
@@ -26895,7 +26895,7 @@ http://dbserv.maxim-ic.com/</description>
 <gate name="P" symbol="VCC-GND" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="DB" package="SSOP-065-530-16">
+<device name="DB" package="SSOP-16-65P-530W">
 <connects>
 <connect gate="G$1" pin="!EN!" pad="1"/>
 <connect gate="G$1" pin="!FORCEOFF!" pad="16"/>
@@ -26918,7 +26918,7 @@ http://dbserv.maxim-ic.com/</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!EN!" pad="1"/>
 <connect gate="G$1" pin="!FORCEOFF!" pad="16"/>
@@ -26952,7 +26952,7 @@ http://dbserv.maxim-ic.com/</description>
 <gate name="P" symbol="VCC-GND" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="PP" package="DIP-300-20">
+<device name="PP" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!EN!" pad="1"/>
 <connect gate="G$1" pin="!FORCEOFF!" pad="20"/>
@@ -26979,7 +26979,7 @@ http://dbserv.maxim-ic.com/</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DB" package="SSOP-065-530-20">
+<device name="DB" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="!EN!" pad="1"/>
 <connect gate="G$1" pin="!FORCEOFF!" pad="20"/>
@@ -27006,7 +27006,7 @@ http://dbserv.maxim-ic.com/</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="PW" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!EN!" pad="1"/>
 <connect gate="G$1" pin="!FORCEOFF!" pad="20"/>
@@ -27033,7 +27033,7 @@ http://dbserv.maxim-ic.com/</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!EN!" pad="1"/>
 <connect gate="G$1" pin="!FORCEOFF!" pad="20"/>
@@ -27071,7 +27071,7 @@ http://dbserv.maxim-ic.com/</description>
 <gate name="P" symbol="VCC-GND" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="PW" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!FORCEOFF!" pad="22"/>
 <connect gate="G$1" pin="!INVALID!" pad="21"/>
@@ -27106,7 +27106,7 @@ http://dbserv.maxim-ic.com/</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="DW" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!FORCEOFF!" pad="22"/>
 <connect gate="G$1" pin="!INVALID!" pad="21"/>
@@ -27141,7 +27141,7 @@ http://dbserv.maxim-ic.com/</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DB" package="SSOP-065-530-28">
+<device name="DB" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="!FORCEOFF!" pad="22"/>
 <connect gate="G$1" pin="!INVALID!" pad="21"/>
@@ -27185,7 +27185,7 @@ DALLAS Semiconductor</description>
 <gate name="G$1" symbol="DS1307" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -27200,7 +27200,7 @@ DALLAS Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="Z" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="Z" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -27227,7 +27227,7 @@ DALLAS Semiconductor</description>
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -27248,7 +27248,7 @@ DALLAS Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -27279,7 +27279,7 @@ DALLAS Semiconductor</description>
 <gate name="P" symbol="PWR+GND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="CSA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="CSA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-1" pin="COM" pad="2"/>
 <connect gate="-1" pin="IN" pad="7"/>
@@ -27294,7 +27294,7 @@ DALLAS Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="CPA" package="DIP-300-8">
+<device name="CPA" package="DIP-8-254P-762W">
 <connects>
 <connect gate="-1" pin="COM" pad="2"/>
 <connect gate="-1" pin="IN" pad="7"/>
@@ -27319,7 +27319,7 @@ DALLAS Semiconductor</description>
 <gate name="P" symbol="PWR+GND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="CSA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="CSA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-1" pin="COM" pad="2"/>
 <connect gate="-1" pin="IN" pad="7"/>
@@ -27334,7 +27334,7 @@ DALLAS Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="CPA" package="DIP-300-8">
+<device name="CPA" package="DIP-8-254P-762W">
 <connects>
 <connect gate="-1" pin="COM" pad="2"/>
 <connect gate="-1" pin="IN" pad="7"/>
@@ -27359,7 +27359,7 @@ DALLAS Semiconductor</description>
 <gate name="P" symbol="PWR+-" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="CSA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="CSA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-A" pin="COM" pad="2"/>
 <connect gate="-A" pin="IN" pad="7"/>
@@ -27374,7 +27374,7 @@ DALLAS Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="CPA" package="DIP-300-8">
+<device name="CPA" package="DIP-8-254P-762W">
 <connects>
 <connect gate="-A" pin="COM" pad="2"/>
 <connect gate="-A" pin="IN" pad="7"/>
@@ -27435,7 +27435,7 @@ DALLAS Semiconductor</description>
 <gate name="G$1" symbol="DS1337" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="U" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="INTA" pad="3"/>
@@ -27450,7 +27450,7 @@ DALLAS Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="INTA" pad="3"/>
@@ -27465,7 +27465,7 @@ DALLAS Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="INTA" pad="3"/>
@@ -27488,7 +27488,7 @@ DALLAS Semiconductor</description>
 <gate name="G$1" symbol="MAX891L" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!ON!" pad="3"/>
 <connect gate="G$1" pin="FAULT/FAULT" pad="6"/>
@@ -27550,7 +27550,7 @@ DALLAS Semiconductor</description>
 <gate name="G$1" symbol="MAX7300-28" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-28">
+<device name="" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="AD0" pad="4"/>
 <connect gate="G$1" pin="AD1" pad="27"/>
@@ -27618,7 +27618,7 @@ Half-Duplex Differential Transceiver for Battery-Powered Systems</description>
 <gate name="P" symbol="VCC-GND" x="27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -27641,7 +27641,7 @@ Half-Duplex Differential Transceiver for Battery-Powered Systems</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -27664,7 +27664,7 @@ Half-Duplex Differential Transceiver for Battery-Powered Systems</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DB" package="SSOP-065-530-16">
+<device name="DB" package="SSOP-16-65P-530W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -27687,7 +27687,7 @@ Half-Duplex Differential Transceiver for Battery-Powered Systems</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -27822,7 +27822,7 @@ RS-232 Transceiver for PDAs and Cell Phones</description>
 <gate name="P" symbol="VCC+VL-GND" x="-27.94" y="15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-780L-120H-100F-24">
+<device name="" package="SSOP-24-65P-440W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!FORCEOFF!" pad="24"/>
 <connect gate="G$1" pin="!INVALID!" pad="9"/>
@@ -27862,7 +27862,7 @@ with SPI Interface</description>
 <gate name="G$1" symbol="MAX3421E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="EHJ+" package="TQFP-50P-500W-500L-120H-32">
+<device name="EHJ+" package="TQFP-32-50P-500W-500L-120H">
 <connects>
 <connect gate="G$1" pin="!RES" pad="12"/>
 <connect gate="G$1" pin="!SS" pad="14"/>
@@ -27910,7 +27910,7 @@ Regulated 5V Charge Pump</description>
 <gate name="G$1" symbol="MAX619" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!ON!/OFF" pad="7"/>
 <connect gate="G$1" pin="C1+" pad="1"/>
@@ -27925,7 +27925,7 @@ Regulated 5V Charge Pump</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DA" package="DIP-300-8">
+<device name="DA" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!ON!/OFF" pad="7"/>
 <connect gate="G$1" pin="C1+" pad="1"/>
@@ -28063,7 +28063,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <gate name="G$1" symbol="MAX3467" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SA" package="DIP-300-8">
+<device name="SA" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -28079,7 +28079,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <technology name="E"/>
 </technologies>
 </device>
-<device name="PA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="PA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -28106,7 +28106,7 @@ Source: http://pdfserv.maxim-ic.com/en/ds/MAX985-MAX994.pdf</description>
 <gate name="P" symbol="PWR+-" x="17.78" y="0"/>
 </gates>
 <devices>
-<device name="ESA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="ESA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -28147,7 +28147,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <gate name="G$1" symbol="MAX3468" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PA" package="DIP-300-8">
+<device name="PA" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="6"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -28165,7 +28165,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <technology name="69E"/>
 </technologies>
 </device>
-<device name="SA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="6"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -28206,7 +28206,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="OUT" pad="5"/>
@@ -28273,7 +28273,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <gate name="G$1" symbol="DS32KHZS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="32KHZ" pad="1"/>
 <connect gate="G$1" pin="GND@13" pad="13"/>
@@ -28294,7 +28294,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <gate name="P" symbol="VCC-GND" x="33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-28">
+<device name="" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="!RE232!" pad="15"/>
 <connect gate="G$1" pin="!RE485!" pad="12"/>
@@ -28339,7 +28339,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <gate name="P" symbol="VCC-GND" x="30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-20">
+<device name="" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="9"/>
 <connect gate="G$1" pin="A/R2IN" pad="13"/>
@@ -28375,7 +28375,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <gate name="P" symbol="PWR+GND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="CSA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="CSA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="COM" pad="2"/>
 <connect gate="A" pin="IN" pad="7"/>
@@ -28401,7 +28401,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="CPA" package="DIP-300-8">
+<device name="CPA" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="COM" pad="2"/>
 <connect gate="A" pin="IN" pad="7"/>
@@ -28435,7 +28435,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <gate name="G$1" symbol="MAX761" x="0" y="0"/>
 </gates>
 <devices>
-<device name="CP" package="DIP-300-8">
+<device name="CP" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="FB" pad="3"/>
 <connect gate="G$1" pin="GND" pad="6"/>
@@ -28450,7 +28450,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="CS" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="CS" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FB" pad="3"/>
 <connect gate="G$1" pin="GND" pad="6"/>
@@ -28474,7 +28474,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <gate name="P" symbol="VCC-GND" x="25.4" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-16">
+<device name="" package="SSOP-16-65P-530W">
 <connects>
 <connect gate="A" pin="!FORCEOFF!" pad="16"/>
 <connect gate="A" pin="!INVALID!" pad="10"/>
@@ -28506,7 +28506,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <gate name="P" symbol="VCC-GND" x="25.4" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="PP" package="DIP-300-20">
+<device name="PP" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!FORCEOFF!" pad="20"/>
 <connect gate="G$1" pin="!INVALID!" pad="11"/>
@@ -28533,7 +28533,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="AP" package="SSOP-065-530-20">
+<device name="AP" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="!FORCEOFF!" pad="20"/>
 <connect gate="G$1" pin="!INVALID!" pad="11"/>
@@ -28560,7 +28560,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="UP" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="UP" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!FORCEOFF!" pad="20"/>
 <connect gate="G$1" pin="!INVALID!" pad="11"/>
@@ -28702,7 +28702,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <gate name="G$1" symbol="MAX1785" x="17.78" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-440W-970L-120H-100F-38">
+<device name="" package="SSOP-38-50P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="2"/>
 <connect gate="G$1" pin="AIN0" pad="33"/>
@@ -28780,7 +28780,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="P" symbol="PWR_VCCVEE" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -28847,7 +28847,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="G$1" symbol="MAX5035" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BST" pad="1"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -28862,7 +28862,7 @@ Precision, Low-Power, High-Voltage</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="BST" pad="1"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -28975,7 +28975,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="P" symbol="V+-GND2" x="-27.94" y="0" addlevel="request" swaplevel="1"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="2"/>
 <connect gate="G$1" pin="IN-" pad="3"/>
@@ -28990,7 +28990,7 @@ Precision, Low-Power, High-Voltage</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="IN+" pad="2"/>
 <connect gate="G$1" pin="IN-" pad="3"/>
@@ -29046,7 +29046,7 @@ Precision, Low-Power, High-Voltage</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="AA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="AA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="IN" pad="2"/>
@@ -29065,7 +29065,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="G$1" symbol="MAX682/3/4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="2"/>
 <connect gate="G$1" pin="!SKIP!" pad="1"/>
@@ -29214,7 +29214,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="G$1" symbol="MAX889" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="6"/>
 <connect gate="G$1" pin="CAP+" pad="2"/>
@@ -29237,7 +29237,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="G$1" symbol="MAX1300" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-780L-120H-100F-24">
+<device name="" package="SSOP-24-65P-440W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="10"/>
 <connect gate="G$1" pin="AGND1" pad="24"/>
@@ -29276,7 +29276,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="G$1" symbol="MAX1673" x="0" y="0"/>
 </gates>
 <devices>
-<device name="ESA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="ESA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="4"/>
 <connect gate="G$1" pin="CAP+" pad="2"/>
@@ -29300,7 +29300,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="G$1" symbol="MAX3488" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -29315,7 +29315,7 @@ Precision, Low-Power, High-Voltage</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -29410,7 +29410,7 @@ Micropower, Single-Supply, Rail-to-Rail</description>
 <gate name="G$1" symbol="MAX4194" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -29434,7 +29434,7 @@ Micropower, Single-Supply, Rail-to-Rail</description>
 <gate name="G$1" symbol="MAX4197" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -29457,7 +29457,7 @@ Micropower, Single-Supply, Rail-to-Rail</description>
 <gate name="G$1" symbol="MAX9051" x="0" y="0"/>
 </gates>
 <devices>
-<device name="ESA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="ESA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>

--- a/memory-atmel.lbr
+++ b/memory-atmel.lbr
@@ -79,7 +79,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SSOP-50P-1840W-800L-120H-80F-32">
+<package name="SSOP-32-50P-1840W-800L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 8.0mm length, 18.4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 8.0mm length, 18.4mm width, 1.20mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation BD, R-PDSO-G.&lt;/p&gt;
@@ -265,7 +265,7 @@ body 11.8 x 8 mm&lt;p&gt;</description>
 <vertex x="-1" y="1.4"/>
 </polygon>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -299,7 +299,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-530W-530L-210H-125F-8">
+<package name="SOP-8-127P-530W-530L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -332,7 +332,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="2.625" y1="-2.625" x2="-2.625" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="2.625" x2="-2.625" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -352,7 +352,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SSOP-65P-440W-300L-120H-100F-8">
+<package name="SSOP-8-65P-440W-300L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -381,7 +381,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <wire x1="1.4" y1="-2.1" x2="1.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="2.1" x2="-1.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-750W-530L-265H-140F-8">
+<package name="SOP-8-127P-750W-530L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads.&lt;/p&gt;
 
@@ -551,7 +551,7 @@ body 6 x 8 x 1.0 mm,  Lead Pitch 1.27 mm</description>
 <vertex x="-2.9" y="5"/>
 </polygon>
 </package>
-<package name="SSOP-50P-1840W-1200L-120H-80F-48">
+<package name="SSOP-48-50P-1840W-1200L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
@@ -714,7 +714,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <rectangle x1="-3" y1="-3.3" x2="-2.6" y2="-2.9" layer="21" rot="R90"/>
 <rectangle x1="-1.75" y1="-2" x2="1.75" y2="2" layer="29" rot="R90"/>
 </package>
-<package name="PLCC-127P-1397W-1143L-355H-32">
+<package name="PLCC-32-127P-1397W-1143L-355H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 11.43mm length, 13.97mm width, 3.56mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Rectangular plastic leaded chip carrier. 1.27mm pitch, 11.43mm body length, 13.97mm body width, 3.56mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-016A, variation AE.&lt;/p&gt;
@@ -800,7 +800,7 @@ JEDEC MS-016A, variation AE.&lt;/p&gt;
 <wire x1="5.715" y1="5.745" x2="5.715" y2="6.985" width="0.2032" layer="21"/>
 <wire x1="5.715" y1="6.985" x2="4.475" y2="6.985" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-600-32">
+<package name="DIP-32-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="20.32" y1="5.715" x2="-20.32" y2="5.715" width="0.2032" layer="21"/>
@@ -844,7 +844,7 @@ JEDEC MS-016A, variation AE.&lt;/p&gt;
 <text x="-20.955" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-17.145" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-890W-2050L-265H-155F-32">
+<package name="SOP-32-127P-890W-2050L-265H-155F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 20.50mm length, 8.90mm width, 2.65mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body length,
 8.90mm body width, 2.65mm max height, 32 leads.
@@ -1482,7 +1482,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <gate name="A" symbol="AT49BV6416" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1200L-120H-80F-48">
+<device name="" package="SSOP-48-50P-1840W-1200L-120H-80F">
 <connects>
 <connect gate="A" pin="!CE!" pad="26"/>
 <connect gate="A" pin="!OE!" pad="28"/>
@@ -1545,7 +1545,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <gate name="A" symbol="AT49F040" x="0" y="0"/>
 </gates>
 <devices>
-<device name="TSOP32" package="SSOP-50P-1840W-800L-120H-80F-32">
+<device name="TSOP32" package="SSOP-32-50P-1840W-800L-120H-80F">
 <connects>
 <connect gate="A" pin="!CE!" pad="30"/>
 <connect gate="A" pin="!OE!" pad="32"/>
@@ -1593,7 +1593,7 @@ SPI bus serial</description>
 <gate name="G$1" symbol="AT45DB01X" x="0" y="0"/>
 </gates>
 <devices>
-<device name="A" package="SOP-127P-750W-530L-265H-140F-8">
+<device name="A" package="SOP-8-127P-750W-530L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="4"/>
 <connect gate="G$1" pin="!RST!" pad="3"/>
@@ -1657,7 +1657,7 @@ SPI bus serial</description>
 <gate name="G$1" symbol="AT45DB" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-TC" package="SSOP-50P-1840W-800L-120H-80F-32">
+<device name="-TC" package="SSOP-32-50P-1840W-800L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="13"/>
 <connect gate="G$1" pin="!RST!" pad="2"/>
@@ -1681,7 +1681,7 @@ SPI bus serial</description>
 <gate name="G$1" symbol="AT49BV1604" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1200L-120H-80F-48">
+<device name="" package="SSOP-48-50P-1840W-1200L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!BYTE!" pad="47"/>
 <connect gate="G$1" pin="!CE!" pad="26"/>
@@ -1745,7 +1745,7 @@ SPI bus serial</description>
 <gate name="G$1" symbol="250X0" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
@@ -1760,7 +1760,7 @@ SPI bus serial</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-SO" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="-SO" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
@@ -1784,7 +1784,7 @@ I2C serial bus</description>
 <gate name="G$1" symbol="AT24C" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-8S1" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="-8S1" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -1799,7 +1799,7 @@ I2C serial bus</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S2" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="-8S2" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -1823,7 +1823,7 @@ DataFlash, 16-megabit, 2.5-volt or 2.7-volt</description>
 <gate name="G$1" symbol="AT45DB161D-S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="4"/>
 <connect gate="G$1" pin="!RST!" pad="3"/>
@@ -1847,7 +1847,7 @@ RapidS Serial Interface, 66 MHZ</description>
 <gate name="G$1" symbol="AT45DB011D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-SS" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="-SS" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="4"/>
 <connect gate="G$1" pin="!RST!" pad="3"/>
@@ -1862,7 +1862,7 @@ RapidS Serial Interface, 66 MHZ</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-S" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="-S" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="4"/>
 <connect gate="G$1" pin="!RST!" pad="3"/>
@@ -1886,7 +1886,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <gate name="G$1" symbol="AT24C1024B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-8P3" package="DIP-300-8">
+<device name="-8P3" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -1901,7 +1901,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8A2" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="-8A2" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -1916,7 +1916,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S1" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="-8S1" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -1931,7 +1931,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S2" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="-8S2" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -1979,7 +1979,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <gate name="G$1" symbol="AT45" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-S" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="-S" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="4"/>
 <connect gate="G$1" pin="!RESET!" pad="3"/>
@@ -2122,7 +2122,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <gate name="G$1" symbol="AT49BV642D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1200L-120H-80F-48">
+<device name="" package="SSOP-48-50P-1840W-1200L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="26"/>
 <connect gate="G$1" pin="!OE!" pad="28"/>
@@ -2209,7 +2209,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <gate name="G$1" symbol="AT27C040" x="0" y="0"/>
 </gates>
 <devices>
-<device name="32J" package="PLCC-127P-1397W-1143L-355H-32">
+<device name="32J" package="PLCC-32-127P-1397W-1143L-355H">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -2248,7 +2248,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="32P6" package="DIP-600-32">
+<device name="32P6" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -2287,7 +2287,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="32T" package="SSOP-50P-1840W-800L-120H-80F-32">
+<device name="32T" package="SSOP-32-50P-1840W-800L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="30"/>
 <connect gate="G$1" pin="!OE!" pad="32"/>
@@ -2326,7 +2326,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-127P-890W-2050L-265H-155F-32">
+<device name="R" package="SOP-32-127P-890W-2050L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -2374,7 +2374,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <gate name="G$1" symbol="AT27C080" x="0" y="0"/>
 </gates>
 <devices>
-<device name="32P6" package="DIP-600-32">
+<device name="32P6" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!/VPP" pad="24"/>
@@ -2413,7 +2413,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-127P-890W-2050L-265H-155F-32">
+<device name="R" package="SOP-32-127P-890W-2050L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!/VPP" pad="24"/>
@@ -2452,7 +2452,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="J" package="PLCC-127P-1397W-1143L-355H-32">
+<device name="J" package="PLCC-32-127P-1397W-1143L-355H">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!/VPP" pad="24"/>
@@ -2491,7 +2491,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SSOP-50P-1840W-800L-120H-80F-32">
+<device name="T" package="SSOP-32-50P-1840W-800L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="30"/>
 <connect gate="G$1" pin="!OE!/VPP" pad="32"/>
@@ -2539,7 +2539,7 @@ I2C serial bus, 512K (65,536 x 8)</description>
 <gate name="G$1" symbol="AT24C" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-8P3" package="DIP-300-8">
+<device name="-8P3" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -2554,7 +2554,7 @@ I2C serial bus, 512K (65,536 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S1" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="-8S1" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -2569,7 +2569,7 @@ I2C serial bus, 512K (65,536 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S2" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="-8S2" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -2584,7 +2584,7 @@ I2C serial bus, 512K (65,536 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8A2" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="-8A2" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>

--- a/memory-cypress.lbr
+++ b/memory-cypress.lbr
@@ -78,7 +78,7 @@ THIS LIBRARY IS PROVIDED AS IS AND WITHOUT WARRANTY OF ANY KIND, EXPRESSED OR IM
 Copyright (C) 2009, Bob Starr
 http://www.bobstarr.net</description>
 <packages>
-<package name="SSOP-50P-1840W-1200L-120H-80F-48">
+<package name="SSOP-48-50P-1840W-1200L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
@@ -409,7 +409,7 @@ body 8 x 9.5 x 1 mm (51-85178)</description>
 <vertex x="-3.35" y="4.7"/>
 </polygon>
 </package>
-<package name="SOP-127P-530W-530L-210H-125F-8">
+<package name="SOP-8-127P-530W-530L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -693,7 +693,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <gate name="G$1" symbol="CY62167EV30-Z" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1200L-120H-80F-48">
+<device name="" package="SSOP-48-50P-1840W-1200L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!BHE!" pad="14"/>
 <connect gate="G$1" pin="!BLE!" pad="15"/>
@@ -949,7 +949,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <gate name="G$1" symbol="FM25V20" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-G" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="-G" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>

--- a/memory-hitachi.lbr
+++ b/memory-hitachi.lbr
@@ -74,7 +74,7 @@
 <description>&lt;b&gt;Hitachi Memories&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -102,7 +102,7 @@
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -132,7 +132,7 @@
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -164,7 +164,7 @@
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-32">
+<package name="DIP-32-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="20.32" y1="5.715" x2="-20.32" y2="5.715" width="0.2032" layer="21"/>
@@ -208,7 +208,7 @@
 <text x="-20.955" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-17.145" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -260,7 +260,7 @@
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -300,7 +300,7 @@
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-400-28">
+<package name="DIP-28-254P-1016W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 400 mil row spacing, JEDEC MS-010C</description>
 <wire x1="17.78" y1="3.175" x2="-17.78" y2="3.175" width="0.2032" layer="21"/>
@@ -340,7 +340,7 @@
 <text x="-18.415" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -380,7 +380,7 @@
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -416,7 +416,7 @@
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-22">
+<package name="DIP-22-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="-14.605" y1="-0.635" x2="-14.605" y2="-1.905" width="0.2032" layer="21"/>
@@ -450,7 +450,7 @@
 <text x="-15.24" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.795" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-42">
+<package name="DIP-42-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-27.6225" y1="-0.9525" x2="-27.6225" y2="-5.715" width="0.2032" layer="21"/>
@@ -504,7 +504,7 @@
 <text x="-28.575" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-22.225" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -2117,7 +2117,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6264" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -2160,7 +2160,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6267" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="9"/>
@@ -2195,7 +2195,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6268" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="9"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -2230,7 +2230,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6716" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="18"/>
 <connect gate="G$1" pin="!OE!" pad="20"/>
@@ -2269,7 +2269,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6719" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!WE!" pad="21"/>
@@ -2308,7 +2308,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6288P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="10"/>
 <connect gate="G$1" pin="!WE!" pad="12"/>
@@ -2345,7 +2345,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6288JP" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="10"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -2384,7 +2384,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6788" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="10"/>
 <connect gate="G$1" pin="!WE!" pad="12"/>
@@ -2421,7 +2421,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6789" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="10"/>
 <connect gate="G$1" pin="!OE!" pad="11"/>
@@ -2460,7 +2460,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6287" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="12"/>
 <connect gate="G$1" pin="!WE!" pad="10"/>
@@ -2497,7 +2497,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6287" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="12"/>
 <connect gate="G$1" pin="!WE!" pad="10"/>
@@ -2534,7 +2534,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62256" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -2577,7 +2577,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62256" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -2620,7 +2620,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62832" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -2663,7 +2663,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6208" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -2702,7 +2702,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6208" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -2741,7 +2741,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="6207" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="13"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -2780,7 +2780,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="628128" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -2827,7 +2827,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="624256" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-400-28">
+<device name="" package="DIP-28-254P-1016W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="12"/>
 <connect gate="G$1" pin="!OE!" pad="13"/>
@@ -2870,7 +2870,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="50464" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CAS!" pad="16"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -2903,7 +2903,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="50256" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CAS!" pad="15"/>
 <connect gate="G$1" pin="!RAS!" pad="4"/>
@@ -2934,7 +2934,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="51258" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="15"/>
 <connect gate="G$1" pin="!RAS!" pad="4"/>
@@ -2965,7 +2965,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="514256" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CAS!" pad="17"/>
 <connect gate="G$1" pin="!OE!" pad="16"/>
@@ -3000,7 +3000,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="514258" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="17"/>
 <connect gate="G$1" pin="!OE!" pad="16"/>
@@ -3035,7 +3035,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="514266" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CAS!" pad="17"/>
 <connect gate="G$1" pin="!OE!" pad="16"/>
@@ -3070,7 +3070,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="511000" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CAS!" pad="16"/>
 <connect gate="G$1" pin="!RAS!" pad="3"/>
@@ -3103,7 +3103,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="511002" x="2.54" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="16"/>
 <connect gate="G$1" pin="!RAS!" pad="3"/>
@@ -3136,7 +3136,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="623257" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="A0" pad="10"/>
@@ -3179,7 +3179,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="623257Z" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -3222,7 +3222,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="623257Z" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -3265,7 +3265,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62321" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="A0" pad="10"/>
@@ -3308,7 +3308,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62321E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="20"/>
 <connect gate="G$1" pin="A0" pad="10"/>
@@ -3351,7 +3351,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62321A" x="-2.54" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -3398,7 +3398,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62404" x="-2.54" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-42">
+<device name="" package="DIP-42-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="10"/>
 <connect gate="G$1" pin="!D10!" pad="18"/>
@@ -3453,7 +3453,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62304" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -3500,7 +3500,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62408" x="-2.54" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-42">
+<device name="" package="DIP-42-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="11"/>
 <connect gate="G$1" pin="!OE!" pad="13"/>
@@ -3557,7 +3557,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="624016" x="2.54" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-42">
+<device name="" package="DIP-42-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="11"/>
 <connect gate="G$1" pin="!OE!" pad="13"/>
@@ -3614,7 +3614,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62308" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -3661,7 +3661,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62414" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="10"/>
 <connect gate="G$1" pin="!OE!" pad="12"/>
@@ -3716,7 +3716,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62414" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="10"/>
 <connect gate="G$1" pin="!OE!" pad="12"/>
@@ -3771,7 +3771,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62304" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -3818,7 +3818,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="58C65" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -3861,7 +3861,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="58C66" x="-2.54" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -3904,7 +3904,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="58C256" x="2.54" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -3947,7 +3947,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="27C256" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -3990,7 +3990,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="27512" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!/VPP" pad="22"/>
@@ -4033,7 +4033,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="27C1024" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="2"/>
 <connect gate="G$1" pin="!OE!" pad="20"/>
@@ -4088,7 +4088,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="27C101" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -4135,7 +4135,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="27C101" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="2"/>
@@ -4182,7 +4182,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="27C4001" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -4229,7 +4229,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="10490" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!WE!" pad="19"/>

--- a/memory-idt.lbr
+++ b/memory-idt.lbr
@@ -191,7 +191,7 @@ rectangle</description>
 <rectangle x1="3.43" y1="3.68" x2="4.19" y2="4.13" layer="51"/>
 <rectangle x1="3.43" y1="-4.13" x2="4.19" y2="-3.68" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -396,7 +396,7 @@ square</description>
 <rectangle x1="-6.22" y1="-2.92" x2="-5.75" y2="-2.16" layer="51"/>
 <rectangle x1="-6.22" y1="-4.19" x2="-5.75" y2="-3.43" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -757,7 +757,7 @@ rectangle</description>
 <rectangle x1="-6.22" y1="-1.65" x2="-5.75" y2="-0.89" layer="51"/>
 <rectangle x1="-6.22" y1="-2.92" x2="-5.75" y2="-2.16" layer="51"/>
 </package>
-<package name="SOP-127P-840W-1790L-254H-180F-28">
+<package name="SOP-28-127P-840W-1790L-254H-180F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
 8.40mm body width, 2.54mm max height, 28 leads.
@@ -2273,7 +2273,7 @@ rectangle</description>
 <rectangle x1="3.43" y1="-4.95" x2="4.19" y2="-4.48" layer="51"/>
 <rectangle x1="4.7" y1="-4.95" x2="5.46" y2="-4.48" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -2322,7 +2322,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1155L-265H-140F-18">
+<package name="SOP-18-127P-750W-1155L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
@@ -2375,7 +2375,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="DIP-900-64">
+<package name="DIP-64-254P-2286W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 900 mil row spacing, JEDEC MO-016D</description>
 <wire x1="-41.275" y1="-0.9525" x2="-41.275" y2="-9.4615" width="0.2032" layer="21"/>
@@ -5585,7 +5585,7 @@ body 10 mm</description>
 <rectangle x1="11.665" y1="-5.7799" x2="12.465" y2="-5.2701" layer="51"/>
 <rectangle x1="12.935" y1="-5.7799" x2="13.735" y2="-5.2701" layer="51"/>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -5613,7 +5613,7 @@ body 10 mm</description>
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -5643,7 +5643,7 @@ body 10 mm</description>
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -5675,7 +5675,7 @@ body 10 mm</description>
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-32">
+<package name="DIP-32-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="20.32" y1="5.715" x2="-20.32" y2="5.715" width="0.2032" layer="21"/>
@@ -5719,7 +5719,7 @@ body 10 mm</description>
 <text x="-20.955" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-17.145" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -5771,7 +5771,7 @@ body 10 mm</description>
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-48">
+<package name="DIP-48-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-29.845" y1="-5.715" x2="29.845" y2="-5.715" width="0.2032" layer="21"/>
@@ -5831,7 +5831,7 @@ body 10 mm</description>
 <text x="-30.48" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -5871,7 +5871,7 @@ body 10 mm</description>
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-400-28">
+<package name="DIP-28-254P-1016W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 400 mil row spacing, JEDEC MS-010C</description>
 <wire x1="17.78" y1="3.175" x2="-17.78" y2="3.175" width="0.2032" layer="21"/>
@@ -5911,7 +5911,7 @@ body 10 mm</description>
 <text x="-18.415" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -5947,7 +5947,7 @@ body 10 mm</description>
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -5987,7 +5987,7 @@ body 10 mm</description>
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-22">
+<package name="DIP-22-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="-14.605" y1="-0.635" x2="-14.605" y2="-1.905" width="0.2032" layer="21"/>
@@ -13546,7 +13546,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="9"/>
@@ -13618,7 +13618,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="9"/>
@@ -13654,7 +13654,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="9"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -13726,7 +13726,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="9"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -13762,7 +13762,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -13846,7 +13846,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -13886,7 +13886,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="18"/>
 <connect gate="G$1" pin="!OE!" pad="20"/>
@@ -13926,7 +13926,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="18"/>
 <connect gate="G$1" pin="!OE!" pad="20"/>
@@ -14097,7 +14097,7 @@ body 10 mm</description>
 <gate name="G$1" symbol="100490" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!WE!" pad="19"/>
@@ -14134,7 +14134,7 @@ body 10 mm</description>
 <gate name="G$1" symbol="100490SO" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="22"/>
 <connect gate="G$1" pin="!WE!" pad="21"/>
@@ -14174,7 +14174,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="10"/>
 <connect gate="G$1" pin="!WE!" pad="12"/>
@@ -14212,7 +14212,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="10"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -14252,7 +14252,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="10"/>
 <connect gate="G$1" pin="!OE!" pad="11"/>
@@ -14376,7 +14376,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="10"/>
 <connect gate="G$1" pin="!CS2!" pad="18"/>
@@ -14416,7 +14416,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="10"/>
 <connect gate="G$1" pin="!CS2!" pad="18"/>
@@ -14500,7 +14500,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="12"/>
 <connect gate="G$1" pin="!CS2!" pad="15"/>
@@ -14544,7 +14544,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-400-28">
+<device name="" package="DIP-28-254P-1016W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="12"/>
 <connect gate="G$1" pin="!CS2!" pad="15"/>
@@ -14632,7 +14632,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -14676,7 +14676,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -14720,7 +14720,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -14856,7 +14856,7 @@ body 10 mm</description>
 <gate name="P" symbol="2VCC2GND" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="2"/>
 <connect gate="G$1" pin="!LB!" pad="37"/>
@@ -14912,7 +14912,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="13"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -14952,7 +14952,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="13"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -14992,7 +14992,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -15032,7 +15032,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -15072,7 +15072,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="12"/>
 <connect gate="G$1" pin="!OE!" pad="13"/>
@@ -15116,7 +15116,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="13"/>
 <connect gate="G$1" pin="!WE!" pad="15"/>
@@ -15160,7 +15160,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15204,7 +15204,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15296,7 +15296,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="15"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -15340,7 +15340,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="12"/>
 <connect gate="G$1" pin="!OE!" pad="13"/>
@@ -15384,7 +15384,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -15432,7 +15432,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="17"/>
 <connect gate="G$1" pin="!OE!" pad="9"/>
@@ -15470,7 +15470,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15514,7 +15514,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15558,7 +15558,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15602,7 +15602,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15646,7 +15646,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15690,7 +15690,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15782,7 +15782,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15826,7 +15826,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15870,7 +15870,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15962,7 +15962,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="14"/>
 <connect gate="G$1" pin="!OE!" pad="13"/>
@@ -16002,7 +16002,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="14"/>
 <connect gate="G$1" pin="!OE!" pad="13"/>
@@ -16086,7 +16086,7 @@ body 10 mm</description>
 <gate name="P" symbol="2VCC4GND" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS0!" pad="45"/>
 <connect gate="G$1" pin="!CS1!" pad="46"/>
@@ -16150,7 +16150,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0L" pad="6"/>
 <connect gate="G$1" pin="A0R" pad="42"/>
@@ -16346,7 +16346,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0L" pad="6"/>
 <connect gate="G$1" pin="A0R" pad="42"/>
@@ -16610,7 +16610,7 @@ body 10 mm</description>
 <gate name="G$1" symbol="71322" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0L" pad="6"/>
 <connect gate="G$1" pin="A0R" pad="42"/>
@@ -16910,7 +16910,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-27.94" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0L" pad="6"/>
 <connect gate="G$1" pin="A0R" pad="42"/>
@@ -17110,7 +17110,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!EF!" pad="21"/>
 <connect gate="G$1" pin="!FF!" pad="8"/>
@@ -17250,7 +17250,7 @@ body 10 mm</description>
 <gate name="G$1" symbol="7202" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!EF!" pad="21"/>
 <connect gate="G$1" pin="!FF!" pad="8"/>
@@ -17390,7 +17390,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!EF!" pad="21"/>
 <connect gate="G$1" pin="!FF!" pad="8"/>
@@ -17482,7 +17482,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!AEF!" pad="2"/>
 <connect gate="G$1" pin="!EF!" pad="17"/>
@@ -17598,7 +17598,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="9"/>
 <connect gate="G$1" pin="D0" pad="4"/>
@@ -17630,7 +17630,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="9"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -17734,7 +17734,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="10"/>
 <connect gate="G$1" pin="D0" pad="4"/>
@@ -17768,7 +17768,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="10"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -17802,7 +17802,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="10"/>
 <connect gate="G$1" pin="D0" pad="4"/>
@@ -17908,7 +17908,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="11"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -17944,7 +17944,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="11"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -17980,7 +17980,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="9"/>
 <connect gate="G$1" pin="D0" pad="4"/>
@@ -18012,7 +18012,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="9"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -18044,7 +18044,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="10"/>
 <connect gate="G$1" pin="D0" pad="4"/>
@@ -18078,7 +18078,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="10"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -18112,7 +18112,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-900-64">
+<device name="" package="DIP-64-254P-2286W">
 <connects>
 <connect gate="G$1" pin="ACC" pad="6"/>
 <connect gate="G$1" pin="CLKP" pad="23"/>
@@ -18276,7 +18276,7 @@ body 10 mm</description>
 <gate name="P" symbol="3VCC2GND" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-900-64">
+<device name="" package="DIP-64-254P-2286W">
 <connects>
 <connect gate="G$1" pin="!OEL!" pad="21"/>
 <connect gate="G$1" pin="!OEM!" pad="22"/>
@@ -18356,7 +18356,7 @@ body 10 mm</description>
 <gate name="P" symbol="3VCC2GND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-900-64">
+<device name="" package="DIP-64-254P-2286W">
 <connects>
 <connect gate="G$1" pin="!ENP!" pad="28"/>
 <connect gate="G$1" pin="!ENX!" pad="60"/>
@@ -18848,7 +18848,7 @@ body 10 mm</description>
 <gate name="P" symbol="2VCC2GND" x="-35.56" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-900-64">
+<device name="" package="DIP-64-254P-2286W">
 <connects>
 <connect gate="G$1" pin="!MSPSEL!" pad="45"/>
 <connect gate="G$1" pin="!OEL!" pad="6"/>
@@ -18928,7 +18928,7 @@ body 10 mm</description>
 <gate name="P" symbol="2VCC2GND" x="-33.02" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-900-64">
+<device name="" package="DIP-64-254P-2286W">
 <connects>
 <connect gate="G$1" pin="!ENP!" pad="41"/>
 <connect gate="G$1" pin="!ENX!" pad="53"/>
@@ -19680,7 +19680,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!G!" pad="32"/>
 <connect gate="G$1" pin="!OE!" pad="40"/>
@@ -19796,7 +19796,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!G!" pad="10"/>
 <connect gate="G$1" pin="!G0!" pad="3"/>
@@ -19864,7 +19864,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!EA!" pad="2"/>
 <connect gate="G$1" pin="!G!/N" pad="14"/>
@@ -19996,7 +19996,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-30.48" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!FE!" pad="25"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -20084,7 +20084,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!FE!" pad="19"/>
 <connect gate="G$1" pin="!OE!" pad="16"/>
@@ -20156,7 +20156,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CC!" pad="14"/>
 <connect gate="G$1" pin="!CCEN!" pad="13"/>
@@ -20272,7 +20272,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!EA!" pad="2"/>
 <connect gate="G$1" pin="!G!/N" pad="14"/>
@@ -20404,7 +20404,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A#LO" pad="8"/>
 <connect gate="G$1" pin="A0" pad="24"/>
@@ -20448,7 +20448,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="A#LO" pad="8"/>
 <connect gate="G$1" pin="A0" pad="24"/>
@@ -20536,7 +20536,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!WE!/BLE" pad="9"/>
 <connect gate="G$1" pin="A0" pad="24"/>
@@ -20580,7 +20580,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!WE!/BLE" pad="9"/>
 <connect gate="G$1" pin="A0" pad="24"/>
@@ -20668,7 +20668,7 @@ body 10 mm</description>
 <gate name="P" symbol="2VCC2GND" x="-27.94" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!HALT!" pad="18"/>
 <connect gate="G$1" pin="!INIT!" pad="22"/>
@@ -20752,7 +20752,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-30.48" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-900-64">
+<device name="" package="DIP-64-254P-2286W">
 <connects>
 <connect gate="G$1" pin="!G!/F15" pad="33"/>
 <connect gate="G$1" pin="!OE!" pad="47"/>
@@ -21208,7 +21208,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-33.02" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CC!" pad="16"/>
 <connect gate="G$1" pin="!CCEN!" pad="15"/>
@@ -21272,7 +21272,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CC!" pad="16"/>
 <connect gate="G$1" pin="!CCEN!" pad="15"/>
@@ -21400,7 +21400,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!ERROR!" pad="32"/>
 <connect gate="G$1" pin="!GENERATE!" pad="42"/>
@@ -21848,7 +21848,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CEA!" pad="11"/>
 <connect gate="G$1" pin="!CEB!" pad="13"/>
@@ -21932,7 +21932,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="13"/>
 <connect gate="G$1" pin="CLK" pad="11"/>
@@ -21972,7 +21972,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="13"/>
 <connect gate="G$1" pin="CLK" pad="11"/>
@@ -22056,7 +22056,7 @@ body 10 mm</description>
 <gate name="P" symbol="1VCC3GND" x="-22.86" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!DOE!" pad="24"/>
@@ -22188,7 +22188,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="C/!D!" pad="23"/>
 <connect gate="G$1" pin="D0" pad="10"/>
@@ -22228,7 +22228,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C/!D!" pad="23"/>
 <connect gate="G$1" pin="D0" pad="10"/>
@@ -22312,7 +22312,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0A" pad="2"/>
 <connect gate="G$1" pin="A0B" pad="14"/>
@@ -22344,7 +22344,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0A" pad="2"/>
 <connect gate="G$1" pin="A0B" pad="14"/>
@@ -22412,7 +22412,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="1"/>
 <connect gate="G$1" pin="!PE!" pad="9"/>
@@ -22444,7 +22444,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="1"/>
 <connect gate="G$1" pin="!PE!" pad="9"/>
@@ -22476,7 +22476,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!PE!" pad="9"/>
 <connect gate="G$1" pin="!SR!" pad="1"/>
@@ -22508,7 +22508,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!PE!" pad="9"/>
 <connect gate="G$1" pin="!SR!" pad="1"/>
@@ -22612,7 +22612,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!G!" pad="10"/>
 <connect gate="G$1" pin="!P!" pad="7"/>
@@ -22644,7 +22644,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!G!" pad="10"/>
 <connect gate="G$1" pin="!P!" pad="7"/>
@@ -22712,7 +22712,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!PL!" pad="11"/>
 <connect gate="G$1" pin="CPD" pad="4"/>
@@ -22744,7 +22744,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!PL!" pad="11"/>
 <connect gate="G$1" pin="CPD" pad="4"/>
@@ -22848,7 +22848,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="DA0" pad="2"/>
 <connect gate="G$1" pin="DA1" pad="4"/>
@@ -22920,7 +22920,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="DA0" pad="2"/>
 <connect gate="G$1" pin="DA1" pad="4"/>
@@ -22992,7 +22992,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="DA0" pad="2"/>
 <connect gate="G$1" pin="DA1" pad="4"/>
@@ -23064,7 +23064,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="19"/>
 <connect gate="G$1" pin="A0" pad="2"/>
@@ -23136,7 +23136,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="19"/>
 <connect gate="G$1" pin="A0" pad="2"/>
@@ -23172,7 +23172,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -23208,7 +23208,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -23280,7 +23280,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="9"/>
 <connect gate="G$1" pin="CP" pad="12"/>
@@ -23316,7 +23316,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="9"/>
 <connect gate="G$1" pin="CP" pad="12"/>
@@ -23388,7 +23388,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="D0" pad="3"/>
@@ -23424,7 +23424,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="D0" pad="3"/>
@@ -23496,7 +23496,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -23532,7 +23532,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -23604,7 +23604,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -23640,7 +23640,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -23712,7 +23712,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="CP" pad="9"/>
 <connect gate="G$1" pin="I0A" pad="3"/>
@@ -23744,7 +23744,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CP" pad="9"/>
 <connect gate="G$1" pin="I0A" pad="3"/>
@@ -23812,7 +23812,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -23848,7 +23848,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -23920,7 +23920,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="D0" pad="3"/>
@@ -23956,7 +23956,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-17.78" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="D0" pad="3"/>
@@ -24028,7 +24028,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -24064,7 +24064,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -24136,7 +24136,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="D0" pad="2"/>
 <connect gate="G$1" pin="D1" pad="3"/>
@@ -24172,7 +24172,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="D0" pad="2"/>
 <connect gate="G$1" pin="D1" pad="3"/>
@@ -24244,7 +24244,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="D0" pad="2"/>
 <connect gate="G$1" pin="D1" pad="3"/>
@@ -24280,7 +24280,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="D0" pad="2"/>
 <connect gate="G$1" pin="D1" pad="3"/>
@@ -24352,7 +24352,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CEAB!" pad="11"/>
 <connect gate="G$1" pin="!CEBA!" pad="23"/>
@@ -24392,7 +24392,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CEAB!" pad="11"/>
 <connect gate="G$1" pin="!CEBA!" pad="23"/>
@@ -24476,7 +24476,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="D0" pad="2"/>
@@ -24512,7 +24512,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="D0" pad="2"/>
@@ -24584,7 +24584,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -24620,7 +24620,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -24692,7 +24692,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="19"/>
 <connect gate="G$1" pin="A0" pad="2"/>
@@ -24728,7 +24728,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="19"/>
 <connect gate="G$1" pin="A0" pad="2"/>
@@ -24800,7 +24800,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="19"/>
 <connect gate="G$1" pin="A0" pad="2"/>
@@ -24836,7 +24836,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="19"/>
 <connect gate="G$1" pin="A0" pad="2"/>
@@ -24908,7 +24908,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!G!" pad="21"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -24948,7 +24948,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!G!" pad="21"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -25032,7 +25032,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!GBA!" pad="21"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -25072,7 +25072,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!GBA!" pad="21"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -25156,7 +25156,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="13"/>
@@ -25196,7 +25196,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="13"/>
@@ -25280,7 +25280,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!EN!" pad="14"/>
@@ -25320,7 +25320,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!EN!" pad="14"/>
@@ -25404,7 +25404,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!EN!" pad="14"/>
@@ -25444,7 +25444,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!EN!" pad="14"/>
@@ -25528,7 +25528,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="D0" pad="2"/>
 <connect gate="G$1" pin="D1" pad="3"/>
@@ -25568,7 +25568,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="D0" pad="2"/>
 <connect gate="G$1" pin="D1" pad="3"/>
@@ -25652,7 +25652,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!ERR!" pad="10"/>
@@ -25692,7 +25692,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!ERR!" pad="10"/>
@@ -25732,7 +25732,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!EN!" pad="13"/>
@@ -25772,7 +25772,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!EN!" pad="13"/>
@@ -25900,7 +25900,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="D0" pad="2"/>
@@ -25940,7 +25940,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="D0" pad="2"/>
@@ -25980,7 +25980,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -26020,7 +26020,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -26060,7 +26060,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!PRE!" pad="14"/>
@@ -26100,7 +26100,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!PRE!" pad="14"/>
@@ -26272,7 +26272,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!OER!" pad="1"/>
 <connect gate="G$1" pin="!OET!" pad="13"/>
@@ -26312,7 +26312,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OER!" pad="1"/>
 <connect gate="G$1" pin="!OET!" pad="13"/>
@@ -26352,7 +26352,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="OER#1" pad="1"/>
 <connect gate="G$1" pin="OER#2" pad="11"/>
@@ -26392,7 +26392,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="OER#1" pad="1"/>
 <connect gate="G$1" pin="OER#2" pad="11"/>
@@ -26520,7 +26520,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -26588,7 +26588,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0A" pad="2"/>
 <connect gate="G$1" pin="A0B" pad="14"/>
@@ -26656,7 +26656,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="4"/>
 <connect gate="G$1" pin="!PL!" pad="11"/>
@@ -26723,7 +26723,7 @@ body 10 mm</description>
 <gate name="G$1" symbol="75C18" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CONV!" pad="7"/>
 <connect gate="G$1" pin="AGND" pad="17"/>
@@ -26805,7 +26805,7 @@ body 10 mm</description>
 <gate name="G$1" symbol="75C19" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CONV!" pad="7"/>
 <connect gate="G$1" pin="AGND" pad="17"/>
@@ -26887,7 +26887,7 @@ body 10 mm</description>
 <gate name="G$1" symbol="75MB38" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="BLANK" pad="4"/>
 <connect gate="G$1" pin="CONV" pad="13"/>
@@ -26942,7 +26942,7 @@ body 10 mm</description>
 <gate name="G$1" symbol="75C48" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="19"/>
 <connect gate="G$1" pin="AGND@1" pad="25"/>
@@ -27028,7 +27028,7 @@ body 10 mm</description>
 <gate name="G$1" symbol="75C58" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="20"/>
 <connect gate="G$1" pin="AGND@1" pad="25"/>
@@ -27115,7 +27115,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="18"/>
 <connect gate="G$1" pin="!OE!" pad="20"/>
@@ -27203,7 +27203,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="21"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -27295,7 +27295,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -27339,7 +27339,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -27431,7 +27431,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!INIT!" pad="1"/>

--- a/memory-intel.lbr
+++ b/memory-intel.lbr
@@ -77,7 +77,7 @@ SDRAM, Flash, etc&lt;p&gt;
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SSOP-50P-1840W-1400L-120H-80F-56">
+<package name="SSOP-56-50P-1840W-1400L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 14.0mm length, 18.4mm width, 1.20mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 14.0mm length, 18.4mm width, 1.20mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation EC, R-PDSO-G.&lt;/p&gt;
@@ -474,7 +474,7 @@ JEDEC MO-142D, variation EC, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="28F128" x="0" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1400L-120H-80F-56">
+<device name="" package="SSOP-56-50P-1840W-1400L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!BYTE!" pad="31"/>
 <connect gate="G$1" pin="!OE!" pad="54"/>
@@ -546,7 +546,7 @@ JEDEC MO-142D, variation EC, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="28FXXXP30" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1400L-120H-80F-56">
+<device name="" package="SSOP-56-50P-1840W-1400L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!ADV!" pad="46"/>
 <connect gate="G$1" pin="!CE!" pad="30"/>
@@ -618,7 +618,7 @@ JEDEC MO-142D, variation EC, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="28FXXX" x="0" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1400L-120H-80F-56">
+<device name="" package="SSOP-56-50P-1840W-1400L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!BYTE!" pad="31"/>
 <connect gate="G$1" pin="!OE!" pad="54"/>
@@ -690,7 +690,7 @@ JEDEC MO-142D, variation EC, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="28FXXXJ3D" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1400L-120H-80F-56">
+<device name="" package="SSOP-56-50P-1840W-1400L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!BYTE!" pad="31"/>
 <connect gate="G$1" pin="!OE!" pad="54"/>

--- a/memory-issi.lbr
+++ b/memory-issi.lbr
@@ -75,7 +75,7 @@
 &lt;p&gt;THIS LIBRARY IS PROVIDED AS IS AND WITHOUT WARRANTY OF ANY KIND, EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2015, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SOP-127P-530W-530L-210H-125F-8">
+<package name="SOP-8-127P-530W-530L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -108,7 +108,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="2.625" y1="-2.625" x2="-2.625" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="2.625" x2="-2.625" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -399,7 +399,7 @@ body 2.00 x 3.00 mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JB" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="JB" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!(IO3)" pad="7"/>
@@ -414,7 +414,7 @@ body 2.00 x 3.00 mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="JN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!(IO3)" pad="7"/>

--- a/memory-microchip.lbr
+++ b/memory-microchip.lbr
@@ -76,7 +76,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2010, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SSOP-65P-440W-300L-120H-100F-8">
+<package name="SSOP-8-65P-440W-300L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -105,7 +105,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <wire x1="1.4" y1="-2.1" x2="1.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="2.1" x2="-1.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -125,7 +125,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -159,7 +159,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -272,7 +272,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="MS" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MS" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -287,7 +287,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="ST" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="ST" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -302,7 +302,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -317,7 +317,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -340,7 +340,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <gate name="G$1" symbol="24XX1025" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SM" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SM" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>

--- a/memory-micron.lbr
+++ b/memory-micron.lbr
@@ -145,7 +145,7 @@
 <text x="-11.7475" y="-5.08" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-2.2225" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SSOP-50P-1840W-1200L-120H-80F-48">
+<package name="SSOP-48-50P-1840W-1200L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
@@ -377,7 +377,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <vertex x="-4" y="3.5"/>
 </polygon>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -765,7 +765,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <gate name="G$1" symbol="MT29F2G16AADWPD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="SSOP-50P-1840W-1200L-120H-80F-48">
+<device name="N" package="SSOP-48-50P-1840W-1200L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="9"/>
 <connect gate="G$1" pin="!RE!" pad="8"/>
@@ -968,7 +968,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <gate name="G$1" symbol="MP25P20" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
@@ -991,7 +991,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <gate name="G$1" symbol="M25P16" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
 <connect gate="G$1" pin="!S!" pad="1"/>

--- a/memory-nec.lbr
+++ b/memory-nec.lbr
@@ -74,7 +74,7 @@
 <description>&lt;b&gt;NEC Memories&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -102,7 +102,7 @@
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -132,7 +132,7 @@
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -164,7 +164,7 @@
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-32">
+<package name="DIP-32-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="20.32" y1="5.715" x2="-20.32" y2="5.715" width="0.2032" layer="21"/>
@@ -208,7 +208,7 @@
 <text x="-20.955" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-17.145" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -260,7 +260,7 @@
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -300,7 +300,7 @@
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -340,7 +340,7 @@
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -376,7 +376,7 @@
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-22">
+<package name="DIP-22-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="-14.605" y1="-0.635" x2="-14.605" y2="-1.905" width="0.2032" layer="21"/>
@@ -410,7 +410,7 @@
 <text x="-15.24" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.795" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -1353,7 +1353,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="41256" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CAS!" pad="15"/>
 <connect gate="G$1" pin="!RAS!" pad="4"/>
@@ -1384,7 +1384,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="41464" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CAS!" pad="16"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -1417,7 +1417,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="421000" x="2.54" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CAS!" pad="16"/>
 <connect gate="G$1" pin="!RAS!" pad="3"/>
@@ -1450,7 +1450,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="421001" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CAS!" pad="16"/>
 <connect gate="G$1" pin="!RAS!" pad="3"/>
@@ -1483,7 +1483,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="421002" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="16"/>
 <connect gate="G$1" pin="!RAS!" pad="3"/>
@@ -1516,7 +1516,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="424256" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CAS!" pad="17"/>
 <connect gate="G$1" pin="!OE!" pad="16"/>
@@ -1551,7 +1551,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="424258" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="17"/>
 <connect gate="G$1" pin="!OE!" pad="16"/>
@@ -1586,7 +1586,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4361" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="12"/>
 <connect gate="G$1" pin="!WE!" pad="10"/>
@@ -1623,7 +1623,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4362" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="10"/>
 <connect gate="G$1" pin="!WE!" pad="12"/>
@@ -1660,7 +1660,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4364" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -1703,7 +1703,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4364CX" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CE1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -1746,7 +1746,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4464" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -1789,7 +1789,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4464" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -1832,7 +1832,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4168" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -1875,7 +1875,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="43251" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="13"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -1914,7 +1914,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="43254" x="0" y="12.7"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -1953,7 +1953,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="43256" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -1996,7 +1996,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="43256" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -2039,7 +2039,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="43257" x="0" y="10.16"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE1!" pad="20"/>
 <connect gate="G$1" pin="!WE!" pad="27"/>
@@ -2082,7 +2082,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="431000" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE1!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -2129,7 +2129,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4311" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="9"/>
@@ -2164,7 +2164,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4314" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="9"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -2199,7 +2199,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="27512" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!/VPP" pad="22"/>
@@ -2242,7 +2242,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="2864" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -2285,7 +2285,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="27C1000A" x="-2.54" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="2"/>
@@ -2332,7 +2332,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="27C1000A" x="-2.54" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -2379,7 +2379,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="27C1024D" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="2"/>
 <connect gate="G$1" pin="!OE!" pad="20"/>
@@ -2434,7 +2434,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="27C2001" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -2481,7 +2481,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="27C4001" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>

--- a/memory-numonyx.lbr
+++ b/memory-numonyx.lbr
@@ -75,7 +75,7 @@
 &lt;p&gt;THIS LIBRARY IS PROVIDED AS IS AND WITHOUT WARRANTY OF ANY KIND, EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2009, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SSOP-50P-1840W-1200L-120H-80F-48">
+<package name="SSOP-48-50P-1840W-1200L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
@@ -184,7 +184,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.9" y1="-9.1" x2="5.9" y2="9.1" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="9.1" x2="-5.9" y2="9.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -300,7 +300,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <gate name="G$1" symbol="NAND128W3A2B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="SSOP-50P-1840W-1200L-120H-80F-48">
+<device name="N" package="SSOP-48-50P-1840W-1200L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!E!" pad="9"/>
 <connect gate="G$1" pin="!R!" pad="8"/>
@@ -365,7 +365,7 @@ with byte alterability, 75 MHz SPI bus, standard pinout</description>
 <gate name="G$1" symbol="M25PEXX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="MN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="MN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!RST!" pad="7"/>

--- a/memory-nxp.lbr
+++ b/memory-nxp.lbr
@@ -78,7 +78,7 @@ SDRAM, Flash, etc&lt;p&gt;
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2013, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -112,7 +112,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -166,7 +166,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <gate name="G$1" symbol="PCA24S08" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!PROT!" pad="3"/>
 <connect gate="G$1" pin="!WP!" pad="7"/>
@@ -179,7 +179,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="DP" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="DP" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!PROT!" pad="3"/>
 <connect gate="G$1" pin="!WP!" pad="7"/>

--- a/memory-samsung.lbr
+++ b/memory-samsung.lbr
@@ -262,7 +262,7 @@ Small outline package J-lead. Lead pitch 1.27mm, body width 400mil/10.15mm. 36 l
 <text x="-11.7475" y="-5.08" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-2.2225" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SSOP-50P-1840W-1200L-120H-80F-48">
+<package name="SSOP-48-50P-1840W-1200L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
@@ -884,7 +884,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="K6F1616T6B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-TF" package="SSOP-50P-1840W-1200L-120H-80F-48">
+<device name="-TF" package="SSOP-48-50P-1840W-1200L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="26"/>
 <connect gate="G$1" pin="!LB!" pad="15"/>

--- a/memory-spansion.lbr
+++ b/memory-spansion.lbr
@@ -73,7 +73,7 @@
 <library>
 <description>Spansion Inc Memory Devices</description>
 <packages>
-<package name="SOP-127P-530W-530L-210H-125F-8">
+<package name="SOP-8-127P-530W-530L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -127,7 +127,7 @@ body 6.00 x 5.00 mm</description>
 <text x="4.1275" y="-2.81" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 <smd name="9" x="0" y="0" dx="4" dy="3.4" layer="1"/>
 </package>
-<package name="SSOP-50P-1840W-1200L-120H-80F-48">
+<package name="SSOP-48-50P-1840W-1200L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
@@ -317,7 +317,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="S25F" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!WP!/IO2" pad="3"/>
@@ -340,7 +340,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="S29AL016J" x="0" y="0"/>
 </gates>
 <devices>
-<device name="F" package="SSOP-50P-1840W-1200L-120H-80F-48">
+<device name="F" package="SSOP-48-50P-1840W-1200L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!BYTE!" pad="47"/>
 <connect gate="G$1" pin="!CE!" pad="26"/>

--- a/memory-sram.lbr
+++ b/memory-sram.lbr
@@ -581,7 +581,7 @@ Small outline package J-lead. Lead pitch 1.27mm, body width 400mil/10.15mm. 28 l
 <wire x1="9.3100" y1="4.9780" x2="9.3100" y2="-4.9780" width="0.2032" layer="21"/>
 <wire x1="9.3100" y1="4.9780" x2="8.8650" y2="4.9780" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-840W-1790L-254H-180F-28">
+<package name="SOP-28-127P-840W-1790L-254H-180F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
 8.40mm body width, 2.54mm max height, 28 leads.
@@ -719,7 +719,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body l
 <rectangle x1="2.9" y1="-6.85" x2="3.15" y2="-5.85" layer="51" rot="R180"/>
 <rectangle x1="3.45" y1="-6.85" x2="3.7" y2="-5.85" layer="51" rot="R180"/>
 </package>
-<package name="DIP-400-22">
+<package name="DIP-22-254P-1016W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 400 mil row spacing, JEDEC MS-010C</description>
 <wire x1="13.97" y1="2.8575" x2="-13.97" y2="2.8575" width="0.2032" layer="21"/>
@@ -2343,7 +2343,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body l
 <gate name="P" symbol="PWRN" x="-30.48" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-400-22">
+<device name="" package="DIP-22-254P-1016W">
 <connects>
 <connect gate="G$1" pin="!E!" pad="10"/>
 <connect gate="G$1" pin="!W!" pad="12"/>
@@ -2420,7 +2420,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body l
 <gate name="G$1" symbol="LH52256" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>

--- a/memory-sst.lbr
+++ b/memory-sst.lbr
@@ -73,7 +73,7 @@
 <library>
 <description>SST Memory Devices</description>
 <packages>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -107,7 +107,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -263,7 +263,7 @@ body 8.00 x 6.00 mm</description>
 <gate name="G$1" symbol="25XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-S2A" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="-S2A" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
@@ -287,7 +287,7 @@ body 8.00 x 6.00 mm</description>
 <gate name="G$1" symbol="25VF" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-S3" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="-S3" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="1"/>
 <connect gate="G$1" pin="!RST!/!HOLD!" pad="7"/>
@@ -302,7 +302,7 @@ body 8.00 x 6.00 mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-S" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="-S" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="7"/>
 <connect gate="G$1" pin="!RST!/!HOLD!" pad="1"/>
@@ -356,7 +356,7 @@ Serial Quad I/O (SQI) Flash Memory</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S2" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S2" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="1"/>
 <connect gate="G$1" pin="SCK" pad="6"/>

--- a/memory-winbond.lbr
+++ b/memory-winbond.lbr
@@ -75,7 +75,7 @@
 &lt;p&gt;THIS LIBRARY IS PROVIDED AS IS AND WITHOUT WARRANTY OF ANY KIND, EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2010, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -136,7 +136,7 @@ body 6.00 x 5.00 mm</description>
 <smd name="9" x="0" y="0" dx="4.3" dy="3.4" layer="1"/>
 <rectangle x1="-3.2" y1="-3.1" x2="-2.7" y2="-2.6" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -258,7 +258,7 @@ body 2.00 x 3.00 mm</description>
 <gate name="G$1" symbol="25XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SS" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SS" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
@@ -273,7 +273,7 @@ body 2.00 x 3.00 mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
@@ -288,7 +288,7 @@ body 2.00 x 3.00 mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DA" package="DIP-300-8">
+<device name="DA" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
@@ -405,7 +405,7 @@ SPI Serial Flash, 4KB Sectors</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!/IO3" pad="7"/>
@@ -420,7 +420,7 @@ SPI Serial Flash, 4KB Sectors</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SS" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SS" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!/IO3" pad="7"/>

--- a/memory.lbr
+++ b/memory.lbr
@@ -74,7 +74,7 @@
 <description>&lt;b&gt;Generic Memories&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="SSOP-50P-1840W-800L-120H-80F-32">
+<package name="SSOP-32-50P-1840W-800L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 8.0mm length, 18.4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 8.0mm length, 18.4mm width, 1.20mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation BD, R-PDSO-G.&lt;/p&gt;
@@ -228,7 +228,7 @@ JEDEC MO-142D, variation BD, R-PDSO-G.&lt;/p&gt;
 <rectangle x1="-8.5" y1="5.616" x2="-8.01" y2="7.136" layer="51"/>
 <rectangle x1="-9.77" y1="5.616" x2="-9.28" y2="7.136" layer="51"/>
 </package>
-<package name="SSOP-50P-1840W-1200L-120H-80F-48">
+<package name="SSOP-48-50P-1840W-1200L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
@@ -337,7 +337,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.9" y1="-9.1" x2="5.9" y2="9.1" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="9.1" x2="-5.9" y2="9.1" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -365,7 +365,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -395,7 +395,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -427,7 +427,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -463,7 +463,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -503,7 +503,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-32">
+<package name="DIP-32-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="20.32" y1="5.715" x2="-20.32" y2="5.715" width="0.2032" layer="21"/>
@@ -547,7 +547,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <text x="-20.955" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-17.145" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -599,7 +599,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-48">
+<package name="DIP-48-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-29.845" y1="-5.715" x2="29.845" y2="-5.715" width="0.2032" layer="21"/>
@@ -659,7 +659,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <text x="-30.48" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-22">
+<package name="DIP-22-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="-14.605" y1="-0.635" x2="-14.605" y2="-1.905" width="0.2032" layer="21"/>
@@ -693,7 +693,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <text x="-15.24" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.795" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-890W-1790L-265H-155F-28">
+<package name="SOP-28-127P-890W-1790L-265H-155F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 17.90mm length, 8.90mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body length,
 8.90mm body width, 2.65mm max height, 28 leads.
@@ -2714,7 +2714,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="!CS!" pad="10"/>
 <connect gate="A" pin="!WE!" pad="8"/>
@@ -2748,7 +2748,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="5"/>
 <connect gate="A" pin="A1" pad="6"/>
@@ -2782,7 +2782,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="5"/>
 <connect gate="A" pin="A1" pad="6"/>
@@ -2816,7 +2816,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CS!" pad="11"/>
 <connect gate="A" pin="!WE!" pad="9"/>
@@ -2852,7 +2852,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CS!" pad="9"/>
 <connect gate="A" pin="!WE!" pad="11"/>
@@ -2888,7 +2888,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="12"/>
 <connect gate="A" pin="!WE!" pad="10"/>
@@ -2926,7 +2926,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="15"/>
 <connect gate="A" pin="A0" pad="1"/>
@@ -2962,7 +2962,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="8"/>
 <connect gate="A" pin="A1" pad="7"/>
@@ -3001,7 +3001,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="8"/>
 <connect gate="A" pin="A1" pad="7"/>
@@ -3040,7 +3040,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="18"/>
 <connect gate="A" pin="!OE!" pad="20"/>
@@ -3080,7 +3080,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CS1!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -3123,7 +3123,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="!CS!" pad="8"/>
 <connect gate="A" pin="!WE!" pad="10"/>
@@ -3157,7 +3157,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CS!" pad="1"/>
 <connect gate="A" pin="!WE!" pad="14"/>
@@ -3189,7 +3189,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CS!" pad="1"/>
 <connect gate="A" pin="!WE!" pad="14"/>
@@ -3221,7 +3221,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="A" pin="A0L" pad="6"/>
 <connect gate="A" pin="A0R" pad="42"/>
@@ -3284,7 +3284,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="A" symbol="2164" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CAS!" pad="15"/>
 <connect gate="A" pin="!RAS!" pad="4"/>
@@ -3315,7 +3315,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -3358,7 +3358,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -3401,7 +3401,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="5"/>
 <connect gate="A" pin="A1" pad="6"/>
@@ -3433,7 +3433,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="5"/>
 <connect gate="A" pin="A1" pad="6"/>
@@ -3465,7 +3465,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="10"/>
 <connect gate="A" pin="A0" pad="5"/>
@@ -3498,7 +3498,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="A" symbol="2620" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="!CAS!" pad="16"/>
 <connect gate="A" pin="!OE!" pad="1"/>
@@ -3532,7 +3532,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -3576,7 +3576,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="13"/>
 <connect gate="A" pin="A0" pad="5"/>
@@ -3608,7 +3608,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="18"/>
 <connect gate="A" pin="!OE!" pad="20"/>
@@ -3648,7 +3648,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="15"/>
 <connect gate="A" pin="A0" pad="10"/>
@@ -3680,7 +3680,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="15"/>
 <connect gate="A" pin="A0" pad="10"/>
@@ -3712,7 +3712,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="18"/>
 <connect gate="A" pin="!OE!/VPP" pad="20"/>
@@ -3752,7 +3752,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CS1!" pad="15"/>
 <connect gate="A" pin="!CS2!" pad="16"/>
@@ -3788,7 +3788,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CS1!" pad="15"/>
 <connect gate="A" pin="!CS2!" pad="16"/>
@@ -3824,7 +3824,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CS1!" pad="20"/>
 <connect gate="A" pin="A0" pad="8"/>
@@ -3864,7 +3864,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -3907,7 +3907,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="18"/>
 <connect gate="A" pin="!OE!" pad="20"/>
@@ -3947,7 +3947,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -3988,7 +3988,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -4031,7 +4031,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CS1!" pad="21"/>
 <connect gate="A" pin="!CS2!" pad="20"/>
@@ -4071,7 +4071,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CS1!" pad="20"/>
 <connect gate="A" pin="A0" pad="8"/>
@@ -4110,7 +4110,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="A" symbol="4161" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CAS!" pad="17"/>
 <connect gate="A" pin="!RAS!" pad="6"/>
@@ -4145,7 +4145,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="G$1" symbol="4256" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CAS!" pad="15"/>
 <connect gate="G$1" pin="!RAS!" pad="4"/>
@@ -4177,7 +4177,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CC!" pad="1"/>
 <connect gate="A" pin="!CE!" pad="20"/>
@@ -4220,7 +4220,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -4264,7 +4264,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CS!" pad="9"/>
 <connect gate="A" pin="!WE!" pad="11"/>
@@ -4300,7 +4300,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CC!" pad="1"/>
 <connect gate="A" pin="!CE!" pad="20"/>
@@ -4342,7 +4342,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="13"/>
 <connect gate="A" pin="A0" pad="5"/>
@@ -4374,7 +4374,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CS1!" pad="21"/>
 <connect gate="A" pin="!CS2!" pad="20"/>
@@ -4414,7 +4414,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CS1!" pad="20"/>
 <connect gate="A" pin="A0" pad="8"/>
@@ -4454,7 +4454,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE1!" pad="20"/>
 <connect gate="A" pin="!CE2!" pad="18"/>
@@ -4494,7 +4494,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="9"/>
 <connect gate="A" pin="!WE!" pad="11"/>
@@ -4530,7 +4530,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="22"/>
 <connect gate="A" pin="!OE!" pad="24"/>
@@ -4577,7 +4577,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -4620,7 +4620,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="A" symbol="27210" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="2"/>
 <connect gate="A" pin="!OE!" pad="20"/>
@@ -4675,7 +4675,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -4719,7 +4719,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -4763,7 +4763,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!/VPP" pad="22"/>
@@ -4807,7 +4807,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -4850,7 +4850,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="G$1" symbol="51C259" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CAS!" pad="16"/>
 <connect gate="G$1" pin="!RAS!" pad="5"/>
@@ -4883,7 +4883,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="A0" pad="9"/>
 <connect gate="A" pin="A1" pad="8"/>
@@ -4919,7 +4919,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="A0" pad="8"/>
@@ -4959,7 +4959,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!OE!" pad="13"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -5047,7 +5047,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="25.4" y="-17.78" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-800L-120H-80F-32">
+<device name="" package="SSOP-32-50P-1840W-800L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="30"/>
 <connect gate="G$1" pin="!OE!" pad="32"/>
@@ -5145,7 +5145,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="-NC" symbol="NC" x="30.48" y="-15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="-NC" pin="NC" pad="1"/>
 <connect gate="G$1" pin="!CE1!" pad="22"/>
@@ -5193,7 +5193,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="G$1" symbol="257" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-890W-1790L-265H-155F-28">
+<device name="" package="SOP-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -5237,7 +5237,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="PWRN" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -5328,7 +5328,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="P" symbol="VCPQ2GND" x="-30.48" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1200L-120H-80F-48">
+<device name="" package="SSOP-48-50P-1840W-1200L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="26"/>
 <connect gate="G$1" pin="!OE!" pad="28"/>

--- a/micrel.lbr
+++ b/micrel.lbr
@@ -185,7 +185,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <wire x1="1.45" y1="-0.65" x2="1.45" y2="0.65" width="0.2032" layer="21"/>
 <wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
 </package>
-<package name="TQFP-50P-700W-700L-120H-48">
+<package name="TQFP-48-50P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
@@ -562,7 +562,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <rectangle x1="-11.6106" y1="-5.8516" x2="-10.0104" y2="-5.6484" layer="51"/>
 <rectangle x1="-11.6106" y1="-6.3516" x2="-10.0104" y2="-6.1484" layer="51"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -582,7 +582,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -616,7 +616,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -665,7 +665,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -1016,7 +1016,7 @@ body 7.6 x 10.5 mm</description>
 <rectangle x1="0.5" y1="-3.5" x2="2.25" y2="-0.5" layer="31"/>
 <rectangle x1="-2.25" y1="-3.5" x2="-0.5" y2="-0.5" layer="31"/>
 </package>
-<package name="LQFP-50P-700W-700L-160H-48">
+<package name="LQFP-48-50P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
@@ -1190,7 +1190,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <wire x1="1" y1="-0.625" x2="-1" y2="-0.625" width="0.2032" layer="51"/>
 <wire x1="1" y1="0.625" x2="1" y2="-0.625" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -2568,7 +2568,7 @@ MIC2027/2077</description>
 <gate name="G$1" symbol="MIC2027/77" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="ENA" pad="2"/>
 <connect gate="G$1" pin="ENB" pad="15"/>
@@ -2591,7 +2591,7 @@ MIC2027/2077</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="WM" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="WM" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="ENA" pad="2"/>
 <connect gate="G$1" pin="ENB" pad="15"/>
@@ -2623,7 +2623,7 @@ MIC2026/2076</description>
 <gate name="G$1" symbol="MIC2026/76" x="0" y="0"/>
 </gates>
 <devices>
-<device name="BN" package="DIP-300-8">
+<device name="BN" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="ENA" pad="1"/>
 <connect gate="G$1" pin="ENB" pad="4"/>
@@ -2638,7 +2638,7 @@ MIC2026/2076</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="BM" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="BM" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="ENA" pad="1"/>
 <connect gate="G$1" pin="ENB" pad="4"/>
@@ -2702,7 +2702,7 @@ MIC2026/2076</description>
 <gate name="G$1" symbol="KS8721B" x="-10.16" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-700W-700L-120H-48">
+<device name="" package="TQFP-48-50P-700W-700L-120H">
 <connects>
 <connect gate="G$1" pin="!INT!/PHYAD0" pad="25"/>
 <connect gate="G$1" pin="!PD!" pad="30"/>
@@ -3052,7 +3052,7 @@ MIC2026/2076</description>
 <gate name="G$1" symbol="KSZ8041TL" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-700W-700L-120H-48">
+<device name="" package="TQFP-48-50P-700W-700L-120H">
 <connects>
 <connect gate="G$1" pin="!RST" pad="47"/>
 <connect gate="G$1" pin="COL/CONFIG0" pad="40"/>
@@ -3116,7 +3116,7 @@ MOSFET, 6A-Peak</description>
 <gate name="G$1" symbol="MIC4420" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND@4" pad="4"/>
 <connect gate="G$1" pin="GND@5" pad="5"/>
@@ -3131,7 +3131,7 @@ MOSFET, 6A-Peak</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND@4" pad="4"/>
 <connect gate="G$1" pin="GND@5" pad="5"/>
@@ -3155,7 +3155,7 @@ MOSFET, 6A-Peak</description>
 <gate name="G$1" symbol="KSZ8001L/S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="L" package="LQFP-50P-700W-700L-160H-48">
+<device name="L" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!INT!/PHYAD0" pad="25"/>
 <connect gate="G$1" pin="!PD!" pad="30"/>
@@ -3380,7 +3380,7 @@ MOSFET, 6A-Peak</description>
 <gate name="G$1" symbol="KSZ8863RLL" x="2.54" y="-7.62"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="AGND" pad="10"/>
 <connect gate="G$1" pin="FXSD1" pad="48"/>
@@ -3444,7 +3444,7 @@ MOSFET, 6A-Peak</description>
 <gate name="G$1" symbol="KSZ8041FTL" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!FEF!/SPEED/LED1" pad="43"/>
 <connect gate="G$1" pin="!RST" pad="47"/>
@@ -3578,7 +3578,7 @@ MOSFET, 6A-Peak</description>
 <gate name="G$1" symbol="MIC5209YM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BYP" pad="4"/>
 <connect gate="G$1" pin="EN" pad="1"/>
@@ -3680,7 +3680,7 @@ MOSFET, 6A-Peak</description>
 <gate name="G3" symbol="GND-1" x="17.78" y="-15.24"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="BYP" pad="4"/>
 <connect gate="G$1" pin="EN" pad="1"/>
@@ -3706,7 +3706,7 @@ MOSFET, 6A-Peak</description>
 <gate name="G$1" symbol="MIC5219A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="4"/>
 <connect gate="G$1" pin="EN" pad="1"/>
@@ -3830,7 +3830,7 @@ Adjustable 150mA Low-Noise</description>
 <gate name="G$1" symbol="MIC5201-X.XYM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EN" pad="5"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -3945,7 +3945,7 @@ Adjustable 150mA Low-Noise</description>
 <gate name="G$1" symbol="PL611-01" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="CLK0" pad="3"/>
 <connect gate="G$1" pin="CLK1" pad="4"/>
@@ -3988,7 +3988,7 @@ Single Channel, High Current, Low Voltage</description>
 <gate name="G$1" symbol="MIC2042-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!EN!" pad="1"/>
 <connect gate="G$1" pin="!FAULT!" pad="2"/>
@@ -4011,7 +4011,7 @@ Single Channel, High Current, Low Voltage</description>
 <gate name="G$1" symbol="MIC5239-ADJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="2"/>
 <connect gate="G$1" pin="EN" pad="1"/>
@@ -4023,7 +4023,7 @@ Single Channel, High Current, Low Voltage</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="MM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="2"/>
 <connect gate="G$1" pin="EN" pad="1"/>
@@ -4043,7 +4043,7 @@ Single Channel, High Current, Low Voltage</description>
 <gate name="G$1" symbol="MIC5239" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EN" pad="1"/>
 <connect gate="G$1" pin="FLG" pad="2"/>
@@ -4055,7 +4055,7 @@ Single Channel, High Current, Low Voltage</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="MM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="EN" pad="1"/>
 <connect gate="G$1" pin="FLG" pad="2"/>

--- a/micro-fujitsu.lbr
+++ b/micro-fujitsu.lbr
@@ -74,7 +74,7 @@
 <description>&lt;b&gt;Fujitsu Microcontrollers and Memories&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="DIP-600-32">
+<package name="DIP-32-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="20.32" y1="5.715" x2="-20.32" y2="5.715" width="0.2032" layer="21"/>
@@ -118,7 +118,7 @@
 <text x="-20.955" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-17.145" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-32">
+<package name="DIP-32-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <pad name="1" x="-19.05" y="-3.81" drill="0.8128" shape="long" rot="R90" first="yes"/>
@@ -563,7 +563,7 @@ rectangle</description>
 <rectangle x1="4.7" y1="4.95" x2="5.46" y2="5.4" layer="51"/>
 <rectangle x1="4.7" y1="-4.13" x2="5.46" y2="-3.68" layer="51"/>
 </package>
-<package name="PLCC-127P-1244W-736L-355H-22">
+<package name="PLCC-22-127P-1244W-736L-355H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 7.37mm length, 12.45mm width, 3.56mm max height, 22 leads)&lt;/b&gt;&lt;p&gt;
 Rectangular plastic leaded chip carrier. 1.27mm pitch, 7.37mm body length, 12.45mm body width, 3.56mm max height, 22 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-016A, variation AC.&lt;/p&gt;
@@ -899,7 +899,7 @@ Small outline package J-lead. Lead pitch 1.27mm, body width 300mil/7.60mm. 28 le
 <wire x1="9.3100" y1="3.7080" x2="9.3100" y2="-3.7080" width="0.2032" layer="21"/>
 <wire x1="9.3100" y1="3.7080" x2="8.8650" y2="3.7080" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-840W-1790L-254H-180F-28">
+<package name="SOP-28-127P-840W-1790L-254H-180F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
 8.40mm body width, 2.54mm max height, 28 leads.
@@ -1290,7 +1290,7 @@ Small outline package J-lead. Lead pitch 1.27mm, body width 400mil/10.15mm. 32 l
 <wire x1="10.5800" y1="4.9780" x2="10.5800" y2="-4.9780" width="0.2032" layer="21"/>
 <wire x1="10.5800" y1="4.9780" x2="10.1350" y2="4.9780" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-890W-2050L-265H-155F-32">
+<package name="SOP-32-127P-890W-2050L-265H-155F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 20.50mm length, 8.90mm width, 2.65mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body length,
 8.90mm body width, 2.65mm max height, 32 leads.
@@ -1715,7 +1715,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body 
 <rectangle x1="-12.6" y1="-6.25" x2="-10.55" y2="-5.75" layer="51"/>
 <rectangle x1="-9.25" y1="-9.6" x2="-8.75" y2="-7.55" layer="51"/>
 </package>
-<package name="QFP-65P-1400W-2000L-315H-160F-100">
+<package name="QFP-100-65P-1400W-2000L-315H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-022B, variation GC-2, PQFP-G.
@@ -2185,7 +2185,7 @@ http://www.fme.gsdc.de</description>
 <rectangle x1="-9" y1="-6.85" x2="-8" y2="-6.65" layer="51"/>
 <rectangle x1="-9" y1="-7.35" x2="-8" y2="-7.15" layer="51"/>
 </package>
-<package name="LQFP-50P-700W-700L-160H-48">
+<package name="LQFP-48-50P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
@@ -2295,7 +2295,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -2327,7 +2327,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-48">
+<package name="DIP-48-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-29.845" y1="-5.715" x2="29.845" y2="-5.715" width="0.2032" layer="21"/>
@@ -2387,7 +2387,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <text x="-30.48" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -2427,7 +2427,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -2463,7 +2463,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -2503,7 +2503,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-22">
+<package name="DIP-22-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="-14.605" y1="-0.635" x2="-14.605" y2="-1.905" width="0.2032" layer="21"/>
@@ -2537,7 +2537,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <text x="-15.24" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.795" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-52">
+<package name="DIP-52-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-33.02" y1="0.9525" x2="-33.02" y2="-0.9525" width="0.1778" layer="21" curve="-180"/>
@@ -4400,7 +4400,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="9"/>
@@ -4472,7 +4472,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="9"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -4544,7 +4544,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-27.94" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="9"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -4616,7 +4616,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="12"/>
 <connect gate="G$1" pin="!WE!" pad="10"/>
@@ -4694,7 +4694,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="10"/>
 <connect gate="G$1" pin="!WE!" pad="12"/>
@@ -4732,7 +4732,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1244W-736L-355H-22">
+<device name="" package="PLCC-22-127P-1244W-736L-355H">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="10"/>
 <connect gate="G$1" pin="!WE!" pad="12"/>
@@ -4770,7 +4770,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="10"/>
 <connect gate="G$1" pin="!OE!" pad="11"/>
@@ -4894,7 +4894,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -5030,7 +5030,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -5074,7 +5074,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -5118,7 +5118,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -5254,7 +5254,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="13"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -5334,7 +5334,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="G$1" symbol="MB81C84" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -5414,7 +5414,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GNDQ" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-32">
+<device name="" package="DIP-32-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="24"/>
 <connect gate="G$1" pin="!OE!" pad="10"/>
@@ -5462,7 +5462,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GNDQ" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-890W-2050L-265H-155F-32">
+<device name="" package="SOP-32-127P-890W-2050L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="24"/>
 <connect gate="G$1" pin="!OE!" pad="10"/>
@@ -5510,7 +5510,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -5554,7 +5554,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -5642,7 +5642,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-32">
+<device name="" package="DIP-32-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -5738,7 +5738,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-890W-2050L-265H-155F-32">
+<device name="" package="SOP-32-127P-890W-2050L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -5922,7 +5922,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -5966,7 +5966,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -6054,7 +6054,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -6142,7 +6142,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -6186,7 +6186,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="13"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -6266,7 +6266,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -6346,7 +6346,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="12"/>
 <connect gate="G$1" pin="!OE!" pad="13"/>
@@ -6434,7 +6434,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -6522,7 +6522,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -6566,7 +6566,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -6610,7 +6610,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -6702,7 +6702,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -6746,7 +6746,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -6790,7 +6790,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-254H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -6834,7 +6834,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-32">
+<device name="" package="DIP-32-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -7010,7 +7010,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GNDQ" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-32">
+<device name="" package="DIP-32-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="28"/>
 <connect gate="G$1" pin="!CS1!" pad="25"/>
@@ -7058,7 +7058,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GNDQ" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-890W-2050L-265H-155F-32">
+<device name="" package="SOP-32-127P-890W-2050L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="28"/>
 <connect gate="G$1" pin="!CS1!" pad="25"/>
@@ -7106,7 +7106,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GNDQ" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-32">
+<device name="" package="DIP-32-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="24"/>
 <connect gate="G$1" pin="!OE!" pad="10"/>
@@ -7154,7 +7154,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GNDQ" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-890W-2050L-265H-155F-32">
+<device name="" package="SOP-32-127P-890W-2050L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="24"/>
 <connect gate="G$1" pin="!OE!" pad="10"/>
@@ -7201,7 +7201,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="G$1" symbol="MB8421" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0L" pad="6"/>
 <connect gate="G$1" pin="A0R" pad="42"/>
@@ -7264,7 +7264,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="G$1" symbol="MB8421P/" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-52">
+<device name="" package="DIP-52-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0L" pad="8"/>
 <connect gate="G$1" pin="A0R" pad="44"/>
@@ -7411,7 +7411,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0L" pad="6"/>
 <connect gate="G$1" pin="A0R" pad="42"/>
@@ -7475,7 +7475,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-52">
+<device name="" package="DIP-52-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0L" pad="8"/>
 <connect gate="G$1" pin="A0R" pad="44"/>
@@ -7701,7 +7701,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="G$1" symbol="MB90540" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-2000L-315H-160F-100">
+<device name="" package="QFP-100-65P-1400W-2000L-315H-160F">
 <connects>
 <connect gate="G$1" pin="!HAK!" pad="15"/>
 <connect gate="G$1" pin="!HST!" pad="52"/>
@@ -7818,7 +7818,7 @@ www.fma.fujitsu.com/pdf/e713717.pdf</description>
 <gate name="G$1" symbol="MB90385" x="0" y="0"/>
 </gates>
 <devices>
-<device name="T" package="LQFP-50P-700W-700L-160H-48">
+<device name="T" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="23"/>
 <connect gate="G$1" pin="ADTG/P37" pad="11"/>

--- a/micro-harris.lbr
+++ b/micro-harris.lbr
@@ -72,7 +72,7 @@
 <description>&lt;b&gt;Harris Microcontrollers and Memories&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="PLCC-127P-1150W-1150L-457H-28">
+<package name="PLCC-28-127P-1150W-1150L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 11.51mm length, 11.51mm width, 4.57mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 11.51mm body length, 11.51mm body width, 4.57mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AB.&lt;/p&gt;
@@ -232,7 +232,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <text x="-12.065" y="15.367" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-6.985" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -260,7 +260,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -290,7 +290,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -322,7 +322,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -374,7 +374,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-48">
+<package name="DIP-48-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-29.845" y1="-5.715" x2="29.845" y2="-5.715" width="0.2032" layer="21"/>
@@ -434,7 +434,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <text x="-30.48" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -470,7 +470,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -510,7 +510,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -546,7 +546,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-22">
+<package name="DIP-22-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="-14.605" y1="-0.635" x2="-14.605" y2="-1.905" width="0.2032" layer="21"/>
@@ -2103,7 +2103,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="A" symbol="HM91M2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="A" pin="!E1A!" pad="9"/>
 <connect gate="A" pin="!E1B!" pad="40"/>
@@ -2165,7 +2165,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-5.08" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!ECP!" pad="4"/>
 <connect gate="A" pin="CO" pad="9"/>
@@ -2197,7 +2197,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-10.16" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!DRR!" pad="18"/>
 <connect gate="A" pin="!TBRL!" pad="23"/>
@@ -2252,7 +2252,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!BOO!" pad="17"/>
 <connect gate="A" pin="!BZO!" pad="15"/>
@@ -2292,7 +2292,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!BOO!" pad="19"/>
 <connect gate="A" pin="!BZO!" pad="18"/>
@@ -2328,7 +2328,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="10"/>
 <connect gate="A" pin="!WE!" pad="8"/>
@@ -2362,7 +2362,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="1"/>
 <connect gate="A" pin="!WE!" pad="14"/>
@@ -2394,7 +2394,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="8"/>
 <connect gate="A" pin="!WE!" pad="10"/>
@@ -2428,7 +2428,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="18"/>
 <connect gate="A" pin="!OE!" pad="20"/>
@@ -2468,7 +2468,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="2"/>
 <connect gate="A" pin="!S1!" pad="1"/>
@@ -2502,7 +2502,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="18"/>
 <connect gate="G$1" pin="!S1!" pad="19"/>
@@ -2540,7 +2540,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="9"/>
 <connect gate="A" pin="!S1!" pad="15"/>
@@ -2573,7 +2573,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="A" symbol="HM6564" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!E1!" pad="32"/>
 <connect gate="A" pin="!E3!" pad="9"/>
@@ -2629,7 +2629,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="18"/>
 <connect gate="A" pin="!OE!" pad="20"/>
@@ -2669,7 +2669,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="19"/>
 <connect gate="A" pin="!G1!" pad="22"/>
@@ -2708,7 +2708,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="A" symbol="80C86MAX" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!BHE!/S7" pad="34"/>
 <connect gate="A" pin="!LOCK!" pad="29"/>
@@ -2763,7 +2763,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="A" symbol="80C86MIN" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!BHE!/S7" pad="34"/>
 <connect gate="A" pin="!DEN!" pad="26"/>
@@ -2818,7 +2818,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="A" symbol="80C88MAX" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!BHE!" pad="34"/>
 <connect gate="A" pin="!LOCK!" pad="29"/>
@@ -2873,7 +2873,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="A" symbol="80C88MIN" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!DEN!" pad="26"/>
 <connect gate="A" pin="!INTA!" pad="24"/>
@@ -2929,7 +2929,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-10.16" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!CS!" pad="11"/>
 <connect gate="A" pin="!EOP!" pad="36"/>
@@ -2985,7 +2985,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-10.16" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!ADS!" pad="25"/>
 <connect gate="A" pin="!BAUDOUT!" pad="15"/>
@@ -3041,7 +3041,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-10.16" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1150W-1150L-457H-28">
+<device name="" package="PLCC-28-127P-1150W-1150L-457H">
 <connects>
 <connect gate="A" pin="!CS0!" pad="28"/>
 <connect gate="A" pin="!CTS!" pad="17"/>
@@ -3085,7 +3085,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!CS!" pad="21"/>
 <connect gate="A" pin="!RD!" pad="22"/>
@@ -3125,7 +3125,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-10.16" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!CS!" pad="6"/>
 <connect gate="A" pin="!RD!" pad="5"/>
@@ -3181,7 +3181,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1150W-1150L-457H-28">
+<device name="" package="PLCC-28-127P-1150W-1150L-457H">
 <connects>
 <connect gate="A" pin="!CS!" pad="1"/>
 <connect gate="A" pin="!INTA!" pad="26"/>
@@ -3225,7 +3225,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!OE!" pad="9"/>
 <connect gate="A" pin="I0" pad="1"/>
@@ -3261,7 +3261,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!O0!" pad="19"/>
 <connect gate="A" pin="!O1!" pad="18"/>
@@ -3297,7 +3297,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="!AEN1!" pad="3"/>
 <connect gate="A" pin="!AEN2!" pad="7"/>
@@ -3331,7 +3331,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-10.16" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="!AEN1!" pad="3"/>
 <connect gate="A" pin="!AEN2!" pad="7"/>
@@ -3371,7 +3371,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!OE!" pad="9"/>
 <connect gate="A" pin="A0" pad="1"/>
@@ -3407,7 +3407,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!B0!" pad="19"/>
 <connect gate="A" pin="!B1!" pad="18"/>
@@ -3443,7 +3443,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!AEN!" pad="6"/>
 <connect gate="A" pin="!AIOWC!" pad="12"/>
@@ -3479,7 +3479,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!AEN!" pad="13"/>
 <connect gate="A" pin="!BCLK!" pad="5"/>
@@ -3515,7 +3515,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -3557,7 +3557,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!WE!" pad="27"/>
@@ -3599,7 +3599,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -3643,7 +3643,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="!BOO!" pad="17"/>
 <connect gate="A" pin="!BZO!" pad="15"/>
@@ -3683,7 +3683,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-10.16" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!BOO!" pad="27"/>
 <connect gate="A" pin="!BZO!" pad="25"/>
@@ -3737,7 +3737,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CE!" pad="11"/>
 <connect gate="A" pin="!WE!" pad="9"/>
@@ -3773,7 +3773,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="!CE1!" pad="20"/>
 <connect gate="A" pin="!OE!" pad="22"/>
@@ -3894,7 +3894,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="P" symbol="PWRN" x="-10.16" y="15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="A" pin="!E1!" pad="6"/>
 <connect gate="A" pin="!E10!" pad="24"/>
@@ -3957,7 +3957,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <gate name="A" symbol="HM92570" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="A" pin="!E1A!" pad="9"/>
 <connect gate="A" pin="!E1B!" pad="40"/>

--- a/micro-intel.lbr
+++ b/micro-intel.lbr
@@ -439,7 +439,7 @@
 <text x="-11.938" y="14.986" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-7.366" y="-2.54" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="PLCC-127P-1658W-1658L-457H-44">
+<package name="PLCC-44-127P-1658W-1658L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 16.59mm length, 16.59mm width, 4.57mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body width, 4.57mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AC.&lt;/p&gt;
@@ -549,7 +549,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <wire x1="8.2931" y1="7.015" x2="8.2931" y2="8.2931" width="0.2032" layer="21"/>
 <wire x1="8.2931" y1="8.2931" x2="7.015" y2="8.2931" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1840W-1400L-120H-80F-56">
+<package name="SSOP-56-50P-1840W-1400L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 14.0mm length, 18.4mm width, 1.20mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 14.0mm length, 18.4mm width, 1.20mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation EC, R-PDSO-G.&lt;/p&gt;
@@ -1242,7 +1242,7 @@ JEDEC MO-142D, variation EC, R-PDSO-G.&lt;/p&gt;
 <text x="-15.24" y="17.907" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-8.89" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="PLCC-SOCKET-TH-17X17-68">
+<package name="PLCC-SOCKET-TH-68-17X17">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 68 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 &lt;/p&gt;</description>
@@ -1617,7 +1617,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 <wire x1="15.24" y1="-15.24" x2="15.24" y2="15.24" width="0.2032" layer="21"/>
 <wire x1="15.24" y1="15.24" x2="-13.97" y2="15.24" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-21X21-84">
+<package name="PLCC-SOCKET-TH-84-21X21">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 68 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 &lt;/p&gt;</description>
@@ -2072,7 +2072,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 <wire x1="17.78" y1="-17.78" x2="17.78" y2="17.78" width="0.2032" layer="21"/>
 <wire x1="17.78" y1="17.78" x2="-16.51" y2="17.78" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-11X11-44">
+<package name="PLCC-SOCKET-TH-44-11X11">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 44 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 &lt;/p&gt;</description>
@@ -2734,7 +2734,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <text x="-3.81" y="1.27" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-6.35" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -2762,7 +2762,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -2792,7 +2792,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -2824,7 +2824,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -2876,7 +2876,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-48">
+<package name="DIP-48-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-29.845" y1="-5.715" x2="29.845" y2="-5.715" width="0.2032" layer="21"/>
@@ -2936,7 +2936,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <text x="-30.48" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -2972,7 +2972,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -6493,7 +6493,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="1" symbol="82C55A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="1" pin="A0" pad="9"/>
 <connect gate="1" pin="A1" pad="8"/>
@@ -6628,7 +6628,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="5VCC5VSS" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-11X11-44">
+<device name="" package="PLCC-SOCKET-TH-44-11X11">
 <connects>
 <connect gate="G$1" pin="BUSY" pad="28"/>
 <connect gate="G$1" pin="CKM" pad="44"/>
@@ -6683,7 +6683,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWRN" x="-30.48" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="5"/>
 <connect gate="G$1" pin="CEN/!AEN!" pad="15"/>
@@ -6719,7 +6719,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWRN" x="-30.48" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="ARDY" pad="1"/>
 <connect gate="G$1" pin="ARDYEN" pad="17"/>
@@ -6752,7 +6752,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWR2GND" x="-35.56" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A16/S3" pad="38"/>
 <connect gate="G$1" pin="A17/S4" pad="37"/>
@@ -7364,7 +7364,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWR2GND" x="-38.1" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!BHE!/S7" pad="34"/>
 <connect gate="A" pin="!MX!" pad="33"/>
@@ -7420,7 +7420,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWR2GND" x="-33.02" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!BHE!/S7" pad="34"/>
 <connect gate="A" pin="A16/S3" pad="38"/>
@@ -7476,7 +7476,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWR2GND" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!MX!" pad="33"/>
 <connect gate="A" pin="A10" pad="6"/>
@@ -7532,7 +7532,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWR2GND" x="-35.56" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A10" pad="6"/>
 <connect gate="A" pin="A11" pad="5"/>
@@ -7587,7 +7587,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8022" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="23"/>
 <connect gate="G$1" pin="AN0" pad="35"/>
@@ -7642,7 +7642,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8021" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="17"/>
 <connect gate="G$1" pin="GND" pad="15"/>
@@ -7685,7 +7685,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8421" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="GND" pad="14"/>
 <connect gate="G$1" pin="INT-T0" pad="12"/>
@@ -7728,7 +7728,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8421" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="GND" pad="14"/>
 <connect gate="G$1" pin="INT-T0" pad="12"/>
@@ -7772,7 +7772,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="2VCC1GND" x="-35.56" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-17X17-68">
+<device name="" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="A" pin="ALE" pad="50"/>
 <connect gate="A" pin="CLKOUTP1.6" pad="30"/>
@@ -7855,7 +7855,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8051" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="30"/>
 <connect gate="G$1" pin="EA" pad="31"/>
@@ -7910,7 +7910,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="80517" x="0" y="20.32"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-21X21-84">
+<device name="" package="PLCC-SOCKET-TH-84-21X21">
 <connects>
 <connect gate="G$1" pin="ALE" pad="50"/>
 <connect gate="G$1" pin="EA" pad="51"/>
@@ -8009,7 +8009,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8052" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="30"/>
 <connect gate="G$1" pin="EA" pad="31"/>
@@ -8064,7 +8064,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8751" x="2.54" y="-2.54"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-40">
+<device name="P" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE-PROG" pad="30"/>
 <connect gate="G$1" pin="EA-VPP" pad="31"/>
@@ -8120,7 +8120,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8044" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="12"/>
 <connect gate="G$1" pin="EA" pad="11"/>
@@ -8175,7 +8175,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8744" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE-PROG" pad="12"/>
 <connect gate="G$1" pin="EA-VPP" pad="11"/>
@@ -8230,7 +8230,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8243" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="CS" pad="6"/>
 <connect gate="G$1" pin="GND" pad="12"/>
@@ -8269,7 +8269,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="83652" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="30"/>
 <connect gate="G$1" pin="EA" pad="31"/>
@@ -8324,7 +8324,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="83652" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="30"/>
 <connect gate="G$1" pin="EA" pad="31"/>
@@ -8379,7 +8379,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="83552" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-17X17-68">
+<device name="" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="G$1" pin="ALE" pad="48"/>
 <connect gate="G$1" pin="AVDD" pad="61"/>
@@ -8462,7 +8462,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="83751" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="GND" pad="12"/>
 <connect gate="G$1" pin="P00-SCL" pad="8"/>
@@ -8501,7 +8501,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="80512" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-17X17-68">
+<device name="" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="G$1" pin="ALE" pad="50"/>
 <connect gate="G$1" pin="EA" pad="51"/>
@@ -8584,7 +8584,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="83C152" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="38"/>
 <connect gate="G$1" pin="EA" pad="39"/>
@@ -8647,7 +8647,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="83C451" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-17X17-68">
+<device name="" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="G$1" pin="AFLAG" pad="58"/>
 <connect gate="G$1" pin="ALE" pad="68"/>
@@ -8731,7 +8731,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="2VCC1GND" x="-40.64" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-17X17-68">
+<device name="" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="A" pin="ALE" pad="50"/>
 <connect gate="A" pin="EA" pad="51"/>
@@ -8814,7 +8814,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="UPI-41" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="9"/>
 <connect gate="G$1" pin="CS" pad="6"/>
@@ -8869,7 +8869,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="UPI-41" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="9"/>
 <connect gate="G$1" pin="CS" pad="6"/>
@@ -8924,7 +8924,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="UPI-41" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="9"/>
 <connect gate="G$1" pin="CS" pad="6"/>
@@ -8979,7 +8979,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="UPI-41" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="9"/>
 <connect gate="G$1" pin="CS" pad="6"/>
@@ -9203,7 +9203,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWRN" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="19"/>
 <connect gate="A" pin="A1" pad="20"/>
@@ -9243,7 +9243,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWRN" x="-30.48" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="9"/>
 <connect gate="A" pin="A1" pad="8"/>
@@ -9299,7 +9299,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWRN" x="-33.02" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="AD0" pad="1"/>
 <connect gate="A" pin="AD1" pad="2"/>
@@ -9355,7 +9355,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="27"/>
 <connect gate="A" pin="CAS0" pad="12"/>
@@ -9399,7 +9399,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWRN" x="-33.02" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="21"/>
 <connect gate="A" pin="BD" pad="23"/>
@@ -9455,7 +9455,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWRN" x="-33.2232" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="32"/>
 <connect gate="A" pin="A1" pad="33"/>
@@ -9511,7 +9511,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="4PWR9VSS" x="-43.18" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-17X17-68">
+<device name="" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="G$1" pin="A0" pad="7"/>
 <connect gate="G$1" pin="A1" pad="8"/>
@@ -9590,7 +9590,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8231A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="21"/>
 <connect gate="G$1" pin="CLK" pad="23"/>
@@ -9627,7 +9627,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="82C08" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AA/TACK" pad="26"/>
 <connect gate="G$1" pin="AH0" pad="43"/>
@@ -10022,7 +10022,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8048" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="11"/>
 <connect gate="G$1" pin="D0" pad="12"/>
@@ -10077,7 +10077,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8048" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="11"/>
 <connect gate="G$1" pin="D0" pad="12"/>
@@ -10132,7 +10132,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8048" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="11"/>
 <connect gate="G$1" pin="D0" pad="12"/>
@@ -10187,7 +10187,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8048" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="11"/>
 <connect gate="G$1" pin="D0" pad="12"/>
@@ -10242,7 +10242,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8048" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="11"/>
 <connect gate="G$1" pin="D0" pad="12"/>
@@ -10297,7 +10297,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8048" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="11"/>
 <connect gate="G$1" pin="D0" pad="12"/>
@@ -10352,7 +10352,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8048" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="11"/>
 <connect gate="G$1" pin="D0" pad="12"/>
@@ -10407,7 +10407,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8048" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ALE" pad="11"/>
 <connect gate="G$1" pin="D0" pad="12"/>
@@ -10462,7 +10462,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8080" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="25"/>
 <connect gate="G$1" pin="A1" pad="26"/>
@@ -10517,7 +10517,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8085" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A10" pad="23"/>
 <connect gate="G$1" pin="A11" pad="24"/>
@@ -10573,7 +10573,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="5PWR6GND" x="-43.18" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="BUSY" pad="25"/>
 <connect gate="G$1" pin="CKM" pad="39"/>
@@ -10627,7 +10627,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8155" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AD0" pad="12"/>
 <connect gate="G$1" pin="AD1" pad="13"/>
@@ -10682,7 +10682,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8156" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AD0" pad="12"/>
 <connect gate="G$1" pin="AD1" pad="13"/>
@@ -10737,7 +10737,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8185" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="A8" pad="10"/>
 <connect gate="G$1" pin="A9" pad="11"/>
@@ -10770,7 +10770,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="82188" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AEN" pad="19"/>
 <connect gate="G$1" pin="ALE" pad="24"/>
@@ -10813,7 +10813,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8224" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="8"/>
 <connect gate="G$1" pin="OSC" pad="12"/>
@@ -10844,7 +10844,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8228" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="BUSEN" pad="22"/>
 <connect gate="G$1" pin="D0" pad="15"/>
@@ -10887,7 +10887,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="8755" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A10" pad="23"/>
 <connect gate="G$1" pin="A8" pad="21"/>
@@ -10947,7 +10947,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="NC1" symbol="NC" x="45.72" y="-15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="ALE-PROG" pad="33"/>
 <connect gate="G$1" pin="EA-VPP" pad="35"/>
@@ -11009,7 +11009,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="2VCC3GND" x="33.02" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1400L-120H-80F-56">
+<device name="" package="SSOP-56-50P-1840W-1400L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!BYTE!" pad="36"/>
 <connect gate="G$1" pin="!OE!" pad="21"/>

--- a/micro-mc68000.lbr
+++ b/micro-mc68000.lbr
@@ -72,7 +72,7 @@
 <description>&lt;b&gt;Motorola MC68000 Processors&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="PLCC-127P-2423W-2423L-457H-68">
+<package name="PLCC-68-127P-2423W-2423L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 24.23mm length, 24.23mm width, 4.57mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body width, 4.57mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AE.&lt;/p&gt;
@@ -324,7 +324,7 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <text x="-5.08" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-12.065" y="13.97" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 </package>
-<package name="PLCC-127P-1912W-1912L-457H-52">
+<package name="PLCC-52-127P-1912W-1912L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 19.13mm length, 19.13mm width, 4.57mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 19.13mm body length, 19.13mm body width, 4.57mm max height, 52 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AD.&lt;/p&gt;
@@ -1247,7 +1247,7 @@ JEDEC MS-018A, variation AD.&lt;/p&gt;
 <text x="-5.08" y="-1.905" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-15.875" y="17.78" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 </package>
-<package name="PLCC-SOCKET-TH-17X17-68">
+<package name="PLCC-SOCKET-TH-68-17X17">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 68 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 &lt;/p&gt;</description>
@@ -1622,7 +1622,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 <wire x1="15.24" y1="-15.24" x2="15.24" y2="15.24" width="0.2032" layer="21"/>
 <wire x1="15.24" y1="15.24" x2="-13.97" y2="15.24" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-13X13-52">
+<package name="PLCC-SOCKET-TH-52-13X13">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 52 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 52 leads.
 &lt;/p&gt;</description>
@@ -2044,7 +2044,7 @@ Source: MC68020UM.pdf</description>
 <text x="-15.875" y="17.78" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-7.62" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -2096,7 +2096,7 @@ Source: MC68020UM.pdf</description>
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-48">
+<package name="DIP-48-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-29.845" y1="-5.715" x2="29.845" y2="-5.715" width="0.2032" layer="21"/>
@@ -2156,7 +2156,7 @@ Source: MC68020UM.pdf</description>
 <text x="-30.48" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-900-64">
+<package name="DIP-64-254P-2286W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 900 mil row spacing, JEDEC MO-016D</description>
 <wire x1="-41.275" y1="-0.9525" x2="-41.275" y2="-9.4615" width="0.2032" layer="21"/>
@@ -3525,7 +3525,7 @@ Source: MC68020UM.pdf</description>
 <gate name="P" symbol="2PWR4GND" x="-40.64" y="15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="A1" pad="32"/>
 <connect gate="G$1" pin="A10" pad="41"/>
@@ -3598,7 +3598,7 @@ Source: MC68020UM.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-SOC" package="PLCC-SOCKET-TH-17X17-68">
+<device name="-SOC" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="G$1" pin="A1" pad="32"/>
 <connect gate="G$1" pin="A10" pad="41"/>
@@ -3680,7 +3680,7 @@ Source: MC68020UM.pdf</description>
 <gate name="P" symbol="2PWR2GND" x="-40.64" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-900-64">
+<device name="" package="DIP-64-254P-2286W">
 <connects>
 <connect gate="G$1" pin="A1" pad="29"/>
 <connect gate="G$1" pin="A10" pad="38"/>
@@ -3840,7 +3840,7 @@ Source: MC68020UM.pdf</description>
 <gate name="P" symbol="PWRN" x="-33.02" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1912W-1912L-457H-52">
+<device name="" package="PLCC-52-127P-1912W-1912L-457H">
 <connects>
 <connect gate="G$1" pin="CLK" pad="44"/>
 <connect gate="G$1" pin="CS" pad="45"/>
@@ -3895,7 +3895,7 @@ Source: MC68020UM.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-SOC" package="PLCC-SOCKET-TH-13X13-52">
+<device name="-SOC" package="PLCC-SOCKET-TH-52-13X13">
 <connects>
 <connect gate="G$1" pin="CLK" pad="45"/>
 <connect gate="G$1" pin="CS" pad="44"/>
@@ -3959,7 +3959,7 @@ Source: MC68020UM.pdf</description>
 <gate name="P" symbol="PWRN" x="-27.94" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="40"/>
 <connect gate="G$1" pin="CS" pad="41"/>
@@ -4765,7 +4765,7 @@ Source: MC68020UM.pdf</description>
 <gate name="P" symbol="PWRN" x="-33.02" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="35"/>
 <connect gate="G$1" pin="CS" pad="48"/>
@@ -4828,7 +4828,7 @@ Source: MC68020UM.pdf</description>
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1912W-1912L-457H-52">
+<device name="" package="PLCC-52-127P-1912W-1912L-457H">
 <connects>
 <connect gate="G$1" pin="CLK" pad="39"/>
 <connect gate="G$1" pin="CS" pad="52"/>
@@ -4882,7 +4882,7 @@ Source: MC68020UM.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-SOC" package="PLCC-SOCKET-TH-13X13-52">
+<device name="-SOC" package="PLCC-SOCKET-TH-52-13X13">
 <connects>
 <connect gate="G$1" pin="CLK" pad="39"/>
 <connect gate="G$1" pin="CS" pad="52"/>
@@ -5028,7 +5028,7 @@ Source: MC68020UM.pdf</description>
 <gate name="P" symbol="8PWR12GN" x="-40.64" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="A0" pad="26"/>
 <connect gate="G$1" pin="A1" pad="25"/>
@@ -5102,7 +5102,7 @@ Source: MC68020UM.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-SOC" package="PLCC-SOCKET-TH-17X17-68">
+<device name="-SOC" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="G$1" pin="A0" pad="26"/>
 <connect gate="G$1" pin="A1" pad="25"/>
@@ -5332,7 +5332,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$1" symbol="68008D" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-48">
+<device name="" package="DIP-48-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="46"/>
 <connect gate="G$1" pin="A1" pad="47"/>
@@ -5395,7 +5395,7 @@ Source: MC68020UM.pdf</description>
 <gate name="G$2" symbol="68008CC" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1912W-1912L-457H-52">
+<device name="" package="PLCC-52-127P-1912W-1912L-457H">
 <connects>
 <connect gate="G$2" pin="A0" pad="51"/>
 <connect gate="G$2" pin="A1" pad="52"/>
@@ -5454,7 +5454,7 @@ Source: MC68020UM.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-SOC" package="PLCC-SOCKET-TH-13X13-52">
+<device name="-SOC" package="PLCC-SOCKET-TH-52-13X13">
 <connects>
 <connect gate="G$2" pin="A0" pad="51"/>
 <connect gate="G$2" pin="A1" pad="52"/>
@@ -5522,7 +5522,7 @@ Source: MC68020UM.pdf</description>
 <gate name="P" symbol="PWRN" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="CS" pad="35"/>
 <connect gate="G$1" pin="D0" pad="25"/>

--- a/micro-motorola.lbr
+++ b/micro-motorola.lbr
@@ -75,7 +75,7 @@
 Motorola DRAMs&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="QFP-65P-1400W-1400L-245H-160F-80">
+<package name="QFP-80-65P-1400W-1400L-245H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-022B, variation BC, PQFP-G.
@@ -825,7 +825,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <vertex x="-2.75" y="-2.25"/>
 </polygon>
 </package>
-<package name="TQFP-65P-2000W-2000L-120H-112">
+<package name="TQFP-112-65P-2000W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 112 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFA, T-PQFP-G.
@@ -1063,7 +1063,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-1400W-1400L-120H-80">
+<package name="TQFP-80-65P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEC, T-PQFP-G.
@@ -1900,7 +1900,7 @@ CASE 1268-01</description>
 <vertex x="-1.375" y="-1.125"/>
 </polygon>
 </package>
-<package name="PLCC-SOCKET-TH-17X17-68">
+<package name="PLCC-SOCKET-TH-68-17X17">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 68 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 &lt;/p&gt;</description>
@@ -2275,7 +2275,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 <wire x1="15.24" y1="-15.24" x2="15.24" y2="15.24" width="0.2032" layer="21"/>
 <wire x1="15.24" y1="15.24" x2="-13.97" y2="15.24" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-11X11-44">
+<package name="PLCC-SOCKET-TH-44-11X11">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 44 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 &lt;/p&gt;</description>
@@ -2526,7 +2526,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <wire x1="11.43" y1="-11.43" x2="11.43" y2="11.43" width="0.2032" layer="21"/>
 <wire x1="11.43" y1="11.43" x2="-10.16" y2="11.43" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1400W-1400L-245H-160F-64">
+<package name="QFP-64-80P-1400W-1400L-245H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-022B, variation BB, PQFP-G.
@@ -2767,7 +2767,7 @@ Small outline package J-lead. Lead pitch 1.27mm, body width 400mil/10.15mm. 28 l
 <wire x1="9.3100" y1="4.9780" x2="9.3100" y2="-4.9780" width="0.2032" layer="21"/>
 <wire x1="9.3100" y1="4.9780" x2="8.8650" y2="4.9780" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-2423W-2423L-457H-68">
+<package name="PLCC-68-127P-2423W-2423L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 24.23mm length, 24.23mm width, 4.57mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body width, 4.57mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AE.&lt;/p&gt;
@@ -2925,7 +2925,7 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <wire x1="12.1158" y1="10.825" x2="12.1158" y2="12.1158" width="0.2032" layer="21"/>
 <wire x1="12.1158" y1="12.1158" x2="10.825" y2="12.1158" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-13X13-52">
+<package name="PLCC-SOCKET-TH-52-13X13">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 52 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 52 leads.
 &lt;/p&gt;</description>
@@ -3216,7 +3216,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 52 leads.
 <wire x1="12.7" y1="-12.7" x2="12.7" y2="12.7" width="0.2032" layer="21"/>
 <wire x1="12.7" y1="12.7" x2="-11.43" y2="12.7" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-530W-530L-210H-125F-8">
+<package name="SOP-8-127P-530W-530L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -3249,7 +3249,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="2.625" y1="-2.625" x2="-2.625" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="2.625" x2="-2.625" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -3277,7 +3277,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -3309,7 +3309,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -3345,7 +3345,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -3385,7 +3385,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -3437,7 +3437,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -3486,7 +3486,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -3543,7 +3543,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -7685,7 +7685,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR2VSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="9"/>
 <connect gate="A" pin="A1" pad="10"/>
@@ -7739,7 +7739,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="E" pad="40"/>
 <connect gate="A" pin="EXTAL" pad="3"/>
@@ -7795,7 +7795,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A0/D0" pad="37"/>
 <connect gate="A" pin="A1/D1" pad="36"/>
@@ -7851,7 +7851,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="29"/>
 <connect gate="A" pin="A1" pad="28"/>
@@ -7907,7 +7907,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWR2VSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="9"/>
 <connect gate="A" pin="A1" pad="10"/>
@@ -7963,7 +7963,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="8"/>
 <connect gate="A" pin="A1" pad="9"/>
@@ -8019,7 +8019,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="CA1" pad="40"/>
 <connect gate="A" pin="CA2" pad="39"/>
@@ -8075,7 +8075,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-10.16" y="12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A12" pad="5"/>
 <connect gate="A" pin="A13" pad="4"/>
@@ -8131,7 +8131,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="C1" pad="28"/>
 <connect gate="A" pin="C2" pad="4"/>
@@ -8175,7 +8175,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="CLK" pad="21"/>
 <connect gate="A" pin="CS" pad="25"/>
@@ -8231,7 +8231,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CS0" pad="8"/>
 <connect gate="A" pin="CS1" pad="10"/>
@@ -8271,7 +8271,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="CS" pad="10"/>
 <connect gate="A" pin="CTS" pad="24"/>
@@ -8311,7 +8311,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="CS" pad="9"/>
 <connect gate="A" pin="CTS" pad="28"/>
@@ -8355,7 +8355,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-10.16" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A0/D0" pad="37"/>
 <connect gate="A" pin="A1/D1" pad="36"/>
@@ -8411,7 +8411,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-7.62" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="29"/>
 <connect gate="A" pin="A1" pad="28"/>
@@ -8467,7 +8467,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-7.62" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="IRQ" pad="2"/>
 <connect gate="A" pin="OSC1" pad="27"/>
@@ -8511,7 +8511,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="EXTAL" pad="4"/>
 <connect gate="A" pin="INT" pad="2"/>
@@ -8555,7 +8555,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="EXTAL" pad="5"/>
 <connect gate="A" pin="INT" pad="3"/>
@@ -8611,7 +8611,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="AN0/PD0" pad="10"/>
 <connect gate="A" pin="AN1/PD1" pad="9"/>
@@ -8655,7 +8655,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-7.62" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="EXTAL" pad="5"/>
 <connect gate="A" pin="INT" pad="3"/>
@@ -8711,7 +8711,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-10.16" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="IRQ" pad="2"/>
 <connect gate="A" pin="OSC1" pad="39"/>
@@ -8766,7 +8766,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-7.62" y="15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="EXTAL" pad="5"/>
 <connect gate="A" pin="INT" pad="3"/>
@@ -8821,7 +8821,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-7.62" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="EXTAL" pad="5"/>
 <connect gate="A" pin="INT" pad="3"/>
@@ -8876,7 +8876,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-12.7" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="IRQ" pad="2"/>
 <connect gate="A" pin="OSC1" pad="39"/>
@@ -8931,7 +8931,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-22.86" y="22.86" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-13X13-52">
+<device name="" package="PLCC-SOCKET-TH-52-13X13">
 <connects>
 <connect gate="A" pin="AN0" pad="14"/>
 <connect gate="A" pin="AN1" pad="13"/>
@@ -8996,7 +8996,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-12.7" y="55.88" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-17X17-68">
+<device name="" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="A" pin="ALRT" pad="34"/>
 <connect gate="A" pin="BP1" pad="62"/>
@@ -9078,7 +9078,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-10.16" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-13X13-52">
+<device name="" package="PLCC-SOCKET-TH-52-13X13">
 <connects>
 <connect gate="A" pin="AS" pad="4"/>
 <connect gate="A" pin="E" pad="5"/>
@@ -9146,7 +9146,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-10.16" y="20.32" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-13X13-52">
+<device name="" package="PLCC-SOCKET-TH-52-13X13">
 <connects>
 <connect gate="A" pin="AS" pad="4"/>
 <connect gate="A" pin="E" pad="5"/>
@@ -9214,7 +9214,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="ASE" pad="4"/>
 <connect gate="A" pin="ATN" pad="26"/>
@@ -9270,7 +9270,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="2PWRVSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="E" pad="40"/>
 <connect gate="A" pin="EXTAL" pad="3"/>
@@ -9326,7 +9326,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="AD0" pad="4"/>
 <connect gate="A" pin="AD1" pad="5"/>
@@ -9364,7 +9364,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="AD0" pad="4"/>
 <connect gate="A" pin="AD1" pad="5"/>
@@ -9404,7 +9404,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="AD0" pad="12"/>
 <connect gate="A" pin="AD1" pad="13"/>
@@ -9460,7 +9460,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="EXTAL" pad="4"/>
 <connect gate="A" pin="INT" pad="2"/>
@@ -9504,7 +9504,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-7.62" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="EXTAL" pad="5"/>
 <connect gate="A" pin="INT" pad="3"/>
@@ -9560,7 +9560,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-7.62" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="EXTAL" pad="5"/>
 <connect gate="A" pin="INT" pad="3"/>
@@ -9616,7 +9616,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-10.16" y="25.4" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="IRQ" pad="2"/>
 <connect gate="A" pin="OSC1" pad="39"/>
@@ -9672,7 +9672,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-10.16" y="25.4" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-13X13-52">
+<device name="" package="PLCC-SOCKET-TH-52-13X13">
 <connects>
 <connect gate="A" pin="AN0" pad="14"/>
 <connect gate="A" pin="AN1" pad="13"/>
@@ -9739,7 +9739,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-35.56" y="20.32" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="37"/>
 <connect gate="A" pin="A1" pad="38"/>
@@ -9795,7 +9795,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-34.7218" y="27.94" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="37"/>
 <connect gate="A" pin="A1" pad="38"/>
@@ -9851,7 +9851,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-32.1818" y="22.86" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="8"/>
 <connect gate="A" pin="A1" pad="9"/>
@@ -9907,7 +9907,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRN" x="-10.16" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="A" pin="A0" pad="23"/>
 <connect gate="A" pin="A1" pad="22"/>
@@ -9947,7 +9947,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="A1" pad="34"/>
 <connect gate="A" pin="A2" pad="33"/>
@@ -10002,7 +10002,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="A" pin="!CS!/TX" pad="2"/>
 <connect gate="A" pin="A0" pad="4"/>
@@ -10058,7 +10058,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P1" symbol="6898" x="27.94" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-13X13-52">
+<device name="" package="PLCC-SOCKET-TH-52-13X13">
 <connects>
 <connect gate="P" pin="VDD" pad="1"/>
 <connect gate="P" pin="VSS@1" pad="9"/>
@@ -10126,7 +10126,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-5.08" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-13X13-52">
+<device name="" package="PLCC-SOCKET-TH-52-13X13">
 <connects>
 <connect gate="A" pin="ACK" pad="3"/>
 <connect gate="A" pin="AMEN" pad="22"/>
@@ -10194,7 +10194,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="EXTAL" pad="4"/>
 <connect gate="A" pin="IRQ" pad="2"/>
@@ -10230,7 +10230,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="PWRVSS" x="-7.62" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="EXTAL" pad="4"/>
 <connect gate="A" pin="IRQ" pad="2"/>
@@ -10274,7 +10274,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-10.16" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-11X11-44">
+<device name="" package="PLCC-SOCKET-TH-44-11X11">
 <connects>
 <connect gate="A" pin="IRQ" pad="2"/>
 <connect gate="A" pin="OSC1" pad="43"/>
@@ -10329,7 +10329,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-10.16" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-11X11-44">
+<device name="" package="PLCC-SOCKET-TH-44-11X11">
 <connects>
 <connect gate="A" pin="A10" pad="20"/>
 <connect gate="A" pin="A11" pad="19"/>
@@ -10385,7 +10385,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="VSSVDD" x="-7.62" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="A" pin="IRQ" pad="2"/>
 <connect gate="A" pin="NUM" pad="3"/>
@@ -10429,7 +10429,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="P" symbol="P56009" x="50.8" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-1400L-245H-160F-80">
+<device name="" package="QFP-80-65P-1400W-1400L-245H-160F">
 <connects>
 <connect gate="M" pin="DR/DR" pad="61"/>
 <connect gate="M" pin="DSCK-OS1" pad="60"/>
@@ -10549,7 +10549,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="68HC11A1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-13X13-52">
+<device name="" package="PLCC-SOCKET-TH-52-13X13">
 <connects>
 <connect gate="G$1" pin="!IRQ" pad="19"/>
 <connect gate="G$1" pin="!MR" pad="17"/>
@@ -10616,7 +10616,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="68HC812A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-65P-2000W-2000L-120H-112">
+<device name="" package="TQFP-112-65P-2000W-2000L-120H">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="40"/>
 <connect gate="G$1" pin="ADDR0" pad="52"/>
@@ -10745,7 +10745,7 @@ source MC68HC11F1.pdf</description>
 <gate name="P" symbol="VSSVDD" x="25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="FN2" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="FN2" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!IRQ!" pad="19"/>
 <connect gate="G$1" pin="!RESET!" pad="17"/>
@@ -10822,7 +10822,7 @@ source MC68HC11F1.pdf</description>
 <technology name="V"/>
 </technologies>
 </device>
-<device name="PU2" package="QFP-65P-1400W-1400L-245H-160F-80">
+<device name="PU2" package="QFP-80-65P-1400W-1400L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!IRQ!" pad="52"/>
 <connect gate="G$1" pin="!RESET!" pad="50"/>
@@ -10899,7 +10899,7 @@ source MC68HC11F1.pdf</description>
 <technology name="V"/>
 </technologies>
 </device>
-<device name="PU3" package="QFP-65P-1400W-1400L-245H-160F-80">
+<device name="PU3" package="QFP-80-65P-1400W-1400L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!IRQ!" pad="52"/>
 <connect gate="G$1" pin="!RESET!" pad="50"/>
@@ -10976,7 +10976,7 @@ source MC68HC11F1.pdf</description>
 <technology name="V"/>
 </technologies>
 </device>
-<device name="PU4" package="QFP-65P-1400W-1400L-245H-160F-80">
+<device name="PU4" package="QFP-80-65P-1400W-1400L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!IRQ!" pad="52"/>
 <connect gate="G$1" pin="!RESET!" pad="50"/>
@@ -11052,7 +11052,7 @@ source MC68HC11F1.pdf</description>
 <technology name="V"/>
 </technologies>
 </device>
-<device name="FN3" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="FN3" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!IRQ!" pad="19"/>
 <connect gate="G$1" pin="!RESET!" pad="17"/>
@@ -11129,7 +11129,7 @@ source MC68HC11F1.pdf</description>
 <technology name="V"/>
 </technologies>
 </device>
-<device name="FN4" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="FN4" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!IRQ!" pad="19"/>
 <connect gate="G$1" pin="!RESET!" pad="17"/>
@@ -11213,7 +11213,7 @@ source MC68HC11F1.pdf</description>
 <gate name="G$1" symbol="68HC912" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D60" package="TQFP-65P-2000W-2000L-120H-112">
+<device name="D60" package="TQFP-112-65P-2000W-2000L-120H">
 <connects>
 <connect gate="G$1" pin="!ECLK!/!BDE!/CAL" pad="36"/>
 <connect gate="G$1" pin="!IRQ!" pad="55"/>
@@ -11341,7 +11341,7 @@ source MC68HC11F1.pdf</description>
 <gate name="P" symbol="VSSVDD" x="15.24" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="2"/>
@@ -11364,7 +11364,7 @@ source MC68HC11F1.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="2"/>
@@ -11396,7 +11396,7 @@ source MC68HC11F1.pdf</description>
 <gate name="P" symbol="VSSVDD" x="15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!TE" pad="14"/>
 <connect gate="G$1" pin="A1" pad="1"/>
@@ -11419,7 +11419,7 @@ source MC68HC11F1.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!TE" pad="14"/>
 <connect gate="G$1" pin="A1" pad="1"/>
@@ -11451,7 +11451,7 @@ source MC68HC11F1.pdf</description>
 <gate name="P" symbol="VSSVDD" x="12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="2"/>
@@ -11474,7 +11474,7 @@ source MC68HC11F1.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="2"/>
@@ -12452,7 +12452,7 @@ Source: 9S12A128DGV1.pdf; 9S12A256DGV1.pdf</description>
 <gate name="A" symbol="MC9S12A256" x="58.42" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="TQFP-65P-2000W-2000L-120H-112">
+<device name="" package="TQFP-112-65P-2000W-2000L-120H">
 <connects>
 <connect gate="-PA" pin="PA0" pad="57"/>
 <connect gate="-PA" pin="PA1" pad="58"/>
@@ -12591,7 +12591,7 @@ Source: 9S12A128DGV1.pdf; 9S12A256DGV1.pdf</description>
 <gate name="-PJ" symbol="MC9S12-PJ-80" x="-43.18" y="-10.16" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-1400L-245H-160F-80">
+<device name="" package="QFP-80-65P-1400W-1400L-245H-160F">
 <connects>
 <connect gate="-PA" pin="PA0" pad="41"/>
 <connect gate="-PA" pin="PA1" pad="42"/>
@@ -12688,7 +12688,7 @@ Source: 9S12A128DGV1.pdf; 9S12A256DGV1.pdf</description>
 <gate name="P" symbol="VSSVDD" x="-30.48" y="2.54"/>
 </gates>
 <devices>
-<device name="1" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="1" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="OSC1" pad="3"/>
 <connect gate="A" pin="OSC2/PTA6" pad="4"/>
@@ -12724,7 +12724,7 @@ Source: 9S12A128DGV1.pdf; 9S12A256DGV1.pdf</description>
 <gate name="P" symbol="2PWRVDDA" x="-48.26" y="30.48"/>
 </gates>
 <devices>
-<device name="CFU" package="QFP-80P-1400W-1400L-245H-160F-64">
+<device name="CFU" package="QFP-64-80P-1400W-1400L-245H-160F">
 <connects>
 <connect gate="A" pin="BP0" pad="61"/>
 <connect gate="A" pin="BP1" pad="62"/>
@@ -12803,7 +12803,7 @@ Source: 9S12A128DGV1.pdf; 9S12A256DGV1.pdf</description>
 <gate name="G$1" symbol="MCHC908QT2" x="12.7" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="PTA0/AD0/TCH0/KBI0" pad="7"/>
 <connect gate="G$1" pin="PTA1/AD1/TCH1/KBI1" pad="6"/>

--- a/micro-philips.lbr
+++ b/micro-philips.lbr
@@ -251,7 +251,7 @@ http://www-eu2.semiconductors.com&lt;p&gt;
 <rectangle x1="-6.8999" y1="-4.4" x2="-5.95" y2="-4.1001" layer="51"/>
 <rectangle x1="-6.8999" y1="-4.8999" x2="-5.95" y2="-4.5999" layer="51"/>
 </package>
-<package name="PLCC-127P-2423W-2423L-457H-68">
+<package name="PLCC-68-127P-2423W-2423L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 24.23mm length, 24.23mm width, 4.57mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body width, 4.57mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AE.&lt;/p&gt;
@@ -409,7 +409,7 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <wire x1="12.1158" y1="10.825" x2="12.1158" y2="12.1158" width="0.2032" layer="21"/>
 <wire x1="12.1158" y1="12.1158" x2="10.825" y2="12.1158" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1400W-2000L-315H-160F-100">
+<package name="QFP-100-65P-1400W-2000L-315H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-022B, variation GC-2, PQFP-G.
@@ -1209,7 +1209,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <wire x1="1" y1="-0.625" x2="-1" y2="-0.625" width="0.2032" layer="51"/>
 <wire x1="1" y1="0.625" x2="1" y2="-0.625" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -1274,7 +1274,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -1479,7 +1479,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <rectangle x1="-10.1001" y1="-5.24" x2="-7.5999" y2="-4.92" layer="51"/>
 <rectangle x1="-10.1001" y1="-6.51" x2="-7.5999" y2="-6.19" layer="51"/>
 </package>
-<package name="QFP-80P-1000W-1000L-245H-160F-44">
+<package name="QFP-44-80P-1000W-1000L-245H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-022B, variation AB, PQFP-G.
@@ -1681,7 +1681,7 @@ LQFP-MSQFP-QFP-SQFP-TQFP-REFLOW.pdf</description>
 <rectangle x1="-9.2" y1="-4.25" x2="-7.35" y2="-3.75" layer="51"/>
 <rectangle x1="-9.2" y1="-5.25" x2="-7.35" y2="-4.75" layer="51"/>
 </package>
-<package name="QFP-65P-1000W-1000L-245H-160F-52">
+<package name="QFP-52-65P-1000W-1000L-245H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-022B, variation AC, PQFP-G.
@@ -1799,7 +1799,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-100P-1400W-2000L-345H-195F-64">
+<package name="QFP-64-100P-1400W-2000L-345H-195F">
 <description>&lt;b&gt;QFP (1.00mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.45mm max height, 64 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation CA-2, S-R-PQFP-G.
@@ -1941,7 +1941,7 @@ Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 20mm length, 14mm wi
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1400W-1400L-315H-160F-64">
+<package name="QFP-64-80P-1400W-1400L-315H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm width, 3.15mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-022B, variation BE, PQFP-G.
@@ -2427,7 +2427,7 @@ LQFP-MSQFP-QFP-SQFP-TQFP-REFLOW.pdf</description>
 <rectangle x1="-11.65" y1="-5.35" x2="-10.05" y2="-5.05" layer="51"/>
 <rectangle x1="-11.65" y1="-6.15" x2="-10.05" y2="-5.85" layer="51"/>
 </package>
-<package name="QFP-65P-1400W-1400L-315H-160F-80">
+<package name="QFP-80-65P-1400W-1400L-315H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm width, 3.15mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-022B, variation BF, PQFP-G.
@@ -2601,7 +2601,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1400W-2000L-340H-195F-100">
+<package name="QFP-100-65P-1400W-2000L-340H-195F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation CC-2, S-R-PQFP-G.
@@ -2815,7 +2815,7 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 20mm length, 14mm wi
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-2800W-2800L-385H-160F-128">
+<package name="QFP-128-80P-2800W-2800L-385H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 128 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DB-2, PQFP-G.
@@ -3085,7 +3085,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -3313,7 +3313,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <rectangle x1="-11.55" y1="-4.105" x2="-9.65" y2="-3.755" layer="27"/>
 <rectangle x1="-11.55" y1="-4.905" x2="-9.65" y2="-4.555" layer="27"/>
 </package>
-<package name="PLCC-127P-1658W-1658L-457H-44">
+<package name="PLCC-44-127P-1658W-1658L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 16.59mm length, 16.59mm width, 4.57mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body width, 4.57mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AC.&lt;/p&gt;
@@ -3538,7 +3538,7 @@ SOT536-1.pdf</description>
 <rectangle x1="-2.8" y1="-6.8" x2="-2.3" y2="-6.65" layer="21"/>
 <rectangle x1="-2.8" y1="-6.8" x2="-2.65" y2="-6.3" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-17X17-68">
+<package name="PLCC-SOCKET-TH-68-17X17">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 68 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 &lt;/p&gt;</description>
@@ -4024,7 +4024,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 <rectangle x1="-3.81" y1="-2.5146" x2="-3.429" y2="-2.3876" layer="21"/>
 <rectangle x1="-3.937" y1="-2.9718" x2="-3.683" y2="-2.7178" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-300L-120H-100F-8">
+<package name="SSOP-8-65P-440W-300L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -4053,7 +4053,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <wire x1="1.4" y1="-2.1" x2="1.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="2.1" x2="-1.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -4073,7 +4073,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -4101,7 +4101,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -4133,7 +4133,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -4185,7 +4185,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -4221,7 +4221,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -4255,7 +4255,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -4304,7 +4304,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -4361,7 +4361,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-065-530-16">
+<package name="SSOP-16-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 16 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 16 leads. JEDEC MO-150B. Variation AC.</description>
 <circle x="-2.235" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -4404,7 +4404,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 16 leads. JED
 <wire x1="3.15" y1="-2.6" x2="3.15" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.6" x2="-3.1" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-24">
+<package name="SSOP-24-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 24 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JEDEC MO-150B. Variation AG.</description>
 <circle x="-3.535" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -4463,7 +4463,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <wire x1="4.45" y1="-2.6" x2="4.45" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="4.45" y1="2.6" x2="-4.4" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-2000W-2000L-120H-144">
+<package name="TQFP-144-50P-2000W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
@@ -6840,7 +6840,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="80C552" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="A08-P2.0" pad="39"/>
 <connect gate="G$1" pin="A09-P2.1" pad="40"/>
@@ -7056,7 +7056,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="SAA1064" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="ADR" pad="1"/>
 <connect gate="G$1" pin="CEXT" pad="2"/>
@@ -7087,7 +7087,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="T" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="ADR" pad="1"/>
 <connect gate="G$1" pin="CEXT" pad="2"/>
@@ -7126,7 +7126,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="PCF8574" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -7149,7 +7149,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="T" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -7180,7 +7180,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <gate name="G$1" symbol="PCF8591" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="5"/>
 <connect gate="G$1" pin="A1" pad="6"/>
@@ -7203,7 +7203,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="T" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="5"/>
 <connect gate="G$1" pin="A1" pad="6"/>
@@ -7235,7 +7235,7 @@ with power fail detector</description>
 <gate name="G$1" symbol="PCF8573" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -7258,7 +7258,7 @@ with power fail detector</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="T" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -7290,7 +7290,7 @@ with digital and analog port functions</description>
 <gate name="G$1" symbol="P82C150" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AVDD" pad="18"/>
 <connect gate="G$1" pin="AVSS" pad="20"/>
@@ -7333,7 +7333,7 @@ with digital and analog port functions</description>
 <gate name="G$1" symbol="P82C250" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CANH" pad="7"/>
 <connect gate="G$1" pin="CANL" pad="6"/>
@@ -7356,7 +7356,7 @@ with digital and analog port functions</description>
 <gate name="G$1" symbol="UDA1320" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-16">
+<device name="" package="SSOP-16-65P-530W">
 <connects>
 <connect gate="G$1" pin="APPL0" pad="11"/>
 <connect gate="G$1" pin="APPL1" pad="10"/>
@@ -7387,7 +7387,7 @@ with digital and analog port functions</description>
 <gate name="G$1" symbol="UDA1360T" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-16">
+<device name="" package="SSOP-16-65P-530W">
 <connects>
 <connect gate="G$1" pin="BCK" pad="11"/>
 <connect gate="G$1" pin="DATAO" pad="13"/>
@@ -7433,7 +7433,7 @@ with digital and analog port functions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!INT" pad="7"/>
 <connect gate="G$1" pin="A0" pad="3"/>
@@ -7456,7 +7456,7 @@ with digital and analog port functions</description>
 <gate name="G$1" symbol="PCF8584" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-20">
+<device name="P" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="17"/>
 <connect gate="G$1" pin="!IACK" pad="4"/>
@@ -7483,7 +7483,7 @@ with digital and analog port functions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="T" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="17"/>
 <connect gate="G$1" pin="!IACK" pad="4"/>
@@ -7518,7 +7518,7 @@ with digital and analog port functions</description>
 <gate name="G$1" symbol="UAA3220TS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-24">
+<device name="" package="SSOP-24-65P-530W">
 <connects>
 <connect gate="G$1" pin="CGND" pad="13"/>
 <connect gate="G$1" pin="CPA" pad="15"/>
@@ -7557,7 +7557,7 @@ with digital and analog port functions</description>
 <gate name="G$1" symbol="80C52" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="QFP-80P-1000W-1000L-245H-160F-44">
+<device name="" package="QFP-44-80P-1000W-1000L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!EA" pad="29"/>
 <connect gate="G$1" pin="!PSEN" pad="26"/>
@@ -7617,7 +7617,7 @@ with digital and analog port functions</description>
 <gate name="G$1" symbol="80C52-PLCC44" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="35"/>
 <connect gate="G$1" pin="!PSEN" pad="32"/>
@@ -7678,7 +7678,7 @@ with digital and analog port functions</description>
 <gate name="G$1" symbol="80C52DIL40" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PN" package="DIP-600-40">
+<device name="PN" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!EA" pad="31"/>
 <connect gate="G$1" pin="!PSEN" pad="29"/>
@@ -7732,7 +7732,7 @@ with digital and analog port functions</description>
 <technology name="3C652"/>
 </technologies>
 </device>
-<device name="AA" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="AA" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="35"/>
 <connect gate="G$1" pin="!PSEN" pad="32"/>
@@ -7784,7 +7784,7 @@ with digital and analog port functions</description>
 <technology name="0C32UF"/>
 </technologies>
 </device>
-<device name="BB" package="QFP-80P-1000W-1000L-245H-160F-44">
+<device name="BB" package="QFP-44-80P-1000W-1000L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!EA" pad="29"/>
 <connect gate="G$1" pin="!PSEN" pad="26"/>
@@ -7845,7 +7845,7 @@ with digital and analog port functions</description>
 <gate name="P" symbol="PWR" x="48.26" y="-22.86" addlevel="can"/>
 </gates>
 <devices>
-<device name="SOCKEL" package="PLCC-SOCKET-TH-17X17-68">
+<device name="SOCKEL" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="G" pin="!EW!" pad="6"/>
 <connect gate="G" pin="ALE" pad="45"/>
@@ -7920,7 +7920,7 @@ with digital and analog port functions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SMD" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="SMD" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G" pin="!EW!" pad="6"/>
 <connect gate="G" pin="ALE" pad="45"/>
@@ -8004,7 +8004,7 @@ with digital and analog port functions</description>
 <gate name="G" symbol="8XC562" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-17X17-68">
+<device name="" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="G" pin="!EW!" pad="6"/>
 <connect gate="G" pin="ALE" pad="48"/>
@@ -8079,7 +8079,7 @@ with digital and analog port functions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SMD" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="SMD" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G" pin="!EW!" pad="6"/>
 <connect gate="G" pin="ALE" pad="48"/>
@@ -8164,7 +8164,7 @@ with digital and analog port functions</description>
 <gate name="P" symbol="PWR2" x="45.72" y="-20.32"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G" pin="A0" pad="5"/>
 <connect gate="G" pin="A1" pad="4"/>
@@ -8204,7 +8204,7 @@ with digital and analog port functions</description>
 <gate name="P" symbol="PWR2" x="35.56" y="-10.16"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G" pin="A0" pad="5"/>
 <connect gate="G" pin="A1" pad="4"/>
@@ -8245,7 +8245,7 @@ with digital and analog port functions</description>
 <gate name="G" symbol="8XC576" x="0" y="-17.78"/>
 </gates>
 <devices>
-<device name="SMD" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="SMD" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="A" pin="AGND" pad="3"/>
 <connect gate="A" pin="AVCC" pad="2"/>
@@ -8296,7 +8296,7 @@ with digital and analog port functions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="S" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="A" pin="AGND" pad="3"/>
 <connect gate="A" pin="AVCC" pad="2"/>
@@ -8458,7 +8458,7 @@ with digital and analog port functions</description>
 <gate name="NC" symbol="NC2" x="40.64" y="0" addlevel="can"/>
 </gates>
 <devices>
-<device name="TD" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="TD" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G" pin="LX" pad="2"/>
 <connect gate="G" pin="LY" pad="7"/>
@@ -8488,7 +8488,7 @@ with digital and analog port functions</description>
 <gate name="VSS3" symbol="VSS" x="38.1" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="T" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="T" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="4"/>
 <connect gate="G$1" pin="!INT!" pad="16"/>
@@ -8532,7 +8532,7 @@ Dual bi-directional I2C bus buffer</description>
 <gate name="G$1" symbol="P82B96" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PN" package="DIP-300-8">
+<device name="PN" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="RX(SDA)" pad="2"/>
@@ -8547,7 +8547,7 @@ Dual bi-directional I2C bus buffer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TD" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="TD" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="RX(SDA)" pad="2"/>
@@ -8562,7 +8562,7 @@ Dual bi-directional I2C bus buffer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DP" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="DP" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="RX(SDA)" pad="2"/>

--- a/micro-siemens.lbr
+++ b/micro-siemens.lbr
@@ -76,7 +76,7 @@
 www.siemens.de&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="QFP-65P-1400W-2000L-315H-160F-100">
+<package name="QFP-100-65P-1400W-2000L-315H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-022B, variation GC-2, PQFP-G.
@@ -464,7 +464,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <rectangle x1="9.873" y1="-6.2" x2="11.473" y2="-5.8" layer="51"/>
 <rectangle x1="-11.473" y1="-6.2" x2="-9.873" y2="-5.8" layer="51"/>
 </package>
-<package name="QFP-65P-1400W-1400L-245H-160F-80">
+<package name="QFP-80-65P-1400W-1400L-245H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-022B, variation BC, PQFP-G.
@@ -638,7 +638,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1400W-1400L-245H-160F-64">
+<package name="QFP-64-80P-1400W-1400L-245H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-022B, variation BB, PQFP-G.
@@ -780,7 +780,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1000W-1000L-245H-160F-44">
+<package name="QFP-44-80P-1000W-1000L-245H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-022B, variation AB, PQFP-G.
@@ -882,7 +882,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-2800W-2800L-385H-160F-144">
+<package name="QFP-144-65P-2800W-2800L-385H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DC-2, PQFP-G.
@@ -1184,7 +1184,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-2800W-2800L-385H-160F-160">
+<package name="QFP-160-65P-2800W-2800L-385H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 160 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DD-2, PQFP-G.
@@ -1518,7 +1518,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-700W-700L-120H-48">
+<package name="TQFP-48-50P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
@@ -1895,7 +1895,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <rectangle x1="7.11" y1="-10.873" x2="7.385" y2="-9.868" layer="51"/>
 <rectangle x1="7.61" y1="-10.873" x2="7.885" y2="-9.868" layer="51"/>
 </package>
-<package name="TQFP-50P-2000W-2000L-120H-144">
+<package name="TQFP-144-50P-2000W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
@@ -2197,7 +2197,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-2000W-2000L-120H-176">
+<package name="TQFP-176-40P-2000W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 176 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFC, T-PQFP-G.
@@ -2942,7 +2942,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20m
 <rectangle x1="-10.872" y1="-8.715" x2="-9.873" y2="-8.485" layer="51"/>
 <rectangle x1="-10.872" y1="-9.115" x2="-9.873" y2="-8.885" layer="51"/>
 </package>
-<package name="QFP-50P-2800W-2800L-385H-130F-208">
+<package name="QFP-208-50P-2800W-2800L-385H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation FA-2, S-R-PQFP.
@@ -4265,7 +4265,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm lengt
 <rectangle x1="-15.473" y1="-12.2" x2="-13.693" y2="-11.85" layer="51"/>
 <rectangle x1="-15.473" y1="-12.85" x2="-13.693" y2="-12.5" layer="51"/>
 </package>
-<package name="PLCC-127P-2423W-2423L-457H-68">
+<package name="PLCC-68-127P-2423W-2423L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 24.23mm length, 24.23mm width, 4.57mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body width, 4.57mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AE.&lt;/p&gt;
@@ -4504,7 +4504,7 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <text x="-11.43" y="14.605" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-5.715" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="PLCC-127P-1658W-1658L-457H-44">
+<package name="PLCC-44-127P-1658W-1658L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 16.59mm length, 16.59mm width, 4.57mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body width, 4.57mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AC.&lt;/p&gt;
@@ -4614,7 +4614,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <wire x1="8.2931" y1="7.015" x2="8.2931" y2="8.2931" width="0.2032" layer="21"/>
 <wire x1="8.2931" y1="8.2931" x2="7.015" y2="8.2931" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-2931W-2931L-457H-84">
+<package name="PLCC-84-127P-2931W-2931L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 29.31mm length, 29.31mm width, 4.57mm max height, 84 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 29.31mm body length, 29.31mm body width, 4.57mm max height, 84 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AF.&lt;/p&gt;
@@ -5065,7 +5065,7 @@ JEDEC MS-018A, variation AF.&lt;/p&gt;
 <vertex x="2.5654" y="3.887"/>
 </polygon>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -5122,7 +5122,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="PLCC-SOCKET-TH-17X17-68">
+<package name="PLCC-SOCKET-TH-68-17X17">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 68 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 &lt;/p&gt;</description>
@@ -6153,7 +6153,7 @@ Emulation Technology, Inc.</description>
 <text x="-4.445" y="3.175" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-4.445" y="-4.445" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="PLCC-SOCKET-TH-21X21-84">
+<package name="PLCC-SOCKET-TH-84-21X21">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 68 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 &lt;/p&gt;</description>
@@ -6793,7 +6793,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 <rectangle x1="-16.5001" y1="-11.59" x2="-14" y2="-11.27" layer="51"/>
 <rectangle x1="-16.5001" y1="-12.86" x2="-14" y2="-12.54" layer="51"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -7048,7 +7048,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <vertex x="4.5654" y="7.267"/>
 </polygon>
 </package>
-<package name="TQFP-50P-1000W-1000L-120H-64">
+<package name="TQFP-64-50P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.
@@ -7190,7 +7190,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -7220,7 +7220,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -7252,7 +7252,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -7304,7 +7304,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -7344,7 +7344,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-22">
+<package name="DIP-22-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="-14.605" y1="-0.635" x2="-14.605" y2="-1.905" width="0.2032" layer="21"/>
@@ -10226,7 +10226,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="6_VCCVSS" x="-50.8" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-2000L-315H-160F-100">
+<device name="" package="QFP-100-65P-1400W-2000L-315H-160F">
 <connects>
 <connect gate="G$1" pin="!BUSACT" pad="22"/>
 <connect gate="G$1" pin="!NMI" pad="29"/>
@@ -10342,7 +10342,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="6_VCCVSS" x="-58.42" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-2000L-315H-160F-100">
+<device name="" package="QFP-100-65P-1400W-2000L-315H-160F">
 <connects>
 <connect gate="G$1" pin="!EA" pad="39"/>
 <connect gate="G$1" pin="!NMI" pad="83"/>
@@ -10458,7 +10458,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="6_VCCVSS" x="-50.8" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="37"/>
 <connect gate="G$1" pin="!NMI" pad="81"/>
@@ -10574,7 +10574,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="10VCCVSS" x="-30.48" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-2800W-2800L-385H-160F-144">
+<device name="" package="QFP-144-65P-2800W-2800L-385H-160F">
 <connects>
 <connect gate="G$1" pin="!EA" pad="99"/>
 <connect gate="G$1" pin="!NMI" pad="142"/>
@@ -10734,7 +10734,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC2GND" x="-35.56" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!BHE!/S7" pad="5"/>
 <connect gate="G$1" pin="!DEN" pad="48"/>
@@ -10818,7 +10818,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2VSS" x="-20.32" y="20.32" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="35"/>
 <connect gate="G$1" pin="!PSEN" pad="33"/>
@@ -10878,7 +10878,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC3VSS" x="-38.1" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2931W-2931L-457H-84">
+<device name="" package="PLCC-84-127P-2931W-2931L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="51"/>
 <connect gate="G$1" pin="!PE!/SWD" pad="4"/>
@@ -10969,7 +10969,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <technology name=""/>
 </technologies>
 </device>
-<device name="SOC" package="PLCC-SOCKET-TH-21X21-84">
+<device name="SOC" package="PLCC-SOCKET-TH-84-21X21">
 <connects>
 <connect gate="G$1" pin="!EA" pad="51"/>
 <connect gate="G$1" pin="!PE!/SWD" pad="4"/>
@@ -11069,7 +11069,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC2VSS" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-2000L-315H-160F-100">
+<device name="" package="QFP-100-65P-1400W-2000L-315H-160F">
 <connects>
 <connect gate="G$1" pin="!EA" pad="24"/>
 <connect gate="G$1" pin="!PE!/SWD" pad="67"/>
@@ -11185,7 +11185,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC2VSS" x="-30.48" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2931W-2931L-457H-84">
+<device name="" package="PLCC-84-127P-2931W-2931L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="51"/>
 <connect gate="G$1" pin="!HWPD" pad="60"/>
@@ -11276,7 +11276,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <technology name=""/>
 </technologies>
 </device>
-<device name="SOC" package="PLCC-SOCKET-TH-21X21-84">
+<device name="SOC" package="PLCC-SOCKET-TH-84-21X21">
 <connects>
 <connect gate="G$1" pin="!EA" pad="51"/>
 <connect gate="G$1" pin="!HWPD" pad="60"/>
@@ -11376,7 +11376,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC2VSS" x="-25.4" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-1400W-2000L-315H-160F-100">
+<device name="" package="QFP-100-65P-1400W-2000L-315H-160F">
 <connects>
 <connect gate="G$1" pin="!EA" pad="24"/>
 <connect gate="G$1" pin="!HWPD" pad="36"/>
@@ -11492,7 +11492,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCVSS" x="-35.56" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="60"/>
 <connect gate="G$1" pin="!PSEN" pad="58"/>
@@ -11576,7 +11576,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCVSS" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="51"/>
 <connect gate="G$1" pin="!HWPD" pad="68"/>
@@ -11651,7 +11651,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <technology name=""/>
 </technologies>
 </device>
-<device name="SOCK" package="PLCC-SOCKET-TH-17X17-68">
+<device name="SOCK" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="G$1" pin="!EA" pad="51"/>
 <connect gate="G$1" pin="!HWPD" pad="68"/>
@@ -11735,7 +11735,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCVSS" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="35"/>
 <connect gate="G$1" pin="!PSEN" pad="32"/>
@@ -11795,7 +11795,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCVSS" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!EA" pad="31"/>
 <connect gate="G$1" pin="!PSEN" pad="29"/>
@@ -11851,7 +11851,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2VSS" x="-35.56" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!EA" pad="35"/>
 <connect gate="G$1" pin="!PSEN" pad="33"/>
@@ -11911,7 +11911,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCVSS" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!INTA" pad="11"/>
 <connect gate="G$1" pin="!RD" pad="32"/>
@@ -11967,7 +11967,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-35.56" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!DEN" pad="26"/>
 <connect gate="G$1" pin="!INTA" pad="24"/>
@@ -12023,7 +12023,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-30.48" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!DEN" pad="29"/>
 <connect gate="G$1" pin="!INTA" pad="27"/>
@@ -12083,7 +12083,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC2GND" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!DEN" pad="48"/>
 <connect gate="G$1" pin="!LCS" pad="42"/>
@@ -12167,7 +12167,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!BHE!/S7" pad="34"/>
 <connect gate="G$1" pin="!LOCK" pad="29"/>
@@ -12223,7 +12223,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC3GND" x="-30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!BHE" pad="10"/>
 <connect gate="G$1" pin="!BUSY" pad="63"/>
@@ -12391,7 +12391,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-30.48" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="11"/>
 <connect gate="G$1" pin="!IOR" pad="1"/>
@@ -12447,7 +12447,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-27.94" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="11"/>
 <connect gate="G$1" pin="!IOR" pad="1"/>
@@ -12503,7 +12503,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-30.48" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="1"/>
 <connect gate="G$1" pin="!INTA" pad="26"/>
@@ -12547,7 +12547,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!OE" pad="9"/>
 <connect gate="G$1" pin="DI0" pad="1"/>
@@ -12583,7 +12583,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!DO0" pad="19"/>
 <connect gate="G$1" pin="!DO1" pad="18"/>
@@ -12619,7 +12619,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!AEN1" pad="3"/>
 <connect gate="G$1" pin="!AEN2" pad="7"/>
@@ -12653,7 +12653,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!OE" pad="9"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -12689,7 +12689,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!B0" pad="19"/>
 <connect gate="G$1" pin="!B1" pad="18"/>
@@ -12725,7 +12725,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!AEN" pad="6"/>
 <connect gate="G$1" pin="!AIOWC" pad="12"/>
@@ -12761,7 +12761,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!AEN" pad="13"/>
 <connect gate="G$1" pin="!BCLK" pad="5"/>
@@ -12797,7 +12797,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-27.94" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-22">
+<device name="" package="DIP-22-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="16"/>
 <connect gate="G$1" pin="!RD" pad="17"/>
@@ -12835,7 +12835,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC3GND" x="-30.48" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2931W-2931L-457H-84">
+<device name="" package="PLCC-84-127P-2931W-2931L-457H">
 <connects>
 <connect gate="G$1" pin="!ACK" pad="33"/>
 <connect gate="G$1" pin="!AEN16" pad="64"/>
@@ -12935,7 +12935,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC2GND" x="-33.02" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!DEN" pad="42"/>
 <connect gate="G$1" pin="!PEX" pad="9"/>
@@ -13019,7 +13019,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC2GND" x="-30.48" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!DEN" pad="42"/>
 <connect gate="G$1" pin="!PEV" pad="9"/>
@@ -13103,7 +13103,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC2GND" x="-25.4" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!CCS" pad="5"/>
 <connect gate="G$1" pin="!CS0" pad="29"/>
@@ -13187,7 +13187,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC2GND" x="-27.94" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!AEN" pad="64"/>
 <connect gate="G$1" pin="!DENIN" pad="42"/>
@@ -13271,7 +13271,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC2GND" x="-27.94" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!AEN" pad="64"/>
 <connect gate="G$1" pin="!BCLK" pad="53"/>
@@ -13355,7 +13355,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC2GND" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!AEN" pad="28"/>
 <connect gate="G$1" pin="!BHE" pad="50"/>
@@ -13439,7 +13439,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC2GND" x="-27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!BHE" pad="10"/>
 <connect gate="G$1" pin="!CS" pad="17"/>
@@ -13523,7 +13523,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC2GND" x="-27.94" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!BHE" pad="10"/>
 <connect gate="G$1" pin="!CS" pad="17"/>
@@ -13607,7 +13607,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!ARDY" pad="1"/>
 <connect gate="G$1" pin="!ARDYEN" pad="17"/>
@@ -13641,7 +13641,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!INTA" pad="13"/>
 <connect gate="G$1" pin="!IORC" pad="12"/>
@@ -13677,7 +13677,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="VCCGND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!AEN" pad="13"/>
 <connect gate="G$1" pin="!ALWAYS" pad="15"/>
@@ -13712,7 +13712,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="G$1" symbol="82532" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="3"/>
@@ -13797,7 +13797,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="+VBB" x="30.48" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="GND" pad="2"/>
 <connect gate="A" pin="IN1" pad="3"/>
@@ -13834,7 +13834,7 @@ Source: http://www.infineon.com/cmc_upload/migrated_files/document_files/Datashe
 <gate name="P" symbol="2VCC1GND" x="30.48" y="38.1" addlevel="request"/>
 </gates>
 <devices>
-<device name="M" package="QFP-65P-1400W-1400L-245H-160F-80">
+<device name="M" package="QFP-80-65P-1400W-1400L-245H-160F">
 <connects>
 <connect gate="G$1" pin="ALE" pad="48"/>
 <connect gate="G$1" pin="CLKOUTP1.6" pad="25"/>
@@ -13909,7 +13909,7 @@ Source: http://www.infineon.com/cmc_upload/migrated_files/document_files/Datashe
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="N" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="ALE" pad="50"/>
 <connect gate="G$1" pin="CLKOUTP1.6" pad="30"/>
@@ -13984,7 +13984,7 @@ Source: http://www.infineon.com/cmc_upload/migrated_files/document_files/Datashe
 <technology name=""/>
 </technologies>
 </device>
-<device name="N-S" package="PLCC-SOCKET-TH-17X17-68">
+<device name="N-S" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="G$1" pin="ALE" pad="50"/>
 <connect gate="G$1" pin="CLKOUTP1.6" pad="30"/>

--- a/microchip.lbr
+++ b/microchip.lbr
@@ -85,7 +85,7 @@ Based on the following sources :
 &lt;/ul&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -105,7 +105,7 @@ Based on the following sources :
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="PLCC-SOCKET-TH-11X11-44">
+<package name="PLCC-SOCKET-TH-44-11X11">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 44 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 &lt;/p&gt;</description>
@@ -480,7 +480,7 @@ Source: http://www.microchip.com .. 39637a.pdf</description>
 <rectangle x1="-1.859" y1="-1.859" x2="1.859" y2="1.859" layer="29"/>
 <rectangle x1="-1.7355" y1="-1.7355" x2="1.7355" y2="1.7355" layer="31"/>
 </package>
-<package name="TQFP-50P-1200W-1200L-120H-80">
+<package name="TQFP-80-50P-1200W-1200L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ADD, T-PQFP-G.
@@ -993,7 +993,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39776a.pdf</description>
 <rectangle x1="-2.4625" y1="2.7125" x2="-2.0375" y2="3.1125" layer="29" rot="R270"/>
 <rectangle x1="-2.9" y1="0" x2="0" y2="2.9" layer="51"/>
 </package>
-<package name="SSOP-065-530-20">
+<package name="SSOP-20-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 20 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JEDEC MO-150B. Variation AE.</description>
 <circle x="-2.885" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -1044,7 +1044,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <wire x1="3.8" y1="-2.6" x2="3.8" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.6" x2="-3.75" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1658W-1658L-457H-44">
+<package name="PLCC-44-127P-1658W-1658L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 16.59mm length, 16.59mm width, 4.57mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body width, 4.57mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AC.&lt;/p&gt;
@@ -1154,7 +1154,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <wire x1="8.2931" y1="7.015" x2="8.2931" y2="8.2931" width="0.2032" layer="21"/>
 <wire x1="8.2931" y1="8.2931" x2="7.015" y2="8.2931" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-2423W-2423L-457H-68">
+<package name="PLCC-68-127P-2423W-2423L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 24.23mm length, 24.23mm width, 4.57mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body width, 4.57mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AE.&lt;/p&gt;
@@ -1312,7 +1312,7 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <wire x1="12.1158" y1="10.825" x2="12.1158" y2="12.1158" width="0.2032" layer="21"/>
 <wire x1="12.1158" y1="12.1158" x2="10.825" y2="12.1158" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1397W-1143L-355H-32">
+<package name="PLCC-32-127P-1397W-1143L-355H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 11.43mm length, 13.97mm width, 3.56mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Rectangular plastic leaded chip carrier. 1.27mm pitch, 11.43mm body length, 13.97mm body width, 3.56mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-016A, variation AE.&lt;/p&gt;
@@ -1398,7 +1398,7 @@ JEDEC MS-016A, variation AE.&lt;/p&gt;
 <wire x1="5.715" y1="5.745" x2="5.715" y2="6.985" width="0.2032" layer="21"/>
 <wire x1="5.715" y1="6.985" x2="4.475" y2="6.985" width="0.2032" layer="21"/>
 </package>
-<package name="LCC-127P-1650W-1650L-304H-44">
+<package name="LCC-44-127P-1650W-1650L-304H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 16.51mm length, 16.51mm width, 3.05mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 16.51mm body length, 16.51mm body width, 3.05mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CD.&lt;/p&gt;
@@ -1752,7 +1752,7 @@ Also known as SOT54. Formerly standardized as JEDEC TO-92.
 <wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
 <wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
 </package>
-<package name="PLCC-127P-896W-896L-457H-20">
+<package name="PLCC-20-127P-896W-896L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 8.97mm length, 8.97mm width, 4.57mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 8.97mm body length, 8.97mm body width, 4.57mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AA.&lt;/p&gt;
@@ -1814,7 +1814,7 @@ JEDEC MS-018A, variation AA.&lt;/p&gt;
 <wire x1="4.4831" y1="3.205" x2="4.4831" y2="4.4831" width="0.2032" layer="21"/>
 <wire x1="4.4831" y1="4.4831" x2="3.205" y2="4.4831" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1400W-1400L-120H-64">
+<package name="TQFP-64-80P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.
@@ -1956,7 +1956,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-300L-120H-100F-8">
+<package name="SSOP-8-65P-440W-300L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -1985,7 +1985,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <wire x1="1.4" y1="-2.1" x2="1.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="2.1" x2="-1.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -2220,7 +2220,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <wire x1="1.45" y1="0.65" x2="1.45" y2="-0.65" width="0.2032" layer="51"/>
 <wire x1="1.45" y1="0.65" x2="0.5" y2="0.65" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -2250,7 +2250,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -2302,7 +2302,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -2342,7 +2342,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -2378,7 +2378,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -2418,7 +2418,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-900-64">
+<package name="DIP-64-254P-2286W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 900 mil row spacing, JEDEC MO-016D</description>
 <wire x1="-41.275" y1="-0.9525" x2="-41.275" y2="-9.4615" width="0.2032" layer="21"/>
@@ -2494,7 +2494,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <text x="-42.545" y="-10.16" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-36.83" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-14">
+<package name="SSOP-14-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
@@ -2535,7 +2535,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -2612,7 +2612,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <text x="-2.54" y="3.175" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2.54" y="-3.81" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -2638,7 +2638,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -2672,7 +2672,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-530W-530L-210H-125F-8">
+<package name="SOP-8-127P-530W-530L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -2705,7 +2705,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="2.625" y1="-2.625" x2="-2.625" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="2.625" x2="-2.625" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-530L-265H-140F-8">
+<package name="SOP-8-127P-750W-530L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads.&lt;/p&gt;
 
@@ -2738,7 +2738,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 5.30mm length,
 <wire x1="2.625" y1="-3.725" x2="-2.625" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="3.725" x2="-2.625" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -2784,7 +2784,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1155L-265H-140F-18">
+<package name="SOP-18-127P-750W-1155L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
@@ -2837,7 +2837,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-065-530-28">
+<package name="SSOP-28-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 28 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JEDEC MO-150B. Variation AH.</description>
 <circle x="-4.185" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -2904,7 +2904,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <wire x1="5.1" y1="-2.6" x2="5.1" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="5.1" y1="2.6" x2="-5.05" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1000W-1000L-120H-44">
+<package name="TQFP-44-80P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
@@ -3006,7 +3006,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1000W-1000L-120H-64">
+<package name="TQFP-64-50P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.
@@ -3282,7 +3282,7 @@ type I, package type TS</description>
 <rectangle x1="-0.975" y1="-6.75" x2="-0.675" y2="-5.55" layer="51"/>
 <rectangle x1="-0.425" y1="-6.75" x2="-0.125" y2="-5.55" layer="51"/>
 </package>
-<package name="QFP-80P-1000W-1000L-245H-160F-44">
+<package name="QFP-44-80P-1000W-1000L-245H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-022B, variation AB, PQFP-G.
@@ -3384,7 +3384,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -3433,7 +3433,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -3506,7 +3506,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -3603,7 +3603,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <rectangle x1="-2" y1="1.5" x2="-1.5" y2="2" layer="21"/>
 <smd name="21" x="0" y="0" dx="2" dy="2" layer="1"/>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -3656,7 +3656,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <wire x1="1" y1="-0.625" x2="-1" y2="-0.625" width="0.2032" layer="51"/>
 <wire x1="1" y1="0.625" x2="1" y2="-0.625" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-24">
+<package name="SSOP-24-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 24 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JEDEC MO-150B. Variation AG.</description>
 <circle x="-3.535" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -3742,7 +3742,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <wire x1="1.45" y1="-0.65" x2="1.45" y2="0.65" width="0.2032" layer="21"/>
 <wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-650L-120H-100F-20">
+<package name="SSOP-20-65P-440W-650L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
@@ -10877,7 +10877,7 @@ see also &lt;a href=PIC16F8*&gt;PIC16F8*&lt;/a&gt;</description>
 <gate name="G$1" symbol="13IO-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-18">
+<device name="P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="16"/>
@@ -10933,7 +10933,7 @@ see also &lt;a href=PIC16F8*&gt;PIC16F8*&lt;/a&gt;</description>
 <technology name="R84"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="16"/>
@@ -10993,7 +10993,7 @@ see also &lt;a href=PIC16F8*&gt;PIC16F8*&lt;/a&gt;</description>
 <gate name="G$1" symbol="13IO-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-18">
+<device name="P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="16"/>
@@ -11018,7 +11018,7 @@ see also &lt;a href=PIC16F8*&gt;PIC16F8*&lt;/a&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JW" package="DIP-300-18">
+<device name="JW" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="16"/>
@@ -11043,7 +11043,7 @@ see also &lt;a href=PIC16F8*&gt;PIC16F8*&lt;/a&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="16"/>
@@ -11077,7 +11077,7 @@ EPROM/ROM-based</description>
 <gate name="G$1" symbol="13IO-1SS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-20">
+<device name="" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="18"/>
@@ -11114,7 +11114,7 @@ EPROM/ROM-based</description>
 <gate name="G$1" symbol="13IO-1SS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SS" package="SSOP-065-530-20">
+<device name="SS" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="18"/>
@@ -11152,7 +11152,7 @@ EPROM/ROM-based</description>
 <gate name="G$1" symbol="20IO-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="28"/>
 <connect gate="G$1" pin="NC" pad="3"/>
@@ -11189,7 +11189,7 @@ EPROM/ROM-based</description>
 <technology name="7A"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="28"/>
 <connect gate="G$1" pin="NC" pad="3"/>
@@ -11226,7 +11226,7 @@ EPROM/ROM-based</description>
 <technology name="7A"/>
 </technologies>
 </device>
-<device name="SS" package="SSOP-065-530-28">
+<device name="SS" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="28"/>
 <connect gate="G$1" pin="NC" pad="3"/>
@@ -11271,7 +11271,7 @@ EPROM/ROM-based</description>
 <gate name="G$1" symbol="33IO-1A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-40">
+<device name="P" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="13"/>
@@ -11320,7 +11320,7 @@ EPROM/ROM-based</description>
 <technology name="B"/>
 </technologies>
 </device>
-<device name="JW" package="DIP-600-40">
+<device name="JW" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="13"/>
@@ -11381,7 +11381,7 @@ PIC16CR65, PIC16C67, PIC16C74A, PIC16C77</description>
 <gate name="G$1" symbol="33IO-1A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-40">
+<device name="P" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="13"/>
@@ -11434,7 +11434,7 @@ PIC16CR65, PIC16C67, PIC16C74A, PIC16C77</description>
 <technology name="R65"/>
 </technologies>
 </device>
-<device name="JW" package="DIP-600-40">
+<device name="JW" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="13"/>
@@ -11495,7 +11495,7 @@ PIC16CR65, PIC16C67, PIC16C74A, PIC16C77</description>
 <gate name="G$1" symbol="33IO-1A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-40">
+<device name="P" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="13"/>
@@ -11542,7 +11542,7 @@ PIC16CR65, PIC16C67, PIC16C74A, PIC16C77</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JW" package="DIP-600-40">
+<device name="JW" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="13"/>
@@ -11599,7 +11599,7 @@ EPROM/ROM-based</description>
 <gate name="G$1" symbol="33IO-1A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-40">
+<device name="P" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="13"/>
@@ -11655,7 +11655,7 @@ EPROM/ROM-based</description>
 <gate name="G$1" symbol="33IO-MQ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="L" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="L" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="2"/>
 <connect gate="G$1" pin="NC" pad="1"/>
@@ -11708,7 +11708,7 @@ EPROM/ROM-based</description>
 <technology name="B"/>
 </technologies>
 </device>
-<device name="PQ" package="QFP-80P-1000W-1000L-245H-160F-44">
+<device name="PQ" package="QFP-44-80P-1000W-1000L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="18"/>
 <connect gate="G$1" pin="NC" pad="12"/>
@@ -11761,7 +11761,7 @@ EPROM/ROM-based</description>
 <technology name="B"/>
 </technologies>
 </device>
-<device name="TQ" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="TQ" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="18"/>
 <connect gate="G$1" pin="NC" pad="12"/>
@@ -11825,7 +11825,7 @@ Note:This product is obsolete.</description>
 <gate name="G$1" symbol="33IO-MQ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PQ" package="QFP-80P-1000W-1000L-245H-160F-44">
+<device name="PQ" package="QFP-44-80P-1000W-1000L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="18"/>
 <connect gate="G$1" pin="NC" pad="12"/>
@@ -11876,7 +11876,7 @@ Note:This product is obsolete.</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="L" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="L" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="2"/>
 <connect gate="G$1" pin="NC" pad="1"/>
@@ -11939,7 +11939,7 @@ PIC16CR65, PIC16C67, PIC16C74A, PIC16C77</description>
 <gate name="G$1" symbol="33IO-MQ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="L" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="L" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="2"/>
 <connect gate="G$1" pin="NC" pad="1"/>
@@ -11996,7 +11996,7 @@ PIC16CR65, PIC16C67, PIC16C74A, PIC16C77</description>
 <technology name="R65"/>
 </technologies>
 </device>
-<device name="PQ" package="QFP-80P-1000W-1000L-245H-160F-44">
+<device name="PQ" package="QFP-44-80P-1000W-1000L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="18"/>
 <connect gate="G$1" pin="NC" pad="12"/>
@@ -12061,7 +12061,7 @@ PIC16CR65, PIC16C67, PIC16C74A, PIC16C77</description>
 <gate name="G$1" symbol="33IO-MQ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="L" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="L" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="2"/>
 <connect gate="G$1" pin="NC" pad="1"/>
@@ -12112,7 +12112,7 @@ PIC16CR65, PIC16C67, PIC16C74A, PIC16C77</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PT" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="PT" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="18"/>
 <connect gate="G$1" pin="NC" pad="12"/>
@@ -12172,7 +12172,7 @@ EPROM/ROM-based</description>
 <gate name="G$1" symbol="33IO-MQ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PQ" package="QFP-80P-1000W-1000L-245H-160F-44">
+<device name="PQ" package="QFP-44-80P-1000W-1000L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="18"/>
 <connect gate="G$1" pin="NC" pad="12"/>
@@ -12224,7 +12224,7 @@ EPROM/ROM-based</description>
 <technology name="4A"/>
 </technologies>
 </device>
-<device name="L" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="L" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="18"/>
 <connect gate="G$1" pin="NC" pad="12"/>
@@ -12276,7 +12276,7 @@ EPROM/ROM-based</description>
 <technology name="5"/>
 </technologies>
 </device>
-<device name="TQ" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="TQ" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="18"/>
 <connect gate="G$1" pin="NC" pad="12"/>
@@ -12336,7 +12336,7 @@ EPROM/ROM-based</description>
 <gate name="G$1" symbol="33IO-1A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-40">
+<device name="P" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="13"/>
@@ -12392,7 +12392,7 @@ EPROM/ROM-based</description>
 <gate name="G$1" symbol="13IO-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="16"/>
@@ -12417,7 +12417,7 @@ EPROM/ROM-based</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-18">
+<device name="P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="16"/>
@@ -12454,7 +12454,7 @@ see also &lt;a href=PIC16C*&gt;PIC16C*&lt;/a&gt;</description>
 <gate name="G$1" symbol="13IO-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="16"/>
@@ -12480,7 +12480,7 @@ see also &lt;a href=PIC16C*&gt;PIC16C*&lt;/a&gt;</description>
 <technology name="4A"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-18">
+<device name="P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="16"/>
@@ -12518,7 +12518,7 @@ PIC16C66, PIC16C72, PIC16C73A, PIC16C76</description>
 <gate name="G$1" symbol="22IO-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SS" package="SSOP-065-530-28">
+<device name="SS" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="9"/>
@@ -12560,7 +12560,7 @@ PIC16C66, PIC16C72, PIC16C73A, PIC16C76</description>
 <technology name="R63"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="9"/>
@@ -12602,7 +12602,7 @@ PIC16C66, PIC16C72, PIC16C73A, PIC16C76</description>
 <technology name="R63"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="9"/>
@@ -12644,7 +12644,7 @@ PIC16C66, PIC16C72, PIC16C73A, PIC16C76</description>
 <technology name="R63"/>
 </technologies>
 </device>
-<device name="PS" package="DIP-300-28">
+<device name="PS" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="9"/>
@@ -12686,7 +12686,7 @@ PIC16C66, PIC16C72, PIC16C73A, PIC16C76</description>
 <technology name="R63"/>
 </technologies>
 </device>
-<device name="JW" package="DIP-600-28">
+<device name="JW" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="9"/>
@@ -12737,7 +12737,7 @@ EPROM/ROM-based</description>
 <gate name="G$1" symbol="22IO-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="9"/>
@@ -12772,7 +12772,7 @@ EPROM/ROM-based</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="9"/>
@@ -12815,7 +12815,7 @@ EPROM/ROM-based</description>
 <gate name="G$1" symbol="22IO-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="9"/>
@@ -12850,7 +12850,7 @@ EPROM/ROM-based</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="9"/>
@@ -12885,7 +12885,7 @@ EPROM/ROM-based</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JW" package="DIP-600-28">
+<device name="JW" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="9"/>
@@ -12929,7 +12929,7 @@ EPROM-based</description>
 <gate name="G$1" symbol="33IO-1MQ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="L" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="L" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="35"/>
 <connect gate="G$1" pin="NC" pad="2"/>
@@ -12982,7 +12982,7 @@ EPROM-based</description>
 <technology name="4"/>
 </technologies>
 </device>
-<device name="PQ" package="QFP-80P-1000W-1000L-245H-160F-44">
+<device name="PQ" package="QFP-44-80P-1000W-1000L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="NC" pad="18"/>
@@ -13044,7 +13044,7 @@ EPROM-based</description>
 <gate name="G$1" symbol="33IO-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-40">
+<device name="P" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="32"/>
 <connect gate="G$1" pin="OSC1" pad="19"/>
@@ -13118,7 +13118,7 @@ PIC16F84A, PIC16CR84</description>
 <gate name="G$1" symbol="13IO-1SS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SS" package="SSOP-065-530-20">
+<device name="SS" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="18"/>
@@ -13173,7 +13173,7 @@ PIC16F84A, PIC16CR84</description>
 <gate name="G$1" symbol="6IO" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GP0" pad="7"/>
 <connect gate="G$1" pin="GP1" pad="6"/>
@@ -13191,7 +13191,7 @@ PIC16F84A, PIC16CR84</description>
 <technology name="672"/>
 </technologies>
 </device>
-<device name="JN" package="DIP-300-8">
+<device name="JN" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GP0" pad="7"/>
 <connect gate="G$1" pin="GP1" pad="6"/>
@@ -13209,7 +13209,7 @@ PIC16F84A, PIC16CR84</description>
 <technology name="672"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="GP0" pad="7"/>
 <connect gate="G$1" pin="GP1" pad="6"/>
@@ -13235,7 +13235,7 @@ PIC16F84A, PIC16CR84</description>
 <gate name="G$1" symbol="14000" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SS" package="SSOP-065-530-28">
+<device name="SS" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="14"/>
 <connect gate="G$1" pin="CDAC" pad="22"/>
@@ -13270,7 +13270,7 @@ PIC16F84A, PIC16CR84</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="14"/>
 <connect gate="G$1" pin="CDAC" pad="22"/>
@@ -13305,7 +13305,7 @@ PIC16F84A, PIC16CR84</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SP" package="DIP-300-28">
+<device name="SP" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="14"/>
 <connect gate="G$1" pin="CDAC" pad="22"/>
@@ -13340,7 +13340,7 @@ PIC16F84A, PIC16CR84</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JW" package="DIP-600-28">
+<device name="JW" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="14"/>
 <connect gate="G$1" pin="CDAC" pad="22"/>
@@ -13384,7 +13384,7 @@ with LCD driver</description>
 <gate name="G$1" symbol="16C9L" x="0" y="0"/>
 </gates>
 <devices>
-<device name="L" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="L" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="2"/>
 <connect gate="G$1" pin="C1" pad="17"/>
@@ -13469,7 +13469,7 @@ with LCD driver</description>
 <gate name="G$1" symbol="16C9P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PS" package="DIP-900-64">
+<device name="PS" package="DIP-64-254P-2286W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="C1" pad="16"/>
@@ -13541,7 +13541,7 @@ with LCD driver</description>
 <technology name="4"/>
 </technologies>
 </device>
-<device name="TQ" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="TQ" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="57"/>
 <connect gate="G$1" pin="C1" pad="8"/>
@@ -13622,7 +13622,7 @@ with LCD driver</description>
 <gate name="G$1" symbol="24AA" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -13645,7 +13645,7 @@ with LCD driver</description>
 <technology name="04C"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -13667,7 +13667,7 @@ with LCD driver</description>
 <technology name="04A"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -13690,7 +13690,7 @@ with LCD driver</description>
 <technology name="04C"/>
 </technologies>
 </device>
-<device name="SL" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="SL" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="3"/>
@@ -13716,7 +13716,7 @@ with LCD driver</description>
 <gate name="G$1" symbol="SERIALEEPROM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-127P-750W-530L-265H-140F-8">
+<device name="SO" package="SOP-8-127P-750W-530L-265H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -13729,7 +13729,7 @@ with LCD driver</description>
 <technology name="2B"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -13742,7 +13742,7 @@ with LCD driver</description>
 <technology name="2B"/>
 </technologies>
 </device>
-<device name="TS" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="TS" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -13773,7 +13773,7 @@ with LCD driver</description>
 <gate name="G$1" symbol="59C11" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13788,7 +13788,7 @@ with LCD driver</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13803,7 +13803,7 @@ with LCD driver</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SM" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13829,7 +13829,7 @@ with LCD driver</description>
 <gate name="7" symbol="NC" x="30.48" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="7" pin="NC" pad="7"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -13846,7 +13846,7 @@ with LCD driver</description>
 <technology name="92"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="7" pin="NC" pad="7"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -13873,7 +13873,7 @@ with LCD driver</description>
 <gate name="G$1" symbol="93C06" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13893,7 +13893,7 @@ with LCD driver</description>
 <technology name="LC56B"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13913,7 +13913,7 @@ with LCD driver</description>
 <technology name="LC56B"/>
 </technologies>
 </device>
-<device name="ST" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="ST" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13929,7 +13929,7 @@ with LCD driver</description>
 <technology name="LC56B"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13955,7 +13955,7 @@ Microwire with software write protect</description>
 <gate name="G$1" symbol="93LCS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13971,7 +13971,7 @@ Microwire with software write protect</description>
 <technology name="66"/>
 </technologies>
 </device>
-<device name="SL" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="SL" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="3"/>
 <connect gate="G$1" pin="CS" pad="2"/>
@@ -13987,7 +13987,7 @@ Microwire with software write protect</description>
 <technology name="66"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -14003,7 +14003,7 @@ Microwire with software write protect</description>
 <technology name="66"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -14028,7 +14028,7 @@ Microwire with software write protect</description>
 <gate name="G$1" symbol="93LC46" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -14048,7 +14048,7 @@ Microwire with software write protect</description>
 <technology name="LC66"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -14068,7 +14068,7 @@ Microwire with software write protect</description>
 <technology name="LC66"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -14088,7 +14088,7 @@ Microwire with software write protect</description>
 <technology name="LC66"/>
 </technologies>
 </device>
-<device name="ST" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="ST" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -14114,7 +14114,7 @@ I2C</description>
 <gate name="G$1" symbol="24AA" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SM" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -14147,7 +14147,7 @@ I2C</description>
 <technology name="LC64"/>
 </technologies>
 </device>
-<device name="SL" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="SL" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="3"/>
@@ -14172,7 +14172,7 @@ I2C</description>
 <technology name="LC16B"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -14214,7 +14214,7 @@ I2C</description>
 <technology name="LCS52"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -14250,7 +14250,7 @@ I2C</description>
 <technology name="LCS52"/>
 </technologies>
 </device>
-<device name="ST" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="ST" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -14281,7 +14281,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11126H.pdf</description>
 <gate name="G$1" symbol="28C04" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-24">
+<device name="P" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE" pad="18"/>
 <connect gate="G$1" pin="!OE" pad="20"/>
@@ -14312,7 +14312,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11126H.pdf</description>
 <technology name="C"/>
 </technologies>
 </device>
-<device name="L" package="PLCC-127P-1397W-1143L-355H-32">
+<device name="L" package="PLCC-32-127P-1397W-1143L-355H">
 <connects>
 <connect gate="G$1" pin="!CE" pad="23"/>
 <connect gate="G$1" pin="!OE" pad="25"/>
@@ -14352,7 +14352,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <gate name="G$1" symbol="28C16" x="0" y="0"/>
 </gates>
 <devices>
-<device name="L" package="PLCC-127P-1397W-1143L-355H-32">
+<device name="L" package="PLCC-32-127P-1397W-1143L-355H">
 <connects>
 <connect gate="G$1" pin="!CE" pad="23"/>
 <connect gate="G$1" pin="!OE" pad="25"/>
@@ -14383,7 +14383,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="C"/>
 </technologies>
 </device>
-<device name="P" package="DIP-600-24">
+<device name="P" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE" pad="18"/>
 <connect gate="G$1" pin="!OE" pad="20"/>
@@ -14488,7 +14488,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <gate name="26" symbol="NC" x="35.56" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="2" pin="NC" pad="2"/>
 <connect gate="23" pin="NC" pad="23"/>
@@ -14523,7 +14523,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="C"/>
 </technologies>
 </device>
-<device name="L" package="PLCC-127P-1397W-1143L-355H-32">
+<device name="L" package="PLCC-32-127P-1397W-1143L-355H">
 <connects>
 <connect gate="2" pin="NC" pad="1"/>
 <connect gate="23" pin="NC" pad="3"/>
@@ -14628,7 +14628,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="C"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="2" pin="NC" pad="2"/>
 <connect gate="23" pin="NC" pad="23"/>
@@ -14672,7 +14672,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <gate name="G$1" symbol="28C64" x="0" y="0"/>
 </gates>
 <devices>
-<device name="L" package="PLCC-127P-1397W-1143L-355H-32">
+<device name="L" package="PLCC-32-127P-1397W-1143L-355H">
 <connects>
 <connect gate="G$1" pin="!CE" pad="23"/>
 <connect gate="G$1" pin="!OE" pad="25"/>
@@ -14707,7 +14707,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="VL"/>
 </technologies>
 </device>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE" pad="20"/>
 <connect gate="G$1" pin="!OE" pad="22"/>
@@ -14742,7 +14742,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="LV"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE" pad="20"/>
 <connect gate="G$1" pin="!OE" pad="22"/>
@@ -14856,7 +14856,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <gate name="G$1" symbol="27C128" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE" pad="20"/>
 <connect gate="G$1" pin="!OE" pad="22"/>
@@ -14891,7 +14891,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="C"/>
 </technologies>
 </device>
-<device name="L" package="PLCC-127P-1397W-1143L-355H-32">
+<device name="L" package="PLCC-32-127P-1397W-1143L-355H">
 <connects>
 <connect gate="G$1" pin="!CE" pad="23"/>
 <connect gate="G$1" pin="!OE" pad="25"/>
@@ -14971,7 +14971,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <gate name="G$1" symbol="27C256" x="0" y="0"/>
 </gates>
 <devices>
-<device name="L" package="PLCC-127P-1397W-1143L-355H-32">
+<device name="L" package="PLCC-32-127P-1397W-1143L-355H">
 <connects>
 <connect gate="G$1" pin="!CE" pad="23"/>
 <connect gate="G$1" pin="!OE" pad="25"/>
@@ -15007,7 +15007,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="LV"/>
 </technologies>
 </device>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE" pad="20"/>
 <connect gate="G$1" pin="!OE" pad="22"/>
@@ -15043,7 +15043,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="LV"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE" pad="20"/>
 <connect gate="G$1" pin="!OE" pad="22"/>
@@ -15159,7 +15159,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <gate name="G$1" symbol="27C512" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE" pad="20"/>
 <connect gate="G$1" pin="A0" pad="10"/>
@@ -15194,7 +15194,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="C"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE" pad="20"/>
 <connect gate="G$1" pin="A0" pad="10"/>
@@ -15229,7 +15229,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="C"/>
 </technologies>
 </device>
-<device name="L" package="PLCC-127P-1397W-1143L-355H-32">
+<device name="L" package="PLCC-32-127P-1397W-1143L-355H">
 <connects>
 <connect gate="G$1" pin="!CE" pad="23"/>
 <connect gate="G$1" pin="A0" pad="11"/>
@@ -15343,7 +15343,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <gate name="G$1" symbol="27HC1616" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-40">
+<device name="P" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE" pad="2"/>
 <connect gate="G$1" pin="!OE" pad="20"/>
@@ -15390,7 +15390,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="L" package="LCC-127P-1650W-1650L-304H-44">
+<device name="L" package="LCC-44-127P-1650W-1650L-304H">
 <connects>
 <connect gate="G$1" pin="!CE" pad="3"/>
 <connect gate="G$1" pin="!OE" pad="22"/>
@@ -15446,7 +15446,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <gate name="G$1" symbol="27C64" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE" pad="20"/>
 <connect gate="G$1" pin="!OE" pad="22"/>
@@ -15482,7 +15482,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="LV"/>
 </technologies>
 </device>
-<device name="P" package="DIP-600-28">
+<device name="P" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!CE" pad="20"/>
 <connect gate="G$1" pin="!OE" pad="22"/>
@@ -15518,7 +15518,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="LV"/>
 </technologies>
 </device>
-<device name="L" package="PLCC-127P-1397W-1143L-355H-32">
+<device name="L" package="PLCC-32-127P-1397W-1143L-355H">
 <connects>
 <connect gate="G$1" pin="!CE" pad="23"/>
 <connect gate="G$1" pin="!OE" pad="25"/>
@@ -15597,7 +15597,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <gate name="G$1" symbol="AY0438" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-600-40">
+<device name="P" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="BP" pad="30"/>
 <connect gate="G$1" pin="CLK" pad="40"/>
@@ -15644,7 +15644,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="L" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="L" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="BP" pad="33"/>
 <connect gate="G$1" pin="CLK" pad="44"/>
@@ -15700,7 +15700,7 @@ code hopping encoder and transponder</description>
 <gate name="P1" symbol="HCS410" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="P1" pin="GND" pad="5"/>
 <connect gate="P1" pin="LC0" pad="7"/>
@@ -15715,7 +15715,7 @@ code hopping encoder and transponder</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SO" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="P1" pin="GND" pad="5"/>
 <connect gate="P1" pin="LC0" pad="7"/>
@@ -15730,7 +15730,7 @@ code hopping encoder and transponder</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TS" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="TS" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="P1" pin="GND" pad="3"/>
 <connect gate="P1" pin="LC0" pad="5"/>
@@ -15754,7 +15754,7 @@ code hopping encoder and transponder</description>
 <gate name="G$1" symbol="SERIALEEPROM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -15767,7 +15767,7 @@ code hopping encoder and transponder</description>
 <technology name="LC"/>
 </technologies>
 </device>
-<device name="ST" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="ST" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -15793,7 +15793,7 @@ code hopping encoder and transponder</description>
 <technology name="LC"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -15815,7 +15815,7 @@ code hopping encoder and transponder</description>
 <gate name="G$1" symbol="SERIAL-EEPROM-DUAL" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!WP" pad="3"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -15828,7 +15828,7 @@ code hopping encoder and transponder</description>
 <technology name="S21A"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!WP" pad="3"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -15850,7 +15850,7 @@ code hopping encoder and transponder</description>
 <gate name="G$1" symbol="24-LC" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -15863,7 +15863,7 @@ code hopping encoder and transponder</description>
 <technology name="C21A"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -15885,7 +15885,7 @@ code hopping encoder and transponder</description>
 <gate name="G$1" symbol="24LC41" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!DWP" pad="2"/>
 <connect gate="G$1" pin="DSCL" pad="1"/>
@@ -15909,7 +15909,7 @@ code hopping encoder and transponder</description>
 <gate name="G$1" symbol="24LC61" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!EDS" pad="3"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -15922,7 +15922,7 @@ code hopping encoder and transponder</description>
 <technology name="2"/>
 </technologies>
 </device>
-<device name="ST" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="ST" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!EDS" pad="3"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -15935,7 +15935,7 @@ code hopping encoder and transponder</description>
 <technology name="2"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!EDS" pad="3"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -15957,7 +15957,7 @@ code hopping encoder and transponder</description>
 <gate name="G$1" symbol="24AA32" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -15977,7 +15977,7 @@ code hopping encoder and transponder</description>
 <technology name="LC65"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -16006,7 +16006,7 @@ code hopping encoder and transponder</description>
 <gate name="G$1" symbol="37LV" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CE" pad="4"/>
 <connect gate="G$1" pin="!CEO" pad="6"/>
@@ -16023,7 +16023,7 @@ code hopping encoder and transponder</description>
 <technology name="65"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CE" pad="4"/>
 <connect gate="G$1" pin="!CEO" pad="6"/>
@@ -16040,7 +16040,7 @@ code hopping encoder and transponder</description>
 <technology name="65"/>
 </technologies>
 </device>
-<device name="L" package="PLCC-127P-896W-896L-457H-20">
+<device name="L" package="PLCC-20-127P-896W-896L-457H">
 <connects>
 <connect gate="G$1" pin="!CE" pad="8"/>
 <connect gate="G$1" pin="!CEO" pad="14"/>
@@ -16066,7 +16066,7 @@ code hopping encoder and transponder</description>
 <gate name="G$1" symbol="25SERIAL" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="1"/>
 <connect gate="G$1" pin="!HOLD" pad="7"/>
@@ -16086,7 +16086,7 @@ code hopping encoder and transponder</description>
 <technology name="LC080"/>
 </technologies>
 </device>
-<device name="ST" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="ST" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="1"/>
 <connect gate="G$1" pin="!HOLD" pad="7"/>
@@ -16103,7 +16103,7 @@ code hopping encoder and transponder</description>
 <technology name="LC040"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="1"/>
 <connect gate="G$1" pin="!HOLD" pad="7"/>
@@ -16129,7 +16129,7 @@ flash type</description>
 <gate name="G$1" symbol="PIC16F870" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -16165,7 +16165,7 @@ flash type</description>
 <technology name="LF"/>
 </technologies>
 </device>
-<device name="SS" package="SSOP-065-530-28">
+<device name="SS" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -16201,7 +16201,7 @@ flash type</description>
 <technology name="LF"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -16246,7 +16246,7 @@ flash type</description>
 <gate name="G$1" symbol="PIC16F871" x="0" y="0"/>
 </gates>
 <devices>
-<device name="L" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="L" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="2"/>
 <connect gate="G$1" pin="INT/RB0" pad="36"/>
@@ -16294,7 +16294,7 @@ flash type</description>
 <technology name="LF"/>
 </technologies>
 </device>
-<device name="T" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="T" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="18"/>
 <connect gate="G$1" pin="INT/RB0" pad="8"/>
@@ -16342,7 +16342,7 @@ flash type</description>
 <technology name="LF"/>
 </technologies>
 </device>
-<device name="P" package="DIP-600-40">
+<device name="P" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="33"/>
@@ -16399,7 +16399,7 @@ flash type</description>
 <gate name="G$1" symbol="PIC16F872" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -16435,7 +16435,7 @@ flash type</description>
 <technology name="LF"/>
 </technologies>
 </device>
-<device name="SS" package="SSOP-065-530-28">
+<device name="SS" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -16471,7 +16471,7 @@ flash type</description>
 <technology name="LF"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -16515,7 +16515,7 @@ flash type</description>
 <gate name="G$1" symbol="PIC17F874" x="0" y="0"/>
 </gates>
 <devices>
-<device name="L" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="L" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="2"/>
 <connect gate="G$1" pin="INT/RB0" pad="36"/>
@@ -16563,7 +16563,7 @@ flash type</description>
 <technology name="7"/>
 </technologies>
 </device>
-<device name="PQ" package="QFP-80P-1000W-1000L-245H-160F-44">
+<device name="PQ" package="QFP-44-80P-1000W-1000L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="18"/>
 <connect gate="G$1" pin="INT/RB0" pad="8"/>
@@ -16611,7 +16611,7 @@ flash type</description>
 <technology name="7"/>
 </technologies>
 </device>
-<device name="PT" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="PT" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="18"/>
 <connect gate="G$1" pin="INT/RB0" pad="8"/>
@@ -16659,7 +16659,7 @@ flash type</description>
 <technology name="7"/>
 </technologies>
 </device>
-<device name="P" package="DIP-600-40">
+<device name="P" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="33"/>
@@ -16707,7 +16707,7 @@ flash type</description>
 <technology name="7"/>
 </technologies>
 </device>
-<device name="SO" package="PLCC-SOCKET-TH-11X11-44">
+<device name="SO" package="PLCC-SOCKET-TH-44-11X11">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="2"/>
 <connect gate="G$1" pin="INT/RB0" pad="36"/>
@@ -16763,7 +16763,7 @@ flash type</description>
 <gate name="G$1" symbol="PIC16F872" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -16798,7 +16798,7 @@ flash type</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -16842,7 +16842,7 @@ flash type</description>
 <gate name="G$1" symbol="PIC16F872" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -16877,7 +16877,7 @@ flash type</description>
 <technology name="F"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-28">
+<device name="P" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -16928,7 +16928,7 @@ flash type</description>
 <gate name="P8" symbol="VSS" x="12.7" y="-58.42" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="AVDD" pad="19"/>
@@ -17010,7 +17010,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/39605c.pdf</description>
 <gate name="G$1" symbol="PIC18F1220" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-18">
+<device name="P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="BKI0/DT/RX/AN6/RB4" pad="10"/>
 <connect gate="G$1" pin="INT0/AN4/RB0" pad="8"/>
@@ -17035,7 +17035,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/39605c.pdf</description>
 <technology name="2"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="BKI0/DT/RX/AN6/RB4" pad="10"/>
 <connect gate="G$1" pin="INT0/AN4/RB0" pad="8"/>
@@ -17071,7 +17071,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/39605c.pdf</description>
 <gate name="G$1" symbol="PIC18F1320" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SS" package="SSOP-065-530-20">
+<device name="SS" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="AVDD" pad="15"/>
 <connect gate="G$1" pin="AVSS" pad="6"/>
@@ -17152,7 +17152,7 @@ Source: http://www.microchip.com .. 41190c.pdf</description>
 <technology name="75"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GP0" pad="7"/>
 <connect gate="G$1" pin="GP1" pad="6"/>
@@ -17168,7 +17168,7 @@ Source: http://www.microchip.com .. 41190c.pdf</description>
 <technology name="75"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GP0" pad="7"/>
 <connect gate="G$1" pin="GP1" pad="6"/>
@@ -17230,7 +17230,7 @@ Source: http://www.microchip.com .. 39637a.pdf</description>
 <technology name="5"/>
 </technologies>
 </device>
-<device name="-E/SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="-E/SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CANRX/RB3" pad="24"/>
 <connect gate="G$1" pin="INT0/AN10/RB0" pad="21"/>
@@ -17265,7 +17265,7 @@ Source: http://www.microchip.com .. 39637a.pdf</description>
 <technology name="5"/>
 </technologies>
 </device>
-<device name="-I/SP" package="DIP-300-28">
+<device name="-I/SP" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="CANRX/RB3" pad="24"/>
 <connect gate="G$1" pin="INT0/AN10/RB0" pad="21"/>
@@ -17310,7 +17310,7 @@ Source: http://www.microchip.com/ .. 39663c.pdf</description>
 <gate name="G$1" symbol="PIC18F6XJ10" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="AVDD" pad="19"/>
@@ -17394,7 +17394,7 @@ Source: http://www.microchip.com/ .. 39663c.pdf</description>
 <gate name="G$1" symbol="PIC18F87J10" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1200W-1200L-120H-80">
+<device name="" package="TQFP-80-50P-1200W-1200L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="9"/>
 <connect gate="G$1" pin="AVDD" pad="25"/>
@@ -17494,7 +17494,7 @@ Source: http://ww1.microchip.com/downloads/en/devicedoc/39632c.pdf</description>
 <gate name="G$1" symbol="PIC18F4455_44TQFP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR!/VPP/RE3" pad="18"/>
 <connect gate="G$1" pin="NC/!ICRST!/IVVPP" pad="33"/>
@@ -17617,7 +17617,7 @@ Source: http://ww1.microchip.com/downloads/en/devicedoc/39632c.pdf</description>
 <gate name="G$1" symbol="PIC18F4455_40" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="!MCLR!/VPP/RE3" pad="1"/>
 <connect gate="G$1" pin="OSC1/CLKI" pad="13"/>
@@ -17674,7 +17674,7 @@ Source: http://ww1.microchip.com/downloads/en/devicedoc/39632c.pdf</description>
 <gate name="G$1" symbol="PIC18F4455_28" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DIP" package="DIP-300-28">
+<device name="DIP" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR!/VPP/RE3" pad="1"/>
 <connect gate="G$1" pin="OSC1/CLKI" pad="9"/>
@@ -17710,7 +17710,7 @@ Source: http://ww1.microchip.com/downloads/en/devicedoc/39632c.pdf</description>
 <technology name="550"/>
 </technologies>
 </device>
-<device name="W" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="W" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR!/VPP/RE3" pad="1"/>
 <connect gate="G$1" pin="OSC1/CLKI" pad="9"/>
@@ -17755,7 +17755,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21952a.pdf</description>
 <gate name="G$1" symbol="MCP23017" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SP" package="DIP-300-28">
+<device name="SP" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="18"/>
 <connect gate="G$1" pin="A0" pad="15"/>
@@ -17788,7 +17788,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21952a.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="18"/>
 <connect gate="G$1" pin="A0" pad="15"/>
@@ -17821,7 +17821,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21952a.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SS" package="SSOP-065-530-28">
+<device name="SS" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="18"/>
 <connect gate="G$1" pin="A0" pad="15"/>
@@ -17896,7 +17896,7 @@ SPI Interface</description>
 <gate name="G$1" symbol="MCP23S17" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SP" package="DIP-300-28">
+<device name="SP" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="11"/>
 <connect gate="G$1" pin="!RESET" pad="18"/>
@@ -17931,7 +17931,7 @@ SPI Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SS" package="SSOP-065-530-28">
+<device name="SS" package="SSOP-28-65P-530W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="11"/>
 <connect gate="G$1" pin="!RESET" pad="18"/>
@@ -17966,7 +17966,7 @@ SPI Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="11"/>
 <connect gate="G$1" pin="!RESET" pad="18"/>
@@ -18045,7 +18045,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <gate name="G$1" symbol="PIC16F62X" x="0" y="0"/>
 </gates>
 <devices>
-<device name="7P" package="DIP-300-18">
+<device name="7P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="RA0/AN0" pad="17"/>
 <connect gate="G$1" pin="RA1/AN1" pad="18"/>
@@ -18071,7 +18071,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <technology name="L"/>
 </technologies>
 </device>
-<device name="7SO" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="7SO" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="RA0/AN0" pad="17"/>
 <connect gate="G$1" pin="RA1/AN1" pad="18"/>
@@ -18097,7 +18097,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <technology name="L"/>
 </technologies>
 </device>
-<device name="8P" package="DIP-300-18">
+<device name="8P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="RA0/AN0" pad="17"/>
 <connect gate="G$1" pin="RA1/AN1" pad="18"/>
@@ -18123,7 +18123,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <technology name="L"/>
 </technologies>
 </device>
-<device name="8SO" package="SSOP-065-530-20">
+<device name="8SO" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="RA0/AN0" pad="17"/>
 <connect gate="G$1" pin="RA1/AN1" pad="18"/>
@@ -18158,7 +18158,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <gate name="G$1" symbol="PIC16F62X-SSOP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="7" package="SSOP-065-530-20">
+<device name="7" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="RA0/AN0" pad="19"/>
 <connect gate="G$1" pin="RA1/AN1" pad="20"/>
@@ -18186,7 +18186,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <technology name="L"/>
 </technologies>
 </device>
-<device name="8" package="SSOP-065-530-20">
+<device name="8" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="RA0/AN0" pad="19"/>
 <connect gate="G$1" pin="RA1/AN1" pad="20"/>
@@ -18222,7 +18222,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21796H.pdf</description>
 <gate name="G$1" symbol="93AA76" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -18239,7 +18239,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21796H.pdf</description>
 <technology name="LC"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -18256,7 +18256,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21796H.pdf</description>
 <technology name="LC"/>
 </technologies>
 </device>
-<device name="ST" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="ST" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -18273,7 +18273,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21796H.pdf</description>
 <technology name="LC"/>
 </technologies>
 </device>
-<device name="MS" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MS" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -18357,7 +18357,7 @@ Source: TC 4469-MOSFET-DRIVER.pdf</description>
 <gate name="P" symbol="VDD-GND" x="25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="DP" package="DIP-300-14">
+<device name="DP" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -18378,7 +18378,7 @@ Source: TC 4469-MOSFET-DRIVER.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JD" package="DIP-300-14">
+<device name="JD" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -18412,7 +18412,7 @@ Source: TC 4469-MOSFET-DRIVER.pdf</description>
 <gate name="P" symbol="VDD-GND-2" x="27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -18448,7 +18448,7 @@ Source: TC 4469-MOSFET-DRIVER.pdf</description>
 <gate name="P" symbol="VDD-GND-2" x="22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -18484,7 +18484,7 @@ Source: TC 4469-MOSFET-DRIVER.pdf</description>
 <gate name="P" symbol="VDD-GND" x="22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="DP" package="DIP-300-14">
+<device name="DP" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -18505,7 +18505,7 @@ Source: TC 4469-MOSFET-DRIVER.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JD" package="DIP-300-14">
+<device name="JD" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -18539,7 +18539,7 @@ Source: TC 4469-MOSFET-DRIVER.pdf</description>
 <gate name="P" symbol="VDD-GND-2" x="22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -18575,7 +18575,7 @@ Source: TC 4469-MOSFET-DRIVER.pdf</description>
 <gate name="P" symbol="VDD-GND" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="DP" package="DIP-300-14">
+<device name="DP" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -18596,7 +18596,7 @@ Source: TC 4469-MOSFET-DRIVER.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JD" package="DIP-300-14">
+<device name="JD" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -18626,7 +18626,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39762c.pdf</description>
 <gate name="G$1" symbol="PIC18F97J60-100" x="0" y="0"/>
 </gates>
 <devices>
-<device name="T" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="T" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="13"/>
 <connect gate="G$1" pin="AVDD" pad="30"/>
@@ -18743,7 +18743,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39762c.pdf</description>
 <gate name="G$1" symbol="PIC18F86-80" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1200W-1200L-120H-80">
+<device name="" package="TQFP-80-50P-1200W-1200L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="9"/>
 <connect gate="G$1" pin="AVDD" pad="25"/>
@@ -18857,7 +18857,7 @@ Source: http://www.microchip.com .. 41190E.pdf</description>
 <gate name="G$1" symbol="PIC12F675" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="8"/>
 <connect gate="G$1" pin="GP0/AN0" pad="7"/>
@@ -18872,7 +18872,7 @@ Source: http://www.microchip.com .. 41190E.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="8"/>
 <connect gate="G$1" pin="GP0/AN0" pad="7"/>
@@ -18911,7 +18911,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39747d.pdf</description>
 <gate name="G$1" symbol="PIC24FJ128GA010" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="13"/>
 <connect gate="G$1" pin="!U1CTS/CN20/RD14" pad="47"/>
@@ -19029,7 +19029,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39747d.pdf</description>
 <gate name="G$1" symbol="PIC24FJ128GA008" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1200W-1200L-120H-80">
+<device name="" package="TQFP-80-50P-1200W-1200L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="9"/>
 <connect gate="G$1" pin="!U1CTS/CN20/RD14" pad="37"/>
@@ -19127,7 +19127,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39747d.pdf</description>
 <gate name="G$1" symbol="PIC24FJ128GA006" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="!U1RTS/BCLK1/SCK1/INT0/RF6" pad="35"/>
@@ -19256,7 +19256,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40039E.pdf</description>
 <gate name="G$1" symbol="PIC16F676" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="CIN+/ICSPDAT/AN0/RA0" pad="13"/>
 <connect gate="G$1" pin="CIN-/VREF/ICSPCLK/AN1/RA1" pad="12"/>
@@ -19277,7 +19277,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40039E.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SL" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="SL" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CIN+/ICSPDAT/AN0/RA0" pad="13"/>
 <connect gate="G$1" pin="CIN-/VREF/ICSPCLK/AN1/RA1" pad="12"/>
@@ -19298,7 +19298,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40039E.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TS" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="TS" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="CIN+/ICSPDAT/AN0/RA0" pad="13"/>
 <connect gate="G$1" pin="CIN-/VREF/ICSPCLK/AN1/RA1" pad="12"/>
@@ -19328,7 +19328,7 @@ Source: http://www.microchip.com .. 39564c.pdf</description>
 <gate name="G$1" symbol="PIC18F452-44" x="0" y="0"/>
 </gates>
 <devices>
-<device name="L" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="L" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="G$1" pin="!MCLR!/VPP" pad="2"/>
 <connect gate="G$1" pin="GND" pad="13"/>
@@ -19380,7 +19380,7 @@ Source: http://www.microchip.com .. 39564c.pdf</description>
 <technology name="45"/>
 </technologies>
 </device>
-<device name="PT" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="PT" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR!/VPP" pad="18"/>
 <connect gate="G$1" pin="GND" pad="6"/>
@@ -19473,7 +19473,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39775b.pdf</description>
 <gate name="G$1" symbol="PIC18F6XJ5X" x="0" y="0"/>
 </gates>
 <devices>
-<device name="0" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="0" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="AVDD" pad="19"/>
@@ -19546,7 +19546,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39775b.pdf</description>
 <technology name="7"/>
 </technologies>
 </device>
-<device name="5" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="5" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="AVDD" pad="19"/>
@@ -19627,7 +19627,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39775b.pdf</description>
 <gate name="G$1" symbol="PIC18F8XJ5X" x="0" y="0"/>
 </gates>
 <devices>
-<device name="0" package="TQFP-50P-1200W-1200L-120H-80">
+<device name="0" package="TQFP-80-50P-1200W-1200L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="9"/>
 <connect gate="G$1" pin="AVDD" pad="25"/>
@@ -19716,7 +19716,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39775b.pdf</description>
 <technology name="7"/>
 </technologies>
 </device>
-<device name="5" package="TQFP-50P-1200W-1200L-120H-80">
+<device name="5" package="TQFP-80-50P-1200W-1200L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="9"/>
 <connect gate="G$1" pin="AVDD" pad="25"/>
@@ -19813,7 +19813,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39762d.pdf</description>
 <gate name="G$1" symbol="PIC18F6XJ6X" x="0" y="0"/>
 </gates>
 <devices>
-<device name="0" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="0" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="AVDD" pad="19"/>
@@ -19885,7 +19885,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39762d.pdf</description>
 <technology name="7"/>
 </technologies>
 </device>
-<device name="5" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="5" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="AVDD" pad="19"/>
@@ -19966,7 +19966,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39762d.pdf</description>
 <gate name="G$1" symbol="PIC18F8XJ6X" x="0" y="0"/>
 </gates>
 <devices>
-<device name="0" package="TQFP-50P-1200W-1200L-120H-80">
+<device name="0" package="TQFP-80-50P-1200W-1200L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="9"/>
 <connect gate="G$1" pin="AVDD" pad="25"/>
@@ -20054,7 +20054,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39762d.pdf</description>
 <technology name="7"/>
 </technologies>
 </device>
-<device name="5" package="TQFP-50P-1200W-1200L-120H-80">
+<device name="5" package="TQFP-80-50P-1200W-1200L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="9"/>
 <connect gate="G$1" pin="AVDD" pad="25"/>
@@ -20151,7 +20151,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39762d.pdf</description>
 <gate name="G$1" symbol="PIC18F9XJ6" x="0" y="0"/>
 </gates>
 <devices>
-<device name="0" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="0" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="13"/>
 <connect gate="G$1" pin="AVDD" pad="30"/>
@@ -20259,7 +20259,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39762d.pdf</description>
 <technology name="7"/>
 </technologies>
 </device>
-<device name="5" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="5" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="13"/>
 <connect gate="G$1" pin="AVDD" pad="30"/>
@@ -20375,7 +20375,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/41211D_.pdf</description
 <gate name="G$1" symbol="PIC12F683" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GP0/AN0/CIN+/ICSPDAT/ULPWU" pad="7"/>
 <connect gate="G$1" pin="GP1/AN1/CIN-/VREF/ICSPCLK" pad="6"/>
@@ -20405,7 +20405,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/41211D_.pdf</description
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GP0/AN0/CIN+/ICSPDAT/ULPWU" pad="7"/>
 <connect gate="G$1" pin="GP1/AN1/CIN-/VREF/ICSPCLK" pad="6"/>
@@ -20444,7 +20444,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21950c.pdf</description>
 <gate name="-1" symbol="MCP3550" x="0" y="0"/>
 </gates>
 <devices>
-<device name="MS" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MS" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="-1" pin="!CS" pad="7"/>
 <connect gate="-1" pin="SCK" pad="5"/>
@@ -20462,7 +20462,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21950c.pdf</description>
 <technology name="3"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-1" pin="!CS" pad="7"/>
 <connect gate="-1" pin="SCK" pad="5"/>
@@ -20489,7 +20489,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/39662c.pdf</description>
 <gate name="G$1" symbol="ENC28J60" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SP" package="DIP-300-28">
+<device name="SP" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="9"/>
 <connect gate="G$1" pin="!INT" pad="4"/>
@@ -20533,7 +20533,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21034D.pdf</description>
 <gate name="P" symbol="MCP3202" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="P" pin="!CS!/SHDN" pad="1"/>
 <connect gate="P" pin="CH0" pad="2"/>
@@ -20548,7 +20548,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21034D.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="P" pin="!CS!/SHDN" pad="1"/>
 <connect gate="P" pin="CH0" pad="2"/>
@@ -20563,7 +20563,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21034D.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="MS" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MS" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="P" pin="!CS!/SHDN" pad="1"/>
 <connect gate="P" pin="CH0" pad="2"/>
@@ -20578,7 +20578,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21034D.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="ST" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="ST" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="P" pin="!CS!/SHDN" pad="1"/>
 <connect gate="P" pin="CH0" pad="2"/>
@@ -20603,7 +20603,7 @@ Source: PIC24FJ256GB110.bsd</description>
 <gate name="G$1" symbol="PIC24FJ256GB110" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="13"/>
 <connect gate="G$1" pin="AVDD" pad="30"/>
@@ -20719,7 +20719,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/61143E.pdf, PIC32MX320F0
 <gate name="G$1" symbol="PIC32MX320F064H" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="AVDD" pad="19"/>
@@ -20802,7 +20802,7 @@ Source: PIC32MX320F128L.bsdl</description>
 <gate name="G$1" symbol="PIC32MX320F128L" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="13"/>
 <connect gate="G$1" pin="AVDD" pad="30"/>
@@ -20919,7 +20919,7 @@ Source: PIC32MX360F512L.bsdl</description>
 <gate name="G$1" symbol="PIC32MX360F512L" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="13"/>
 <connect gate="G$1" pin="AVDD" pad="30"/>
@@ -21036,7 +21036,7 @@ Source: PIC32MX440F256H.bsdl</description>
 <gate name="G$1" symbol="PIC32MX440F256H" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="AVDD" pad="19"/>
@@ -21117,7 +21117,7 @@ Source: PIC32MX460F512L.bsdl</description>
 <gate name="G$1" symbol="PIC32MX460F512L" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="13"/>
 <connect gate="G$1" pin="AVDD" pad="30"/>
@@ -21234,7 +21234,7 @@ Source: PIC32MX460F256L.bsdl</description>
 <gate name="G$1" symbol="PIC32MX460F256L" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="13"/>
 <connect gate="G$1" pin="AVDD" pad="30"/>
@@ -21351,7 +21351,7 @@ Source: PIC32MX320F032H.bsdl</description>
 <gate name="G$1" symbol="PIC32MX320F032H" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="AVDD" pad="19"/>
@@ -21432,7 +21432,7 @@ Source: PIC32MX420F032H.bsdl</description>
 <gate name="G$1" symbol="PIC32MX420F032H" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1400W-1400L-120H-64">
+<device name="" package="TQFP-64-80P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="AVDD" pad="19"/>
@@ -21513,7 +21513,7 @@ Source: PIC32MX360F256L.bsdl</description>
 <gate name="G$1" symbol="PIC32MX360F256L" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="13"/>
 <connect gate="G$1" pin="AVDD" pad="30"/>
@@ -21630,7 +21630,7 @@ Source: PIC24FJ64GA002.bsd</description>
 <gate name="G$1" symbol="PIC24FJ64GA002" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="DISVREG" pad="19"/>
@@ -21720,7 +21720,7 @@ Source: PIC24FJ48GA002.bsd</description>
 <gate name="G$1" symbol="PIC24FJ48GA002" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="DISVREG" pad="19"/>
@@ -21810,7 +21810,7 @@ Source: PIC24FJ32GA002.bsd</description>
 <gate name="G$1" symbol="PIC24FJ32GA002" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="DISVREG" pad="19"/>
@@ -21900,7 +21900,7 @@ Source: PIC24FJ16GA002.bsd</description>
 <gate name="G$1" symbol="PIC24FJ16GA002" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="DISVREG" pad="19"/>
@@ -21990,7 +21990,7 @@ Source: PIC24FJ256GB108.bsd</description>
 <gate name="G$1" symbol="PIC24FJ256GB108" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1200W-1200L-120H-80">
+<device name="" package="TQFP-80-50P-1200W-1200L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="9"/>
 <connect gate="G$1" pin="AVDD" pad="25"/>
@@ -22087,7 +22087,7 @@ Source: PIC24FJ64GB110.bsd</description>
 <gate name="G$1" symbol="PIC24FJ64GB110" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="13"/>
 <connect gate="G$1" pin="AVDD" pad="30"/>
@@ -22204,7 +22204,7 @@ Source: PIC32MX440F128L.bsdl</description>
 <gate name="G$1" symbol="PIC32MX440F128L" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="13"/>
 <connect gate="G$1" pin="AVDD" pad="30"/>
@@ -22321,7 +22321,7 @@ Source: PIC24FJ64GA004.bsd</description>
 <gate name="G$1" symbol="PIC24FJ64GA004" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="18"/>
 <connect gate="G$1" pin="AVDD" pad="17"/>
@@ -22382,7 +22382,7 @@ Source: PIC24FJ48GA004.bsd</description>
 <gate name="G$1" symbol="PIC24FJ48GA004" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="18"/>
 <connect gate="G$1" pin="AVDD" pad="17"/>
@@ -22443,7 +22443,7 @@ Source: PIC24HJ64GP506.bsd</description>
 <gate name="G$1" symbol="PIC24HJ64GP506" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="AVDD" pad="19"/>
@@ -22524,7 +22524,7 @@ Source: PIC24FJ32GA004.bsd</description>
 <gate name="G$1" symbol="PIC24FJ32GA004" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="18"/>
 <connect gate="G$1" pin="AVDD" pad="17"/>
@@ -22585,7 +22585,7 @@ Source: PIC24FJ256GB106.bsd</description>
 <gate name="G$1" symbol="PIC24FJ256GB106" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="AVDD" pad="19"/>
@@ -22801,7 +22801,7 @@ Source: dsPIC33FJ128GP710.bsd</description>
 <gate name="G$1" symbol="DSPIC33FJ128GP710" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="AVDD" pad="30"/>
 <connect gate="G$1" pin="AVSS" pad="31"/>
@@ -22918,7 +22918,7 @@ Source: dsPIC33FJ256MC510.bsd</description>
 <gate name="G$1" symbol="DSPIC33FJ256MC510" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="AVDD" pad="30"/>
 <connect gate="G$1" pin="AVSS" pad="31"/>
@@ -23090,7 +23090,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/61143E.pdf, PIC32MX320F0
 <gate name="G$1" symbol="PIC32MX320F064H" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="7"/>
 <connect gate="G$1" pin="AVDD" pad="19"/>
@@ -23172,7 +23172,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <gate name="G$1" symbol="PIC16F62*" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="RA0/AN0" pad="17"/>
 <connect gate="G$1" pin="RA1/AN1" pad="18"/>
@@ -23198,7 +23198,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <technology name="8"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-18">
+<device name="P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="RA0/AN0" pad="17"/>
 <connect gate="G$1" pin="RA1/AN1" pad="18"/>
@@ -23233,7 +23233,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <gate name="G$1" symbol="PIC16F62-SSOP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-20">
+<device name="" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="RA0/AN0" pad="19"/>
 <connect gate="G$1" pin="RA1/AN1" pad="20"/>
@@ -23269,7 +23269,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <gate name="G$1" symbol="24XX512" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SM" package="SOP-127P-530W-530L-210H-125F-8">
+<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -23292,7 +23292,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <gate name="G$1" symbol="MCP9804" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="A0" pad="7"/>
 <connect gate="G$1" pin="A1" pad="6"/>
@@ -23318,7 +23318,7 @@ nanoWatt Technol</description>
 <gate name="G$1" symbol="PIC16F690" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-I/P" package="DIP-300-20">
+<device name="-I/P" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!SS!/AN8/RC6" pad="8"/>
 <connect gate="G$1" pin="C12IN1-/AN5/RC1" pad="15"/>
@@ -23345,7 +23345,7 @@ nanoWatt Technol</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-I/SO" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="-I/SO" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!SS!/AN8/RC6" pad="8"/>
 <connect gate="G$1" pin="C12IN1-/AN5/RC1" pad="15"/>
@@ -23372,7 +23372,7 @@ nanoWatt Technol</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-I/SS" package="SSOP-065-530-20">
+<device name="-I/SS" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="!SS!/AN8/RC6" pad="8"/>
 <connect gate="G$1" pin="C12IN1-/AN5/RC1" pad="15"/>
@@ -23459,7 +23459,7 @@ Open-Drain Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -23471,7 +23471,7 @@ Open-Drain Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="MS" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MS" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -23483,7 +23483,7 @@ Open-Drain Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -23504,7 +23504,7 @@ SPI Interface</description>
 <gate name="G$1" symbol="MCP23S18" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="12"/>
 <connect gate="G$1" pin="!RESET" pad="16"/>
@@ -23536,7 +23536,7 @@ SPI Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SP" package="DIP-300-28">
+<device name="SP" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="12"/>
 <connect gate="G$1" pin="!RESET" pad="16"/>
@@ -23577,7 +23577,7 @@ I2C Interface</description>
 <gate name="G$1" symbol="MCP23018" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SS" package="SSOP-065-530-24">
+<device name="SS" package="SSOP-24-65P-530W">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="14"/>
 <connect gate="G$1" pin="ADDR" pad="13"/>
@@ -23608,7 +23608,7 @@ I2C Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SP" package="DIP-300-28">
+<device name="SP" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="16"/>
 <connect gate="G$1" pin="ADDR" pad="15"/>
@@ -23639,7 +23639,7 @@ I2C Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="16"/>
 <connect gate="G$1" pin="ADDR" pad="15"/>
@@ -23678,7 +23678,7 @@ I2C Interface</description>
 <gate name="G$1" symbol="MCP2551" x="0" y="0"/>
 </gates>
 <devices>
-<device name="/P" package="DIP-300-8">
+<device name="/P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CANH" pad="7"/>
 <connect gate="G$1" pin="CANL" pad="6"/>
@@ -23693,7 +23693,7 @@ I2C Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="/SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CANH" pad="7"/>
 <connect gate="G$1" pin="CANL" pad="6"/>
@@ -23717,7 +23717,7 @@ Internal VREF and SPI Interface</description>
 <gate name="G$1" symbol="MCP4801/4811/4821" x="0" y="0"/>
 </gates>
 <devices>
-<device name="MS" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MS" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!LDAC!" pad="5"/>
@@ -23732,7 +23732,7 @@ Internal VREF and SPI Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!LDAC!" pad="5"/>
@@ -23747,7 +23747,7 @@ Internal VREF and SPI Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!LDAC!" pad="5"/>
@@ -23793,7 +23793,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="G$1" symbol="MCP4821" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!LDAC!" pad="5"/>
@@ -23808,7 +23808,7 @@ Push-Pull Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!LDAC!" pad="5"/>
@@ -23823,7 +23823,7 @@ Push-Pull Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="MS" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MS" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!LDAC!" pad="5"/>
@@ -23847,7 +23847,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="G$1" symbol="MCP4822" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!LDAC!" pad="5"/>
@@ -23862,7 +23862,7 @@ Push-Pull Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!LDAC!" pad="5"/>
@@ -23877,7 +23877,7 @@ Push-Pull Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="MS" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MS" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!LDAC!" pad="5"/>
@@ -23900,7 +23900,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="G$1" symbol="DSPIC33EP256MU810" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR!" pad="13"/>
 <connect gate="G$1" pin="AN10/CVREF/PMA13/RPI42/RB10" pad="34"/>
@@ -24015,7 +24015,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="G$1" symbol="PIC24EP256GU810" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!MCLR!" pad="13"/>
 <connect gate="G$1" pin="AN10/CVREF/PMA13/RPI42/RB10" pad="34"/>
@@ -24130,7 +24130,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="G$1" symbol="TC647B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!FAULT!" pad="6"/>
 <connect gate="G$1" pin="CF" pad="2"/>
@@ -24145,7 +24145,7 @@ Push-Pull Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!FAULT!" pad="6"/>
 <connect gate="G$1" pin="CF" pad="2"/>
@@ -24160,7 +24160,7 @@ Push-Pull Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="MS" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MS" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!FAULT!" pad="6"/>
 <connect gate="G$1" pin="CF" pad="2"/>
@@ -24188,7 +24188,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="-3" symbol="DIGIPOT" x="48.26" y="-17.78" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="-0" pin="A" pad="11"/>
 <connect gate="-0" pin="B" pad="13"/>
@@ -24222,7 +24222,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="G$1" symbol="MCP23008" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-18">
+<device name="P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="6"/>
 <connect gate="G$1" pin="A0" pad="5"/>
@@ -24246,7 +24246,7 @@ Push-Pull Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="6"/>
 <connect gate="G$1" pin="A0" pad="5"/>
@@ -24270,7 +24270,7 @@ Push-Pull Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SS" package="SSOP-065-530-20">
+<device name="SS" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="6"/>
 <connect gate="G$1" pin="A0" pad="5"/>
@@ -24329,7 +24329,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="-CTL" symbol="MCP46X1" x="-30.48" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="TS" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="TS" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="-0" pin="A" pad="8"/>
 <connect gate="-0" pin="B" pad="10"/>
@@ -24377,7 +24377,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="G$1" symbol="MCP23S08" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="7"/>
 <connect gate="G$1" pin="!RESET" pad="6"/>
@@ -24402,7 +24402,7 @@ Push-Pull Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SS" package="SSOP-065-530-20">
+<device name="SS" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="G$1" pin="!CS" pad="7"/>
 <connect gate="G$1" pin="!RESET" pad="6"/>
@@ -24435,7 +24435,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="G$1" symbol="MCP2120" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SL" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="SL" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="4"/>
 <connect gate="G$1" pin="BAUD0" pad="10"/>
@@ -24456,7 +24456,7 @@ Push-Pull Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="4"/>
 <connect gate="G$1" pin="BAUD0" pad="10"/>
@@ -24485,7 +24485,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="G$1" symbol="PIC18F87J94" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1200W-1200L-120H-80">
+<device name="" package="TQFP-80-50P-1200W-1200L-120H">
 <connects>
 <connect gate="G$1" pin="!LB!/SEG37/RJ6" pad="41"/>
 <connect gate="G$1" pin="!MCLR!" pad="9"/>

--- a/micronas.lbr
+++ b/micronas.lbr
@@ -72,7 +72,7 @@
 <description>&lt;b&gt;Micronas Intermetall Devices&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="QFP-80P-1000W-1000L-245H-160F-44">
+<package name="QFP-44-80P-1000W-1000L-245H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-022B, variation AB, PQFP-G.
@@ -174,7 +174,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1658W-1658L-457H-44">
+<package name="PLCC-44-127P-1658W-1658L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 16.59mm length, 16.59mm width, 4.57mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body width, 4.57mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AC.&lt;/p&gt;
@@ -471,7 +471,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <gate name="NC1" symbol="MAS3507D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="QFP-80P-1000W-1000L-245H-160F-44">
+<device name="D" package="QFP-44-80P-1000W-1000L-245H-160F">
 <connects>
 <connect gate="NC1" pin="!EOD" pad="8"/>
 <connect gate="NC1" pin="!PCS" pad="15"/>
@@ -522,7 +522,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="J" package="PLCC-127P-1658W-1658L-457H-44">
+<device name="J" package="PLCC-44-127P-1658W-1658L-457H">
 <connects>
 <connect gate="NC1" pin="!EOD" pad="43"/>
 <connect gate="NC1" pin="!PCS" pad="36"/>
@@ -582,7 +582,7 @@ update 14.05.2001 librarian@cadsoft.de</description>
 <gate name="NC1" symbol="DAC3550A-" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="QFP-80P-1000W-1000L-245H-160F-44">
+<device name="D" package="QFP-44-80P-1000W-1000L-245H-160F">
 <connects>
 <connect gate="NC1" pin="AGNDC" pad="1"/>
 <connect gate="NC1" pin="AUX1L" pad="31"/>

--- a/motorola-sensor-driver.lbr
+++ b/motorola-sensor-driver.lbr
@@ -437,7 +437,7 @@ On-Chip Temparetur Compensated &amp; Calibrated Silicon Pressure Sensor</descrip
 <text x="-11.25" y="-6.9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="3.5" y="-6.92" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SSOP-65P-800W-1100L-120H-100F-32">
+<package name="SSOP-32-65P-800W-1100L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 11.0mm length, 8.0mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 11.0mm length, 8.0mm width, 1.20mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation GB, R-PDSO-G.&lt;/p&gt;
@@ -514,7 +514,7 @@ JEDEC MO-153F, variation GB, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-3.9" x2="5.4" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="3.9" x2="-5.4" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -534,7 +534,7 @@ JEDEC MO-153F, variation GB, R-PDSO-G.&lt;/p&gt;
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -566,7 +566,7 @@ JEDEC MO-153F, variation GB, R-PDSO-G.&lt;/p&gt;
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -602,7 +602,7 @@ JEDEC MO-153F, variation GB, R-PDSO-G.&lt;/p&gt;
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -636,7 +636,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -693,7 +693,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -1008,7 +1008,7 @@ On-Chip Temparetur Compensated &amp; Calibrated Silicon Pressure Sensor</descrip
 <gate name="G$1" symbol="PC33395" x="0" y="0"/>
 </gates>
 <devices>
-<device name="WB" package="SSOP-65P-800W-1100L-120H-100F-32">
+<device name="WB" package="SSOP-32-65P-800W-1100L-120H-100F">
 <technologies>
 <technology name=""/>
 </technologies>
@@ -1023,7 +1023,7 @@ http://onsemi.com; mc33039-d.pdf</description>
 <gate name="G$1" symbol="MC33039" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!A" pad="4"/>
 <connect gate="G$1" pin="A" pad="3"/>
@@ -1039,7 +1039,7 @@ http://onsemi.com; mc33039-d.pdf</description>
 <technology name="NCV"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!A" pad="4"/>
 <connect gate="G$1" pin="A" pad="3"/>
@@ -1063,7 +1063,7 @@ http://onsemi.com; mc33035-d.pdf</description>
 <gate name="G$1" symbol="MC33035" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CSENSIN" pad="15"/>
 <connect gate="G$1" pin="!ERRAMP" pad="12"/>
@@ -1095,7 +1095,7 @@ http://onsemi.com; mc33035-d.pdf</description>
 <technology name="NCV"/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-24">
+<device name="P" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CSENSIN" pad="15"/>
 <connect gate="G$1" pin="!ERRAMP" pad="12"/>
@@ -1135,7 +1135,7 @@ http://onsemi.com; mc33033-d.pdf</description>
 <gate name="G$1" symbol="MC33033" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-20">
+<device name="P" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="!ERRAMP" pad="10"/>
 <connect gate="G$1" pin="AB" pad="17"/>
@@ -1162,7 +1162,7 @@ http://onsemi.com; mc33033-d.pdf</description>
 <technology name="MC"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!ERRAMP" pad="10"/>
 <connect gate="G$1" pin="AB" pad="17"/>

--- a/national-semi.lbr
+++ b/national-semi.lbr
@@ -174,7 +174,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <wire x1="1" y1="-0.625" x2="-1" y2="-0.625" width="0.2032" layer="51"/>
 <wire x1="1" y1="0.625" x2="1" y2="-0.625" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -235,7 +235,7 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <wire x1="1.45" y1="-0.65" x2="1.45" y2="0.65" width="0.2032" layer="21"/>
 <wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -426,7 +426,7 @@ NS Package Number SDA08A</description>
 <rectangle x1="0.15" y1="0.1" x2="0.65" y2="0.6" layer="31"/>
 <rectangle x1="-1.95" y1="-1.55" x2="-1.65" y2="-1.25" layer="21"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -613,7 +613,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <wire x1="3.25" y1="-1.75" x2="-3.25" y2="-1.75" width="0.2032" layer="21"/>
 <wire x1="3.25" y1="1.75" x2="3.25" y2="-1.75" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -747,7 +747,7 @@ Also known as SOT78.</description>
 <wire x1="4.699" y1="-4.318" x2="-4.699" y2="-4.318" width="0.2032" layer="21"/>
 <wire x1="5.08" y1="-1.143" x2="4.953" y2="-4.064" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -1464,7 +1464,7 @@ with over-current protection</description>
 <gate name="G$1" symbol="LM3526-H" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="ENA" pad="1"/>
 <connect gate="G$1" pin="ENB" pad="4"/>
@@ -1488,7 +1488,7 @@ with over-current protection</description>
 <gate name="G$1" symbol="LM3526-L" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!ENA!" pad="1"/>
 <connect gate="G$1" pin="!ENB!" pad="4"/>
@@ -1575,7 +1575,7 @@ Open Drain Output</description>
 <gate name="G$1" symbol="LM2675" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CB" pad="1"/>
 <connect gate="G$1" pin="EN" pad="5"/>
@@ -1590,7 +1590,7 @@ Open Drain Output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CB" pad="1"/>
 <connect gate="G$1" pin="EN" pad="5"/>
@@ -1779,7 +1779,7 @@ with Precision Enable</description>
 <gate name="G$1" symbol="LM25085A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="MM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="1"/>
 <connect gate="G$1" pin="FB" pad="3"/>
@@ -1833,7 +1833,7 @@ with Precision Enable</description>
 <gate name="G$1" symbol="LM5107" x="0" y="0"/>
 </gates>
 <devices>
-<device name="MA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="MA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="HB" pad="8"/>
 <connect gate="G$1" pin="HI" pad="2"/>
@@ -1903,7 +1903,7 @@ with Precision Enable</description>
 <gate name="G$1" symbol="LM3916" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-18">
+<device name="N" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="L1" pad="1"/>
 <connect gate="G$1" pin="L10" pad="10"/>
@@ -2000,7 +2000,7 @@ High Efficiency Switching Regulator</description>
 <gate name="G$1" symbol="LM3478" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="4"/>
 <connect gate="G$1" pin="COMP" pad="2"/>
@@ -2024,7 +2024,7 @@ High Efficiency Switching Regulator</description>
 <gate name="G$1" symbol="LM2674" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="N" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CB" pad="1"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -2037,7 +2037,7 @@ High Efficiency Switching Regulator</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CB" pad="1"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -2059,7 +2059,7 @@ High Efficiency Switching Regulator</description>
 <gate name="G$1" symbol="LM2622" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="3"/>
 <connect gate="G$1" pin="FB" pad="2"/>
@@ -2083,7 +2083,7 @@ High Efficiency Switching Regulator</description>
 <gate name="G$1" symbol="LM3224" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="3"/>
 <connect gate="G$1" pin="FB" pad="2"/>
@@ -2137,7 +2137,7 @@ SIMPLE SWITCHERSynchronous 1MHz 0.75A</description>
 <gate name="G$1" symbol="LM3488" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="4"/>
 <connect gate="G$1" pin="COMP" pad="2"/>
@@ -2236,7 +2236,7 @@ SIMPLE SWITCHERSynchronous 1MHz 0.75A</description>
 <gate name="G$1" symbol="LM34" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DM" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="DM" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="VOUT" pad="1"/>
@@ -2308,7 +2308,7 @@ SIMPLE SWITCHERSynchronous 1MHz 0.75A</description>
 <gate name="G$1" symbol="LM628" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="G$1" pin="/CS" pad="12"/>
 <connect gate="G$1" pin="/IN" pad="1"/>

--- a/nxp-arm.lbr
+++ b/nxp-arm.lbr
@@ -1648,7 +1648,7 @@ Samtech</description>
 <rectangle x1="8.636" y1="-1.524" x2="9.144" y2="-1.016" layer="51"/>
 <rectangle x1="11.176" y1="-1.524" x2="11.684" y2="-1.016" layer="51"/>
 </package>
-<package name="LQFP-50P-1200W-1200L-160H-80">
+<package name="LQFP-80-50P-1200W-1200L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BDD, L-PQFP-G.
@@ -2092,7 +2092,7 @@ Samtec FTSH-105-01-L-DV-K</description>
 <text x="-4.445" y="3.175" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-4.445" y="-3.81" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="LQFP-50P-1000W-1000L-160H-64">
+<package name="LQFP-64-50P-1000W-1000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
@@ -2234,7 +2234,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-1400W-1400L-160H-100">
+<package name="LQFP-100-50P-1400W-1400L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BED, L-PQFP-G.
@@ -2448,7 +2448,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-2000W-2000L-160H-144">
+<package name="LQFP-144-50P-2000W-2000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
@@ -2966,7 +2966,7 @@ outline SOT926-1</description>
 <vertex x="-4.5" y="4"/>
 </polygon>
 </package>
-<package name="LQFP-50P-700W-700L-160H-48">
+<package name="LQFP-48-50P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
@@ -5470,7 +5470,7 @@ up to 512 kB flash and 64 kB SRAM&lt;br&gt;
 <gate name="G$1" symbol="LPC1758BD80" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1200W-1200L-160H-80">
+<device name="" package="LQFP-80-50P-1200W-1200L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="14"/>
 <connect gate="G$1" pin="!RSTOUT!" pad="11"/>
@@ -5567,7 +5567,7 @@ up to 512 kB flash and 64 kB SRAM&lt;br&gt;
 <gate name="G$1" symbol="LPC1768/66/65/64FBD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="17"/>
 <connect gate="G$1" pin="!RSTOUT!" pad="14"/>
@@ -5713,7 +5713,7 @@ fast ports and 10-bit ADC</description>
 <gate name="G$1" symbol="LPC2101/02/03" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FBD48" package="LQFP-50P-700W-700L-160H-48">
+<device name="FBD48" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST" pad="6"/>
 <connect gate="G$1" pin="DBGSEL" pad="27"/>
@@ -5778,7 +5778,7 @@ ISP/IAP flash with 10-bit ADC and DAC</description>
 <gate name="G$1" symbol="LPC2134/36/38" x="0" y="0"/>
 </gates>
 <devices>
-<device name="BD" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="BD" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!TRST!/P1.31" pad="20"/>
 <connect gate="G$1" pin="AD0.0/CAP0.1/MAT0.1/P0.27" pad="11"/>
@@ -5859,7 +5859,7 @@ with ISP/IAP, USB 2.0 full-speed device, 10-bit ADC and DAC</description>
 <gate name="G$1" symbol="LPC2142" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="57"/>
 <connect gate="G$1" pin="!TRST!/P1.31" pad="20"/>
@@ -5940,7 +5940,7 @@ with ISP/IAP, USB 2.0 full-speed device, 10-bit ADC and DAC</description>
 <gate name="G$1" symbol="LPC2144/46/48" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="57"/>
 <connect gate="G$1" pin="!TRST!/P1.31" pad="20"/>
@@ -6021,7 +6021,7 @@ up to 512 kB flash with ISP/IAP, Ethernet, USB 2.0, CAN, and 10-bit ADC/DAC</des
 <gate name="G$1" symbol="LPC2364/66/68FBD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!EINT0!/P2[10]" pad="53"/>
 <connect gate="G$1" pin="!RESET!" pad="17"/>
@@ -6138,7 +6138,7 @@ up to 512 kB flash with ISP/IAP, Ethernet, USB 2.0, CAN, and 10-bit ADC/DAC</des
 <gate name="G$1" symbol="LPC2210" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FBD144" package="LQFP-50P-2000W-2000L-160H-144">
+<device name="FBD144" package="LQFP-144-50P-2000W-2000L-160H">
 <connects>
 <connect gate="G$1" pin="CAP0.0/EINT3/AIN3/P0.30" pad="33"/>
 <connect gate="G$1" pin="CAP0.0/SCL/P0.2" pad="50"/>
@@ -6434,7 +6434,7 @@ up to 512 kB flash with ISP/IAP, Ethernet, USB 2.0, CAN, and 10-bit ADC/DAC</des
 <gate name="LPC" symbol="LPC11CX2/CX4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="LPC" pin="!CTS!/PIO0_7" pad="23"/>
 <connect gate="LPC" pin="!DCD!/PIO3_2" pad="43"/>

--- a/nxp.lbr
+++ b/nxp.lbr
@@ -149,7 +149,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -177,7 +177,7 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SSOP-65P-440W-650L-120H-100F-20">
+<package name="SSOP-20-65P-440W-650L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
@@ -230,7 +230,7 @@ JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.15" y1="-2.1" x2="3.15" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.1" x2="-3.15" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-16">
+<package name="SSOP-16-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 16 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 16 leads. JEDEC MO-150B. Variation AC.</description>
 <circle x="-2.235" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -310,7 +310,7 @@ body 3 x 3 x 0.85 mm, JEDEC MO-220</description>
 <rectangle x1="-0.8" y1="-0.8" x2="0.8" y2="0.8" layer="31"/>
 <rectangle x1="-1.7" y1="1.3" x2="-1.3" y2="1.7" layer="21"/>
 </package>
-<package name="SSOP-065-530-24">
+<package name="SSOP-24-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 24 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JEDEC MO-150B. Variation AG.</description>
 <circle x="-3.535" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -369,7 +369,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <wire x1="4.45" y1="-2.6" x2="4.45" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="4.45" y1="2.6" x2="-4.4" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -418,7 +418,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -483,7 +483,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-16">
+<package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -528,7 +528,7 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-780L-120H-100F-24">
+<package name="SSOP-24-65P-440W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
@@ -634,7 +634,7 @@ body 4x4 mm, JDEC MO-220, outline SOT616-1</description>
 <rectangle x1="-1.2" y1="-1.2" x2="1.2" y2="1.2" layer="31"/>
 <rectangle x1="-2.2" y1="1.8" x2="-1.8" y2="2.2" layer="21"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -668,7 +668,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -725,7 +725,7 @@ body 4 x 4 x 0.85 mm, JEDEC MO-220</description>
 <rectangle x1="-1" y1="-1" x2="1" y2="1" layer="31"/>
 <rectangle x1="-2.2" y1="1.7" x2="-1.7" y2="2.2" layer="21"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -1098,7 +1098,7 @@ Octal SMBus and I2C registered interface</description>
 <gate name="G$1" symbol="PCA9556" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="15"/>
 <connect gate="G$1" pin="A0" pad="3"/>
@@ -1130,7 +1130,7 @@ Remote 8-bit I/O expander for I2C-bus</description>
 <gate name="G$1" symbol="PCF8574" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1153,7 +1153,7 @@ Remote 8-bit I/O expander for I2C-bus</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TS" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="TS" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="1"/>
 <connect gate="G$1" pin="A0" pad="6"/>
@@ -1176,7 +1176,7 @@ Remote 8-bit I/O expander for I2C-bus</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="T" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1208,7 +1208,7 @@ Remote 8-bit I/O expander for I2C-bus</description>
 <gate name="G$1" symbol="PCA9500" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="D" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!WC" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1231,7 +1231,7 @@ Remote 8-bit I/O expander for I2C-bus</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!WC" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1263,7 +1263,7 @@ Remote 8-bit I/O expander for I2C-bus</description>
 <gate name="G$1" symbol="PCA9554" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1286,7 +1286,7 @@ Remote 8-bit I/O expander for I2C-bus</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="D" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1309,7 +1309,7 @@ Remote 8-bit I/O expander for I2C-bus</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DB" package="SSOP-065-530-16">
+<device name="DB" package="SSOP-16-65P-530W">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1332,7 +1332,7 @@ Remote 8-bit I/O expander for I2C-bus</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="1"/>
 <connect gate="G$1" pin="A0" pad="6"/>
@@ -1355,7 +1355,7 @@ Remote 8-bit I/O expander for I2C-bus</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="DW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1387,7 +1387,7 @@ Remote 8-bit I/O expander for Fm+ I2C-bus with interrupt and reset</description>
 <gate name="G$1" symbol="PCA9672" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="D" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="!RESET" pad="3"/>
@@ -1410,7 +1410,7 @@ Remote 8-bit I/O expander for Fm+ I2C-bus with interrupt and reset</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="!RESET" pad="3"/>
@@ -1465,7 +1465,7 @@ with interrupt</description>
 <gate name="G$1" symbol="PCA9675" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="1"/>
 <connect gate="G$1" pin="AD0" pad="21"/>
@@ -1496,7 +1496,7 @@ with interrupt</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-780L-120H-100F-24">
+<device name="PW" package="SSOP-24-65P-440W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="1"/>
 <connect gate="G$1" pin="AD0" pad="21"/>
@@ -1527,7 +1527,7 @@ with interrupt</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DB" package="SSOP-065-530-24">
+<device name="DB" package="SSOP-24-65P-530W">
 <connects>
 <connect gate="G$1" pin="!INT" pad="1"/>
 <connect gate="G$1" pin="AD0" pad="21"/>
@@ -1606,7 +1606,7 @@ with interrupt</description>
 <gate name="G$1" symbol="PCA9534" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="D" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1629,7 +1629,7 @@ with interrupt</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1706,7 +1706,7 @@ with interrupt</description>
 <gate name="G$1" symbol="PCA82C251" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CANH" pad="7"/>
 <connect gate="G$1" pin="CANL" pad="6"/>
@@ -1721,7 +1721,7 @@ with interrupt</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="T" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CANH" pad="7"/>
 <connect gate="G$1" pin="CANL" pad="6"/>
@@ -1745,7 +1745,7 @@ with interrupt</description>
 <gate name="G$1" symbol="PCA9535" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="1"/>
 <connect gate="G$1" pin="A0" pad="21"/>
@@ -1776,7 +1776,7 @@ with interrupt</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-780L-120H-100F-24">
+<device name="PW" package="SSOP-24-65P-440W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="1"/>
 <connect gate="G$1" pin="A0" pad="21"/>
@@ -1847,7 +1847,7 @@ Hot swappable</description>
 <gate name="G$1" symbol="PCA9514" x="0" y="0"/>
 </gates>
 <devices>
-<device name="AD" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="AD" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EN" pad="1"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -1862,7 +1862,7 @@ Hot swappable</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="ADP" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="ADP" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="EN" pad="1"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -1885,7 +1885,7 @@ Hot swappable</description>
 <gate name="G$1" symbol="PCA9517" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EN" pad="5"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -1900,7 +1900,7 @@ Hot swappable</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DP" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="DP" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="EN" pad="5"/>
 <connect gate="G$1" pin="GND" pad="4"/>

--- a/on-semi.lbr
+++ b/on-semi.lbr
@@ -257,7 +257,7 @@ D2PAK 5, CASE 936A?02</description>
 <rectangle x1="-0.8" y1="-0.8" x2="0.8" y2="0.8" layer="29" rot="R90"/>
 <rectangle x1="-0.7" y1="-0.7" x2="0.7" y2="0.7" layer="31"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -764,7 +764,7 @@ with programmable delay</description>
 <gate name="G$1" symbol="AMIS-42770" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!EN1!" pad="10"/>
 <connect gate="G$1" pin="!EN2!" pad="2"/>

--- a/op-amp.lbr
+++ b/op-amp.lbr
@@ -220,7 +220,7 @@ DGQ Package, Texas Instruments</description>
 <rectangle x1="-1" y1="-0.785" x2="1" y2="0.785" layer="29"/>
 <rectangle x1="-0.9" y1="-0.7" x2="0.9" y2="0.7" layer="31"/>
 </package>
-<package name="SSOP-65P-440W-300L-120H-100F-8">
+<package name="SSOP-8-65P-440W-300L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -249,7 +249,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <wire x1="1.4" y1="-2.1" x2="1.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="2.1" x2="-1.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -269,7 +269,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -295,7 +295,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -329,7 +329,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -375,7 +375,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-14">
+<package name="SSOP-14-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
@@ -416,7 +416,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-530W-1030L-210H-125F-14">
+<package name="SOP-14-127P-530W-1030L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -461,7 +461,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="5.125" y1="-2.625" x2="-5.125" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="2.625" x2="-5.125" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127-530X620-8">
+<package name="SOP-8-127P-530W-620L">
 <description>&lt;b&gt;SOP (1.27mm pitch, 5.30mm width, 6.20mm length, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. Lead pitch 1.27mm, body width 5.3mm, body length 6.2mm, 8 leads. Non-standard.</description>
 <circle x="-2.5550" y="-1.3500" radius="0.3175" width="0" layer="21"/>
@@ -494,7 +494,7 @@ Small outline package. Lead pitch 1.27mm, body width 5.3mm, body length 6.2mm, 8
 <wire x1="3.2000" y1="1.9050" x2="-3.2000" y2="1.9050" width="0.2032" layer="21"/>
 <wire x1="3.2000" y1="1.9050" x2="3.2000" y2="2.5500" width="0.2032" layer="51"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -1303,7 +1303,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <gate name="P" symbol="PWRN_V+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1318,7 +1318,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1344,7 +1344,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <gate name="A" symbol="OPAMP_PV" x="0" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-BAL" pin="BAL" pad="1"/>
 <connect gate="-BALCOMP" pin="BAL/CMP" pad="8"/>
@@ -1359,7 +1359,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="-BAL" pin="BAL" pad="1"/>
 <connect gate="-BALCOMP" pin="BAL/CMP" pad="8"/>
@@ -1374,7 +1374,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-127-530X620-8">
+<device name="PS" package="SOP-8-127P-530W-620L">
 <connects>
 <connect gate="-BAL" pin="BAL" pad="1"/>
 <connect gate="-BALCOMP" pin="BAL/CMP" pad="8"/>
@@ -1399,7 +1399,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <gate name="P" symbol="PWR_V+-" x="-15.24" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-NULL" pin="NULL1" pad="1"/>
 <connect gate="-NULL" pin="NULL2" pad="5"/>
@@ -1413,7 +1413,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="-NULL" pin="NULL1" pad="1"/>
 <connect gate="-NULL" pin="NULL2" pad="5"/>
@@ -1427,7 +1427,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-127-530X620-8">
+<device name="PS" package="SOP-8-127P-530W-620L">
 <connects>
 <connect gate="-NULL" pin="NULL1" pad="1"/>
 <connect gate="-NULL" pin="NULL2" pad="5"/>
@@ -1451,7 +1451,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <gate name="P" symbol="PWRN_V+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1466,7 +1466,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1481,7 +1481,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="PW" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1496,7 +1496,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-127-530X620-8">
+<device name="PS" package="SOP-8-127P-530W-620L">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1511,7 +1511,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="RM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="RM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1538,7 +1538,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <gate name="P" symbol="PWRN_V+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1559,7 +1559,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="SOP-127P-530W-1030L-210H-125F-14">
+<device name="NS" package="SOP-14-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1580,7 +1580,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1601,7 +1601,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1634,7 +1634,7 @@ Single Supply, External Shutdown</description>
 <gate name="-SHDN" symbol="_SHDN" x="-2.54" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-NULL" pin="NULL1" pad="1"/>
 <connect gate="-NULL" pin="NULL2" pad="5"/>
@@ -1649,7 +1649,7 @@ Single Supply, External Shutdown</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="-NULL" pin="NULL1" pad="1"/>
 <connect gate="-NULL" pin="NULL2" pad="5"/>
@@ -1702,7 +1702,7 @@ Single Supply</description>
 <gate name="-NULL" symbol="_OFFNULL2" x="2.54" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-NULL" pin="NULL1" pad="1"/>
 <connect gate="-NULL" pin="NULL2" pad="5"/>
@@ -1716,7 +1716,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="-NULL" pin="NULL1" pad="1"/>
 <connect gate="-NULL" pin="NULL2" pad="5"/>
@@ -1766,7 +1766,7 @@ Single Supply</description>
 <gate name="P" symbol="PWRN_VDDGND" x="-17.78" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1781,7 +1781,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1863,7 +1863,7 @@ Single Supply</description>
 <gate name="P" symbol="PWRN_VDDGND" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1884,7 +1884,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1916,7 +1916,7 @@ Single Supply</description>
 <gate name="P" symbol="PWRN_VDDGND" x="-12.7" y="2.54" addlevel="always"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1933,7 +1933,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1996,7 +1996,7 @@ Single Supply</description>
 <gate name="P" symbol="PWR_V+-" x="-17.78" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2025,7 +2025,7 @@ Single Supply</description>
 <gate name="G$1" symbol="NE5534_P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2037,7 +2037,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2049,7 +2049,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-127-530X620-8">
+<device name="PS" package="SOP-8-127P-530W-620L">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2069,7 +2069,7 @@ Single Supply</description>
 <gate name="G$1" symbol="NE5534_PC" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2083,7 +2083,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2097,7 +2097,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-127-530X620-8">
+<device name="PS" package="SOP-8-127P-530W-620L">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2119,7 +2119,7 @@ Single Supply</description>
 <gate name="G$1" symbol="NE5534_PCB" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2134,7 +2134,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2149,7 +2149,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-127-530X620-8">
+<device name="PS" package="SOP-8-127P-530W-620L">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2174,7 +2174,7 @@ Single Supply</description>
 <gate name="P" symbol="PWRN_V+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2189,7 +2189,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2217,7 +2217,7 @@ Single Supply</description>
 <gate name="P" symbol="PWRN_V+GND" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="MTX" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="MTX" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2238,7 +2238,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2259,7 +2259,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="M" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2292,7 +2292,7 @@ Single Supply</description>
 <gate name="P" symbol="PWRN_VCC+-" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2313,7 +2313,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2334,7 +2334,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="P" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2366,7 +2366,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWRN_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2397,7 +2397,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWRN_V+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="PW" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2422,7 +2422,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWRN_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="E" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2436,7 +2436,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2460,7 +2460,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWRN_V+-" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2487,7 +2487,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWRN_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2518,7 +2518,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWR_VCCVEE" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2533,7 +2533,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2548,7 +2548,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="DM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2572,7 +2572,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWR_VCCVEE" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2584,7 +2584,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2596,7 +2596,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="DM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2620,7 +2620,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWR_VCCVEE" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2641,7 +2641,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2662,7 +2662,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DTB" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="DTB" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2693,7 +2693,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWRN_VCC+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2708,7 +2708,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2723,7 +2723,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="PW" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2748,7 +2748,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWRN_VCC+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2763,7 +2763,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="N" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2778,7 +2778,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="PW" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2793,7 +2793,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-127-530X620-8">
+<device name="PS" package="SOP-8-127P-530W-620L">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2818,7 +2818,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="G$1" symbol="OPAMP_PV" x="0" y="0" addlevel="must"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2832,7 +2832,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2846,7 +2846,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-127-530X620-8">
+<device name="PS" package="SOP-8-127P-530W-620L">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2872,7 +2872,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="D" symbol="OPAMP_NV" x="0" y="-45.72" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2893,7 +2893,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2914,7 +2914,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="SOP-127P-530W-1030L-210H-125F-14">
+<device name="NS" package="SOP-14-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2935,7 +2935,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2970,7 +2970,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <gate name="D" symbol="COMPARATOR-OC" x="43.18" y="-10.16" swaplevel="1"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-14">
+<device name="N" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -2991,7 +2991,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -3012,7 +3012,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="SOP-127P-530W-1030L-210H-125F-14">
+<device name="NS" package="SOP-14-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -3033,7 +3033,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -3064,7 +3064,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <gate name="G$2" symbol="_OFFNULL2" x="2.54" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -3087,7 +3087,7 @@ Single Supply, Rail-to-Rail, 2.2V to 36V</description>
 <gate name="G$1" symbol="INA122" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -3102,7 +3102,7 @@ Single Supply, Rail-to-Rail, 2.2V to 36V</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -3127,7 +3127,7 @@ Low Voltage Rail-to-Rail</description>
 <gate name="P" symbol="PWRN_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="E" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3139,7 +3139,7 @@ Low Voltage Rail-to-Rail</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3151,7 +3151,7 @@ Low Voltage Rail-to-Rail</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3174,7 +3174,7 @@ Low Voltage Rail-to-Rail</description>
 <gate name="P" symbol="PWRN_V+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="E" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="E" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3189,7 +3189,7 @@ Low Voltage Rail-to-Rail</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3204,7 +3204,7 @@ Low Voltage Rail-to-Rail</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3232,7 +3232,7 @@ Low Voltage Rail-to-Rail</description>
 <gate name="D" symbol="OPAMP_NV" x="0" y="-45.72" swaplevel="1"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3264,7 +3264,7 @@ Single Operational Amplifier</description>
 <gate name="P" symbol="PWRN_VCC+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -3276,7 +3276,7 @@ Single Operational Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -3288,7 +3288,7 @@ Single Operational Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="P" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -3333,7 +3333,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <gate name="G$2" symbol="OPAMP_PV" x="0" y="0"/>
 </gates>
 <devices>
-<device name="/SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="/SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="REF" pad="5"/>
 <connect gate="G$2" pin="+IN" pad="3"/>
@@ -3346,7 +3346,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/P" package="DIP-300-8">
+<device name="/P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="REF" pad="5"/>
 <connect gate="G$2" pin="+IN" pad="3"/>
@@ -3359,7 +3359,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/ST" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="/ST" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="REF" pad="5"/>
 <connect gate="G$2" pin="+IN" pad="3"/>
@@ -3405,7 +3405,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <gate name="P" symbol="PWR_VDDVSS" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="/P" package="DIP-300-8">
+<device name="/P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3420,7 +3420,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="/SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3435,7 +3435,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/ST" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="/ST" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3461,7 +3461,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <gate name="G$2" symbol="OPAMP_PV" x="0" y="0"/>
 </gates>
 <devices>
-<device name="/P" package="DIP-300-8">
+<device name="/P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="REF" pad="5"/>
 <connect gate="G$2" pin="+IN" pad="3"/>
@@ -3474,7 +3474,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/SN" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="/SN" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="REF" pad="5"/>
 <connect gate="G$2" pin="+IN" pad="3"/>
@@ -3487,7 +3487,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/ST" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="/ST" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="REF" pad="5"/>
 <connect gate="G$2" pin="+IN" pad="3"/>
@@ -3513,7 +3513,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <gate name="P" symbol="PWR_VDDVSS" x="-20.32" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="/P" package="DIP-300-14">
+<device name="/P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3534,7 +3534,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/SN" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="/SN" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3555,7 +3555,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/ST" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="/ST" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3609,7 +3609,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="P" symbol="PWR_VCCVEE" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3633,7 +3633,7 @@ Audio Grade, Fully-Differential</description>
 <gate name="G$1" symbol="OPA1632" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="+OUT" pad="4"/>
@@ -3673,7 +3673,7 @@ Audio Grade, Fully-Differential</description>
 <gate name="B" symbol="COMPARATOR-OC" x="27.94" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3688,7 +3688,7 @@ Audio Grade, Fully-Differential</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3713,7 +3713,7 @@ Audio Grade, Fully-Differential</description>
 <gate name="P" symbol="PWR_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -3760,7 +3760,7 @@ Audio Grade, Fully-Differential</description>
 <gate name="P" symbol="PWR+-" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3775,7 +3775,7 @@ Audio Grade, Fully-Differential</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3801,7 +3801,7 @@ Audio Grade, Fully-Differential</description>
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -3815,7 +3815,7 @@ Audio Grade, Fully-Differential</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="N" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -3842,7 +3842,7 @@ Audio Grade, Fully-Differential</description>
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3863,7 +3863,7 @@ Audio Grade, Fully-Differential</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3918,7 +3918,7 @@ Micro-Power (50mA), Zerø-Drift, Rail-to-Rail Out, Instrumentation Amplifier</de
 <gate name="P" symbol="PWRI_V+-" x="2.54" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="DGK" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="DGK" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3959,7 +3959,7 @@ JFET, wide bandwidth</description>
 <gate name="P" symbol="PWRN_VCC+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3974,7 +3974,7 @@ JFET, wide bandwidth</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3999,7 +3999,7 @@ JFET, wide bandwidth</description>
 <gate name="P" symbol="PWRI_V+-" x="-15.24" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4013,7 +4013,7 @@ JFET, wide bandwidth</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4037,7 +4037,7 @@ JFET, wide bandwidth</description>
 <gate name="P" symbol="PWRI_V+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4052,7 +4052,7 @@ JFET, wide bandwidth</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4079,7 +4079,7 @@ JFET, wide bandwidth</description>
 <gate name="P" symbol="PWR+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4100,7 +4100,7 @@ JFET, wide bandwidth</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4143,7 +4143,7 @@ Rail-to-Rail, 3 MHz</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4155,7 +4155,7 @@ Rail-to-Rail, 3 MHz</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4236,7 +4236,7 @@ Output Current Drive and Shutdown Option</description>
 <gate name="P" symbol="PWR_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4257,7 +4257,7 @@ Output Current Drive and Shutdown Option</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4287,7 +4287,7 @@ Output Current Drive and Shutdown Option</description>
 <gate name="A" symbol="OPAMP_NV" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4333,7 +4333,7 @@ Output Current Drive and Shutdown Option</description>
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4373,7 +4373,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <gate name="G$1" symbol="OPAMP_NV" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DGK" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="DGK" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4385,7 +4385,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4408,7 +4408,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <gate name="P" symbol="PWRN_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4423,7 +4423,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <technology name=""/>
 </technologies>
 </device>
-<device name="DGK" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="DGK" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4451,7 +4451,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <gate name="P" symbol="PWRI_V+-" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4472,7 +4472,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4503,7 +4503,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <gate name="P" symbol="PWRN_V+-" x="-15.24" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4518,7 +4518,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4533,7 +4533,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <technology name=""/>
 </technologies>
 </device>
-<device name="MM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4581,7 +4581,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <gate name="P" symbol="PWR+G" x="-12.7" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4596,7 +4596,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="PW" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4611,7 +4611,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4669,7 +4669,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <gate name="P" symbol="PWR+G" x="-17.78" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4684,7 +4684,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <technology name=""/>
 </technologies>
 </device>
-<device name="DGK" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="DGK" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4699,7 +4699,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="PW" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4726,7 +4726,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <gate name="D" symbol="OPAMP_NV" x="0" y="-38.1"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4747,7 +4747,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4800,7 +4800,7 @@ Single-Supply, Low-Noise, Low-Distortion, Rail-to-Rail Op Amps</description>
 <gate name="G$1" symbol="OPAMP_PV" x="0" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4814,7 +4814,7 @@ Single-Supply, Low-Noise, Low-Distortion, Rail-to-Rail Op Amps</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4852,7 +4852,7 @@ Single-Supply, Low-Noise, Low-Distortion, Rail-to-Rail Op Amps</description>
 <gate name="G$1" symbol="OPAMP_PV" x="0" y="0" addlevel="must"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4866,7 +4866,7 @@ Single-Supply, Low-Noise, Low-Distortion, Rail-to-Rail Op Amps</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JG" package="DIP-300-8">
+<device name="JG" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4904,7 +4904,7 @@ Single-Supply, Low-Noise, Low-Distortion, Rail-to-Rail Op Amps</description>
 <gate name="P" symbol="PWRN_VCC+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4945,7 +4945,7 @@ High Precision</description>
 <gate name="P" symbol="PWRN_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4975,7 +4975,7 @@ High Precision</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5001,7 +5001,7 @@ High Precision, Low Noise</description>
 <gate name="P" symbol="PWRI_V+-" x="-20.32" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -5025,7 +5025,7 @@ High Precision, Low Noise</description>
 <gate name="P" symbol="PWRN_VCC+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5040,7 +5040,7 @@ High Precision, Low Noise</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5055,7 +5055,7 @@ High Precision, Low Noise</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="P" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5101,7 +5101,7 @@ High Precision, Low Noise</description>
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5126,7 +5126,7 @@ High Precision, Low Noise</description>
 <gate name="A" symbol="ICL7650S" x="0" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="CBA" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="CBA" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5163,7 +5163,7 @@ Wideband, Low-Noise, Voltage-Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5185,7 +5185,7 @@ Wideband, Ultra-Low Noise, Voltage-Feedback with Shutdown</description>
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -5221,7 +5221,7 @@ Wideband, Ultra-Low Noise, Voltage-Feedback with Shutdown</description>
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5236,7 +5236,7 @@ Wideband, Ultra-Low Noise, Voltage-Feedback with Shutdown</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DGK" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="DGK" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5284,7 +5284,7 @@ Wideband, Ultra-Low Noise, Voltage-Feedback with Shutdown</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5307,7 +5307,7 @@ Precision, Low-Noise, Rail-to-Rail Output,
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5319,7 +5319,7 @@ Precision, Low-Noise, Rail-to-Rail Output,
 <technology name=""/>
 </technologies>
 </device>
-<device name="DGK" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="DGK" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5388,7 +5388,7 @@ Precision, Low-Noise, Rail-to-Rail Output,
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5423,7 +5423,7 @@ Dual-Supply</description>
 <gate name="P" symbol="PWR_VCCVEE" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5456,7 +5456,7 @@ Dual-Supply</description>
 <gate name="P" symbol="PWR_VDDVSS" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5532,7 +5532,7 @@ Precision Micropower, Low Noise CMOS, Rail-to-Rail</description>
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="RM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="RM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5547,7 +5547,7 @@ Precision Micropower, Low Noise CMOS, Rail-to-Rail</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5575,7 +5575,7 @@ Precision Micropower, Low Noise CMOS, Rail-to-Rail</description>
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="RU" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="RU" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5596,7 +5596,7 @@ Precision Micropower, Low Noise CMOS, Rail-to-Rail</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="R" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5625,7 +5625,7 @@ Precision Micropower, Low Noise CMOS, Rail-to-Rail</description>
 <gate name="G$1" symbol="AD8221" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="4"/>
 <connect gate="G$1" pin="+VS" pad="8"/>
@@ -5674,7 +5674,7 @@ Very High Precision, 3V/5V Rail-to-Rail Op Amps</description>
 <gate name="B" symbol="OPAMP" x="0" y="-15.24"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5700,7 +5700,7 @@ Low Voltage Rail-to-Rail</description>
 <gate name="P" symbol="PWRN_V+-" x="-17.78" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5726,7 +5726,7 @@ Precision Low-Noise, Low Quiescent Current</description>
 <gate name="P" symbol="PWRI_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5741,7 +5741,7 @@ Precision Low-Noise, Low Quiescent Current</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DGK" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="DGK" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5784,7 +5784,7 @@ Precision Low-Noise, Low Quiescent Current</description>
 <gate name="P" symbol="PWRI_V+-" x="-17.78" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5815,7 +5815,7 @@ Precision Low-Noise, Low Quiescent Current</description>
 <gate name="P" symbol="PWRN_VCC+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5830,7 +5830,7 @@ Precision Low-Noise, Low Quiescent Current</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>

--- a/opto-micro-linear.lbr
+++ b/opto-micro-linear.lbr
@@ -76,7 +76,7 @@ Fiber optic data quantizers&lt;br&gt;
 http://www.microlinear.com&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="PLCC-127P-1150W-1150L-457H-28">
+<package name="PLCC-28-127P-1150W-1150L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 11.51mm length, 11.51mm width, 4.57mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 11.51mm body length, 11.51mm body width, 4.57mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AB.&lt;/p&gt;
@@ -154,7 +154,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <wire x1="5.7531" y1="4.475" x2="5.7531" y2="5.7531" width="0.2032" layer="21"/>
 <wire x1="5.7531" y1="5.7531" x2="4.475" y2="5.7531" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -182,7 +182,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -218,7 +218,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -331,7 +331,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="NC1" symbol="ML4622" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="NC1" pin="!CMPENABLE" pad="16"/>
 <connect gate="NC1" pin="!TTLMON" pad="1"/>
@@ -362,7 +362,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="NC1" symbol="ML4622" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="NC1" pin="!CMPENABLE" pad="16"/>
 <connect gate="NC1" pin="!TTLMON" pad="1"/>
@@ -400,7 +400,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="NC7" symbol="NC" x="30.48" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CMPENABLE" pad="3"/>
 <connect gate="G$1" pin="!TTLMON" pad="2"/>
@@ -450,7 +450,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="NC11" symbol="NC" x="35.56" y="-27.94" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-1150W-1150L-457H-28">
+<device name="" package="PLCC-28-127P-1150W-1150L-457H">
 <connects>
 <connect gate="G$1" pin="!CMPENABLE" pad="3"/>
 <connect gate="G$1" pin="!TTLMON" pad="2"/>

--- a/opto-vishay.lbr
+++ b/opto-vishay.lbr
@@ -220,7 +220,7 @@ Vishay Telefunken</description>
 <text x="-3.175" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="4.1275" y="-2.54" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 </package>
-<package name="DIP-300-6">
+<package name="DIP-6-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="3.81" y1="1.905" x2="-3.81" y2="1.905" width="0.2032" layer="21"/>
@@ -238,7 +238,7 @@ Vishay Telefunken</description>
 <text x="-2.54" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-4.445" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -651,7 +651,7 @@ Vishay Telefunken</description>
 <gate name="G$1" symbol="OK-TR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="C" pad="2"/>
@@ -671,7 +671,7 @@ Vishay Telefunken</description>
 <gate name="B" symbol="OK" x="0" y="-17.78" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>

--- a/optocoupler.lbr
+++ b/optocoupler.lbr
@@ -136,7 +136,7 @@ Siemens, Hewlett-Packard, Texas Instuments, Sharp, Motorola&lt;p&gt;
 <rectangle x1="-1.651" y1="3.175" x2="-0.889" y2="4.191" layer="21"/>
 <rectangle x1="1.016" y1="3.175" x2="1.651" y2="4.191" layer="21"/>
 </package>
-<package name="DIP-400-6">
+<package name="DIP-6-254P-1016W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 400 mil row spacing, JEDEC MS-010C</description>
 <wire x1="-4.445" y1="0.635" x2="-4.445" y2="2.8575" width="0.2032" layer="21"/>
@@ -635,7 +635,7 @@ HCPL-181</description>
 <rectangle x1="1.07" y1="2.78" x2="1.47" y2="3.57" layer="51"/>
 <rectangle x1="-1.47" y1="-3.57" x2="-1.07" y2="-2.78" layer="51"/>
 </package>
-<package name="DIP-300-4">
+<package name="DIP-4-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="2.54" y1="1.905" x2="-2.54" y2="1.905" width="0.2032" layer="21"/>
@@ -651,7 +651,7 @@ HCPL-181</description>
 <text x="4.445" y="-2.8575" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 <text x="-3.175" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 </package>
-<package name="DIP-300-6">
+<package name="DIP-6-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="3.81" y1="1.905" x2="-3.81" y2="1.905" width="0.2032" layer="21"/>
@@ -669,7 +669,7 @@ HCPL-181</description>
 <text x="-2.54" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-4.445" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -689,7 +689,7 @@ HCPL-181</description>
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -717,7 +717,7 @@ HCPL-181</description>
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -923,7 +923,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <text x="-2.032" y="-0.381" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <circle x="-3.205" y="-1.4825" radius="0.6" width="0" layer="21"/>
 </package>
-<package name="DIP-400-6">
+<package name="DIP-6-254P-1016W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 400 mil row spacing, JEDEC MS-010C</description>
 <wire x1="-4.445" y1="0.635" x2="-4.445" y2="2.8575" width="0.2032" layer="21"/>
@@ -4106,7 +4106,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="D" symbol="OK" x="27.94" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4137,7 +4137,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="1" symbol="OK-B" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="1" pin="A" pad="1"/>
 <connect gate="1" pin="BAS" pad="6"/>
@@ -4157,7 +4157,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="G$1" symbol="OK-B" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="BAS" pad="6"/>
@@ -4177,7 +4177,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="G$1" symbol="OK" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="C" pad="2"/>
@@ -4196,7 +4196,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="OK" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-4">
+<device name="" package="DIP-4-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4215,7 +4215,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="G$1" symbol="OK" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-4">
+<device name="" package="DIP-4-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="2"/>
 <connect gate="G$1" pin="C" pad="1"/>
@@ -4234,7 +4234,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="G$1" symbol="OK" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-4">
+<device name="" package="DIP-4-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="C" pad="2"/>
@@ -4272,7 +4272,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="G$1" symbol="OK-B" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="BAS" pad="6"/>
@@ -4311,7 +4311,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="G$1" symbol="OK-DT" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="B" pad="6"/>
@@ -4331,7 +4331,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="G$1" symbol="OK-DL" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="AC1" pad="1"/>
 <connect gate="G$1" pin="AC2" pad="2"/>
@@ -4351,7 +4351,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="G$1" symbol="OK-TH" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="AT" pad="5"/>
@@ -4371,7 +4371,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="G$1" symbol="OK-B" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="BAS" pad="6"/>
@@ -4391,7 +4391,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="G$1" symbol="138" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="2"/>
 <connect gate="G$1" pin="C" pad="3"/>
@@ -4412,7 +4412,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="G$1" symbol="OK-TRN" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -4432,7 +4432,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="OK" x="0" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4456,7 +4456,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="OK-D" x="0" y="-17.78"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4480,7 +4480,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="OK" x="0" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4504,7 +4504,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="OK-LD" x="0" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="AC1" pad="1"/>
 <connect gate="A" pin="AC2" pad="2"/>
@@ -4528,7 +4528,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="OK" x="0" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4554,7 +4554,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="D" symbol="OK-D" x="27.94" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4588,7 +4588,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="D" symbol="OK-LD" x="33.02" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="AC1" pad="1"/>
 <connect gate="A" pin="AC2" pad="2"/>
@@ -4619,7 +4619,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="G$1" symbol="OK-TR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -4638,7 +4638,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="G$1" symbol="OK-B" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="BAS" pad="6"/>
@@ -4661,7 +4661,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="D" symbol="OK-D" x="27.94" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4692,7 +4692,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="OK" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-400-6">
+<device name="" package="DIP-6-254P-1016W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4711,7 +4711,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="OK-B" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-400-6">
+<device name="" package="DIP-6-254P-1016W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="BAS" pad="6"/>
@@ -4731,7 +4731,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="137" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -4766,7 +4766,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="2630A" x="0" y="-15.24"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="C1" pad="2"/>
@@ -4789,7 +4789,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="OPI" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4809,7 +4809,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="OK" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-4">
+<device name="" package="DIP-4-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4828,7 +4828,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="OK-LD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-4">
+<device name="" package="DIP-4-254P-762W">
 <connects>
 <connect gate="A" pin="AC1" pad="1"/>
 <connect gate="A" pin="AC2" pad="2"/>
@@ -4847,7 +4847,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="OK-D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-4">
+<device name="" package="DIP-4-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4867,7 +4867,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="OK" x="0" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4891,7 +4891,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="OK-LD" x="0" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="AC1" pad="1"/>
 <connect gate="A" pin="AC2" pad="2"/>
@@ -4915,7 +4915,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="OK-D" x="0" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4941,7 +4941,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="D" symbol="OK" x="22.86" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -4975,7 +4975,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="D" symbol="OK-LD" x="30.48" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="AC1" pad="1"/>
 <connect gate="A" pin="AC2" pad="2"/>
@@ -5006,7 +5006,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="OK-B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="BAS" pad="6"/>
@@ -5029,7 +5029,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="D" symbol="OK" x="30.48" y="-20.32" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -5063,7 +5063,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="D" symbol="OK2" x="27.94" y="-17.78" swaplevel="2"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -5094,7 +5094,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="OK" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-4">
+<device name="" package="DIP-4-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -5113,7 +5113,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="OK-LD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-4">
+<device name="" package="DIP-4-254P-762W">
 <connects>
 <connect gate="A" pin="AC1" pad="1"/>
 <connect gate="A" pin="AC2" pad="2"/>
@@ -5133,7 +5133,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="OK" x="0" y="-17.78" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -5156,7 +5156,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="OK-DT" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="6"/>
@@ -5176,7 +5176,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="135" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5198,7 +5198,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="2530A" x="0" y="-20.32"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="C1" pad="2"/>
@@ -5221,7 +5221,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="2200" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5242,7 +5242,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="2300" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5263,7 +5263,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="2601" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5284,7 +5284,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="2602" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="+" pad="2"/>
 <connect gate="A" pin="-" pad="3"/>
@@ -5307,7 +5307,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="2730A" x="0" y="-22.86"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="C1" pad="2"/>
@@ -5330,7 +5330,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="4N45" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="6"/>
@@ -5392,7 +5392,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="1" symbol="2200" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="1" pin="A" pad="2"/>
 <connect gate="1" pin="C" pad="3"/>
@@ -5413,7 +5413,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="1" symbol="2201" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="1" pin="A" pad="2"/>
 <connect gate="1" pin="C" pad="3"/>
@@ -5433,7 +5433,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="1" symbol="2201" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="1" pin="A" pad="2"/>
 <connect gate="1" pin="C" pad="3"/>
@@ -5454,7 +5454,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="2231A" x="0" y="-20.32"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -5477,7 +5477,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="1" symbol="2200" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="1" pin="A" pad="2"/>
 <connect gate="1" pin="C" pad="3"/>
@@ -5499,7 +5499,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="B" symbol="2231A" x="0" y="-20.32"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>
@@ -5522,7 +5522,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="0600" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5543,7 +5543,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="0601" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5564,7 +5564,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="4502" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5584,7 +5584,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="135" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5605,7 +5605,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="4502" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5625,7 +5625,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="4503" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5665,7 +5665,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="138" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5686,7 +5686,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="7100" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="GND1" pad="4"/>
 <connect gate="A" pin="GND2" pad="5"/>
@@ -5879,7 +5879,7 @@ MOSFET IGBT GATE DRIVER</description>
 <gate name="G$1" symbol="TLP250" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="2"/>
 <connect gate="G$1" pin="C" pad="3"/>
@@ -5974,7 +5974,7 @@ PerkinElmer Optoelectronics</description>
 <gate name="G$1" symbol="0730" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="5"/>
 <connect gate="G$1" pin="V01" pad="7"/>
@@ -6018,7 +6018,7 @@ Fairchild</description>
 <gate name="G$1" symbol="MOCD223-M" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="C1" pad="8"/>
 <connect gate="G$1" pin="C2" pad="6"/>
@@ -6116,7 +6116,7 @@ VTL5C1(PerkinElmer)/NSL-32SR2(Silonex)</description>
 <gate name="G$1" symbol="OK-TR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="A1" pad="6"/>
@@ -6167,7 +6167,7 @@ Source: http://www.fairchildsemi.com/ds/H1/H11L2-M.pdf</description>
 <gate name="G$1" symbol="H11L" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="C" pad="2"/>
@@ -6197,7 +6197,7 @@ Source: http://www.fairchildsemi.com/ds/H1/H11L2-M.pdf</description>
 <technology name="3"/>
 </technologies>
 </device>
-<device name="T" package="DIP-400-6">
+<device name="T" package="DIP-6-254P-1016W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="C" pad="2"/>

--- a/oxford-semi.lbr
+++ b/oxford-semi.lbr
@@ -76,7 +76,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -409,7 +409,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="G$1" symbol="OXFW971" x="0" y="0"/>
 </gates>
 <devices>
-<device name="TQ" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="TQ" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="AUDIO1_NFS_CLK_OUT@21" pad="21"/>
 <connect gate="G$1" pin="AUDIO1_NFS_CLK_OUT@85" pad="85"/>

--- a/pal.lbr
+++ b/pal.lbr
@@ -72,7 +72,7 @@
 <description>&lt;b&gt;PALs&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -104,7 +104,7 @@
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -144,7 +144,7 @@
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -1474,7 +1474,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="1" pin="I0" pad="1"/>
 <connect gate="1" pin="I1" pad="2"/>
@@ -1510,7 +1510,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="1" pin="I0" pad="1"/>
 <connect gate="1" pin="I1" pad="2"/>
@@ -1546,7 +1546,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="1" pin="!O" pad="15"/>
 <connect gate="1" pin="I0" pad="1"/>
@@ -1582,7 +1582,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="1" pin="I0" pad="1"/>
 <connect gate="1" pin="I1" pad="2"/>
@@ -1618,7 +1618,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="1" pin="I0" pad="1"/>
 <connect gate="1" pin="I1" pad="2"/>
@@ -1654,7 +1654,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="1" pin="I0" pad="1"/>
 <connect gate="1" pin="I1" pad="2"/>
@@ -1690,7 +1690,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="1" pin="I0" pad="1"/>
 <connect gate="1" pin="I1" pad="2"/>
@@ -1726,7 +1726,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="I0" pad="1"/>
 <connect gate="G$1" pin="I1" pad="2"/>
@@ -1762,7 +1762,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="1"/>
 <connect gate="G$1" pin="I0" pad="2"/>
@@ -1798,7 +1798,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="1"/>
 <connect gate="G$1" pin="I0" pad="2"/>
@@ -1834,7 +1834,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="1"/>
 <connect gate="G$1" pin="I0" pad="2"/>
@@ -1870,7 +1870,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="1"/>
 <connect gate="G$1" pin="I0" pad="2"/>
@@ -1906,7 +1906,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="I0" pad="1"/>
 <connect gate="G$1" pin="I1" pad="2"/>
@@ -1946,7 +1946,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="1"/>
 <connect gate="G$1" pin="I0" pad="2"/>
@@ -1986,7 +1986,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="1"/>
 <connect gate="G$1" pin="I0" pad="2"/>
@@ -2026,7 +2026,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK" pad="1"/>
 <connect gate="G$1" pin="I0" pad="2"/>
@@ -2066,7 +2066,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="I0" pad="2"/>
 <connect gate="G$1" pin="I1" pad="3"/>
@@ -2106,7 +2106,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK/I0" pad="1"/>
 <connect gate="G$1" pin="I0" pad="2"/>
@@ -2146,7 +2146,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK/I0" pad="1"/>
 <connect gate="G$1" pin="I0" pad="2"/>
@@ -2186,7 +2186,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK/I0" pad="1"/>
 <connect gate="G$1" pin="I0" pad="2"/>
@@ -2230,7 +2230,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK1/I0" pad="1"/>
 <connect gate="G$1" pin="CLK2/I3" pad="4"/>
@@ -2274,7 +2274,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK/LE" pad="1"/>
 <connect gate="G$1" pin="F0" pad="3"/>
@@ -2314,7 +2314,7 @@
 <gate name="P" symbol="PWRN" x="-33.02" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="CLK/LE" pad="1"/>
 <connect gate="G$1" pin="F0" pad="3"/>
@@ -2354,7 +2354,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -2390,7 +2390,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -2426,7 +2426,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -2466,7 +2466,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -2502,7 +2502,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!OE" pad="11"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -2538,7 +2538,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -2578,7 +2578,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -2614,7 +2614,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -2650,7 +2650,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -2686,7 +2686,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -2726,7 +2726,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="!O" pad="18"/>
 <connect gate="A" pin="I0" pad="1"/>
@@ -2766,7 +2766,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -2806,7 +2806,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="!OE" pad="13"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -2846,7 +2846,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="!OE" pad="13"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -2886,7 +2886,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -2926,7 +2926,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -2966,7 +2966,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="!OE" pad="13"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -3006,7 +3006,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CS1" pad="15"/>
 <connect gate="A" pin="!CS2" pad="16"/>
@@ -3042,7 +3042,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="!CS1" pad="20"/>
 <connect gate="A" pin="!CS2" pad="18"/>
@@ -3082,7 +3082,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-24">
+<device name="" package="DIP-24-254P-762W">
 <connects>
 <connect gate="A" pin="B0" pad="14"/>
 <connect gate="A" pin="B1" pad="15"/>
@@ -3122,7 +3122,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="A" pin="!CS" pad="9"/>
 <connect gate="A" pin="!WE" pad="11"/>
@@ -3158,7 +3158,7 @@
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-28">
+<device name="" package="DIP-28-254P-762W">
 <connects>
 <connect gate="A" pin="!CC" pad="1"/>
 <connect gate="A" pin="!CE" pad="20"/>

--- a/philips-6.lbr
+++ b/philips-6.lbr
@@ -245,7 +245,7 @@
 <rectangle x1="-6.8999" y1="-4.4" x2="-5.95" y2="-4.1001" layer="51"/>
 <rectangle x1="-6.8999" y1="-4.8999" x2="-5.95" y2="-4.5999" layer="51"/>
 </package>
-<package name="PLCC-127P-2423W-2423L-457H-68">
+<package name="PLCC-68-127P-2423W-2423L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 24.23mm length, 24.23mm width, 4.57mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body width, 4.57mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AE.&lt;/p&gt;
@@ -403,7 +403,7 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <wire x1="12.1158" y1="10.825" x2="12.1158" y2="12.1158" width="0.2032" layer="21"/>
 <wire x1="12.1158" y1="12.1158" x2="10.825" y2="12.1158" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1400W-2000L-315H-160F-100">
+<package name="QFP-100-65P-1400W-2000L-315H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-022B, variation GC-2, PQFP-G.
@@ -790,7 +790,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <rectangle x1="-11.7201" y1="-5.4201" x2="-9.9499" y2="-4.9799" layer="51"/>
 <rectangle x1="-11.7201" y1="-6.22" x2="-9.9499" y2="-5.78" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -863,7 +863,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="TQFP-50P-2000W-2000L-120H-144">
+<package name="TQFP-144-50P-2000W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
@@ -1165,7 +1165,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -1199,7 +1199,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="TQFP-50P-1000W-1000L-120H-64">
+<package name="TQFP-64-50P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.
@@ -1630,7 +1630,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <rectangle x1="-5.08" y1="-2.5146" x2="-4.699" y2="-2.3876" layer="21"/>
 <rectangle x1="-5.207" y1="-2.9718" x2="-4.953" y2="-2.7178" layer="21"/>
 </package>
-<package name="LQFP-50P-1000W-1000L-160H-64">
+<package name="LQFP-64-50P-1000W-1000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
@@ -1919,7 +1919,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <rectangle x1="-11.43" y1="-2.5146" x2="-11.049" y2="-2.3876" layer="21"/>
 <rectangle x1="-11.557" y1="-2.9718" x2="-11.303" y2="-2.7178" layer="21"/>
 </package>
-<package name="LQFP-50P-700W-700L-160H-48">
+<package name="LQFP-48-50P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
@@ -2029,7 +2029,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-14">
+<package name="SSOP-14-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
@@ -2070,7 +2070,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -2090,7 +2090,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="PLCC-SOCKET-TH-7X7-28">
+<package name="PLCC-SOCKET-TH-28-7X7">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 28 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 28 leads.
 &lt;/p&gt;</description>
@@ -2261,7 +2261,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 28 leads.
 <wire x1="8.89" y1="-8.89" x2="8.89" y2="8.89" width="0.2032" layer="21"/>
 <wire x1="8.89" y1="8.89" x2="-7.62" y2="8.89" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -4127,7 +4127,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <gate name="G$1" symbol="80C552" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-2423W-2423L-457H-68">
+<device name="" package="PLCC-68-127P-2423W-2423L-457H">
 <connects>
 <connect gate="G$1" pin="A08-P2.0" pad="39"/>
 <connect gate="G$1" pin="A09-P2.1" pad="40"/>
@@ -4315,7 +4315,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <gate name="G$1" symbol="OP+-DIF" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="2"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -4335,7 +4335,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <gate name="G$1" symbol="OP+-DIF" x="-5.08" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+IN" pad="2"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -4355,7 +4355,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <gate name="82C250" symbol="82C250" x="5.08" y="-20.32"/>
 </gates>
 <devices>
-<device name="SMD" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SMD" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="82C250" pin="CANH" pad="7"/>
 <connect gate="82C250" pin="CANL" pad="6"/>
@@ -4370,7 +4370,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="DIL" package="DIP-300-8">
+<device name="DIL" package="DIP-8-254P-762W">
 <connects>
 <connect gate="82C250" pin="CANH" pad="7"/>
 <connect gate="82C250" pin="CANL" pad="6"/>
@@ -4392,7 +4392,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <gate name="G$1" symbol="SJA1000" x="2.54" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AD0" pad="23"/>
 <connect gate="G$1" pin="AD1" pad="24"/>
@@ -4434,7 +4434,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <gate name="G$1" symbol="82C150" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AVDD" pad="18"/>
 <connect gate="G$1" pin="AVSS" pad="20"/>
@@ -4478,7 +4478,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <gate name="G$2" symbol="VCCVSS" x="2.54" y="27.94"/>
 </gates>
 <devices>
-<device name="SOT16W" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="SOT16W" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!IOUT!" pad="2"/>
 <connect gate="G$1" pin="B1" pad="5"/>
@@ -4513,7 +4513,7 @@ Vbat 5...27Volt
 <gate name="G$1" symbol="TJA1020" x="-2.54" y="2.54"/>
 </gates>
 <devices>
-<device name="SO8" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SO8" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BAT" pad="7"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -4535,7 +4535,7 @@ Vbat 5...27Volt
 <gate name="TDA5051" symbol="TDA5051" x="-15.24" y="10.16"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="TDA5051" pin="AGND" pad="12"/>
 <connect gate="TDA5051" pin="APGND" pad="9"/>
@@ -4565,7 +4565,7 @@ Vbat 5...27Volt
 <gate name="IC" symbol="LPC938" x="2.54" y="-7.62"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-7X7-28">
+<device name="" package="PLCC-SOCKET-TH-28-7X7">
 <connects>
 <connect gate="IC" pin="CLKOUT/XTAL2/P3.0" pad="9"/>
 <connect gate="IC" pin="P0.0/CMP2/KBI0/AD05" pad="3"/>
@@ -4607,7 +4607,7 @@ Vbat 5...27Volt
 <gate name="G$1" symbol="LPC2114" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="P0.0/TXD0/PWM1" pad="19"/>
 <connect gate="G$1" pin="P0.1/RXD0/PWM3/EINT0" pad="21"/>
@@ -4685,7 +4685,7 @@ Vbat 5...27Volt
 <gate name="G$1" symbol="LPC2214" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-2000W-2000L-120H-144">
+<device name="" package="TQFP-144-50P-2000W-2000L-120H">
 <connects>
 <connect gate="G$1" pin="P.012/DSR1/MAT1.0" pad="84"/>
 <connect gate="G$1" pin="P0.0/TXD0/PWM1" pad="42"/>
@@ -4843,7 +4843,7 @@ Vbat 5...27Volt
 <gate name="G$1" symbol="LPC904" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="FD" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="FD" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="AD11/PO.2/CIN2A/KBI2" pad="2"/>
 <connect gate="G$1" pin="P0.4/CIN1A/AD13/DAC1" pad="7"/>
@@ -4858,7 +4858,7 @@ Vbat 5...27Volt
 <technology name=""/>
 </technologies>
 </device>
-<device name="FN" package="DIP-300-8">
+<device name="FN" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="AD11/PO.2/CIN2A/KBI2" pad="2"/>
 <connect gate="G$1" pin="P0.4/CIN1A/AD13/DAC1" pad="7"/>
@@ -4880,7 +4880,7 @@ Vbat 5...27Volt
 <gate name="G$1" symbol="LPC9107" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="N.C." pad="2"/>
 <connect gate="G$1" pin="NC" pad="13"/>
@@ -4908,7 +4908,7 @@ Vbat 5...27Volt
 <gate name="G$1" symbol="LPC213X" x="-2.54" y="25.4"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1000W-1000L-120H-64">
+<device name="" package="TQFP-64-50P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="(AD0.0/CAP0.1/MAT0.1)P0.27" pad="11"/>
 <connect gate="G$1" pin="(AD0.1/CAP0.2/MAT0.2)P0.28" pad="13"/>
@@ -5035,7 +5035,7 @@ Vbat 5...27Volt
 <gate name="G$1" symbol="PCF8563" x="0" y="0"/>
 </gates>
 <devices>
-<device name="T" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="T" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!INT!" pad="3"/>
 <connect gate="G$1" pin="CLKOUT" pad="7"/>
@@ -5057,7 +5057,7 @@ Vbat 5...27Volt
 <gate name="G$1" symbol="LM75A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="7"/>
 <connect gate="G$1" pin="A1" pad="6"/>
@@ -5081,7 +5081,7 @@ microcontroler from Philips</description>
 <gate name="G$1" symbol="LPC2103" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="DBGSEL" pad="27"/>
 <connect gate="G$1" pin="P0.0/MAT3.1/TXD0" pad="13"/>
@@ -5168,7 +5168,7 @@ microcontroler from Philips</description>
 <gate name="G$1" symbol="LPC2131" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FBD64" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="FBD64" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="57"/>
 <connect gate="G$1" pin="P0.0/TXD0/PWM1" pad="19"/>
@@ -5246,7 +5246,7 @@ microcontroler from Philips</description>
 <gate name="G$1" symbol="LPC2132/2134/2136" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FBD64" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="FBD64" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="57"/>
 <connect gate="G$1" pin="P0.0/TXD0/PWM1" pad="19"/>
@@ -5324,7 +5324,7 @@ microcontroler from Philips</description>
 <gate name="G$1" symbol="LPC2132/2134/2136" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FBD64" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="FBD64" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="57"/>
 <connect gate="G$1" pin="P0.0/TXD0/PWM1" pad="19"/>
@@ -5402,7 +5402,7 @@ microcontroler from Philips</description>
 <gate name="G$1" symbol="LPC2132/2134/2136" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FBD64" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="FBD64" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="57"/>
 <connect gate="G$1" pin="P0.0/TXD0/PWM1" pad="19"/>
@@ -5480,7 +5480,7 @@ microcontroler from Philips</description>
 <gate name="G$1" symbol="LPC2138" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FBD64" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="FBD64" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="57"/>
 <connect gate="G$1" pin="P0.0/TXD0/PWM1" pad="19"/>
@@ -5558,7 +5558,7 @@ microcontroler from Philips</description>
 <gate name="G$1" symbol="LPC2141" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FBD64" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="FBD64" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="57"/>
 <connect gate="G$1" pin="D+" pad="10"/>
@@ -5636,7 +5636,7 @@ microcontroler from Philips</description>
 <gate name="G$1" symbol="LPC2142" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FBD64" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="FBD64" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="57"/>
 <connect gate="G$1" pin="D+" pad="10"/>
@@ -5714,7 +5714,7 @@ microcontroler from Philips</description>
 <gate name="G$1" symbol="LPC2144/2146/2148" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FBD64" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="FBD64" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="57"/>
 <connect gate="G$1" pin="D+" pad="10"/>
@@ -5792,7 +5792,7 @@ microcontroler from Philips</description>
 <gate name="G$1" symbol="LPC2144/2146/2148" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FBD64" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="FBD64" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="57"/>
 <connect gate="G$1" pin="D+" pad="10"/>
@@ -5870,7 +5870,7 @@ microcontroler from Philips</description>
 <gate name="G$1" symbol="LPC2144/2146/2148" x="0" y="0"/>
 </gates>
 <devices>
-<device name="FBD64" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="FBD64" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="57"/>
 <connect gate="G$1" pin="D+" pad="10"/>
@@ -6019,7 +6019,7 @@ Hi-Speed Universal Serial Bus peripheral controller</description>
 <gate name="G$1" symbol="ISP1581BD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="25"/>
 <connect gate="G$1" pin="!CS0!" pad="18"/>

--- a/pld-intel.lbr
+++ b/pld-intel.lbr
@@ -357,7 +357,7 @@
 <rectangle x1="-9.7282" y1="-14.1986" x2="-9.4234" y2="-12.0396" layer="51"/>
 <rectangle x1="-10.3632" y1="-14.1986" x2="-10.0584" y2="-12.0396" layer="51"/>
 </package>
-<package name="PLCC-SOCKET-TH-17X17-68">
+<package name="PLCC-SOCKET-TH-68-17X17">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 68 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 &lt;/p&gt;</description>
@@ -732,7 +732,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 <wire x1="15.24" y1="-15.24" x2="15.24" y2="15.24" width="0.2032" layer="21"/>
 <wire x1="15.24" y1="15.24" x2="-13.97" y2="15.24" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-21X21-84">
+<package name="PLCC-SOCKET-TH-84-21X21">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 68 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 &lt;/p&gt;</description>
@@ -1187,7 +1187,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 <wire x1="17.78" y1="-17.78" x2="17.78" y2="17.78" width="0.2032" layer="21"/>
 <wire x1="17.78" y1="17.78" x2="-16.51" y2="17.78" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-7X7-28">
+<package name="PLCC-SOCKET-TH-28-7X7">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 28 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 28 leads.
 &lt;/p&gt;</description>
@@ -1358,7 +1358,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 28 leads.
 <wire x1="8.89" y1="-8.89" x2="8.89" y2="8.89" width="0.2032" layer="21"/>
 <wire x1="8.89" y1="8.89" x2="-7.62" y2="8.89" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-11X11-44">
+<package name="PLCC-SOCKET-TH-44-11X11">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 44 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 &lt;/p&gt;</description>
@@ -2100,7 +2100,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="FX740-44" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-11X11-44">
+<device name="" package="PLCC-SOCKET-TH-44-11X11">
 <connects>
 <connect gate="G$1" pin="CLK1" pad="13"/>
 <connect gate="G$1" pin="CLK2" pad="35"/>
@@ -2159,7 +2159,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="FX740-68" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-17X17-68">
+<device name="" package="PLCC-SOCKET-TH-68-17X17">
 <connects>
 <connect gate="G$1" pin="CLK1" pad="19"/>
 <connect gate="G$1" pin="CLK2" pad="53"/>
@@ -2242,7 +2242,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="FX780-84" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-21X21-84">
+<device name="" package="PLCC-SOCKET-TH-84-21X21">
 <connects>
 <connect gate="G$1" pin="CLK1" pad="3"/>
 <connect gate="G$1" pin="CLK2" pad="45"/>
@@ -2489,7 +2489,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="P" symbol="PWRN" x="-30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-7X7-28">
+<device name="" package="PLCC-SOCKET-TH-28-7X7">
 <connects>
 <connect gate="G$1" pin="CLK/I0" pad="2"/>
 <connect gate="G$1" pin="I1" pad="3"/>
@@ -2528,7 +2528,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="PLD610" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-7X7-28">
+<device name="" package="PLCC-SOCKET-TH-28-7X7">
 <connects>
 <connect gate="G$1" pin="CLK1" pad="2"/>
 <connect gate="G$1" pin="CLK2" pad="16"/>
@@ -2569,7 +2569,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <gate name="G$1" symbol="PLD910" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-11X11-44">
+<device name="" package="PLCC-SOCKET-TH-44-11X11">
 <connects>
 <connect gate="G$1" pin="CLK1" pad="2"/>
 <connect gate="G$1" pin="CLK2" pad="24"/>

--- a/pot-xicor.lbr
+++ b/pot-xicor.lbr
@@ -74,7 +74,7 @@
 <description>&lt;B&gt;Xicor Digitally-Controlled Potentiometers&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -94,7 +94,7 @@
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -173,7 +173,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <gate name="1" symbol="X9C10X" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="1" pin="!CS" pad="7"/>
 <connect gate="1" pin="!INC" pad="1"/>
@@ -188,7 +188,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="1" pin="!CS" pad="7"/>
 <connect gate="1" pin="!INC" pad="1"/>

--- a/princeton-tech.lbr
+++ b/princeton-tech.lbr
@@ -78,7 +78,7 @@ source: http://www.princeton.com.tw/&lt;p&gt;
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2010, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -106,7 +106,7 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -155,7 +155,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -191,7 +191,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -322,7 +322,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <gate name="G$1" symbol="PT2399" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="3"/>
 <connect gate="G$1" pin="CC0" pad="8"/>
@@ -345,7 +345,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="S" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="3"/>
 <connect gate="G$1" pin="CC0" pad="8"/>
@@ -376,7 +376,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <gate name="G$1" symbol="PT2396" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-24">
+<device name="" package="DIP-24-254P-1524W">
 <connects>
 <connect gate="G$1" pin="AGND" pad="12"/>
 <connect gate="G$1" pin="CC1" pad="18"/>
@@ -407,7 +407,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="-S" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="-S" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="12"/>
 <connect gate="G$1" pin="CC1" pad="18"/>

--- a/quickfilter.lbr
+++ b/quickfilter.lbr
@@ -76,7 +76,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="LQFP-80P-700W-700L-160H-32">
+<package name="LQFP-32-80P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.
@@ -204,7 +204,7 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="G$1" symbol="QF4A512" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-80P-700W-700L-160H-32">
+<device name="" package="LQFP-32-80P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="12"/>
 <connect gate="G$1" pin="!RST!" pad="17"/>

--- a/ref-packages-dip.lbr
+++ b/ref-packages-dip.lbr
@@ -67,7 +67,7 @@
 <description>&lt;b&gt;Maintenence Library&lt;/b&gt;&lt;p&gt;
 NOTE: This library is used to globally update common IC packages in all other libraries.&lt;p&gt;</description>
 <packages>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -93,7 +93,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -121,7 +121,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -151,7 +151,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-2">
+<package name="DIP-2-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="-0.635" y1="-1.905" x2="0.635" y2="-1.905" width="0.2032" layer="21"/>
@@ -168,7 +168,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-1.27" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="2.54" y="-2.54" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -200,7 +200,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-22">
+<package name="DIP-22-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="-14.605" y1="-0.635" x2="-14.605" y2="-1.905" width="0.2032" layer="21"/>
@@ -234,7 +234,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-15.24" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.795" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -270,7 +270,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-28">
+<package name="DIP-28-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="17.78" y1="1.905" x2="-17.78" y2="1.905" width="0.2032" layer="21"/>
@@ -310,7 +310,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-32">
+<package name="DIP-32-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <pad name="1" x="-19.05" y="-3.81" drill="0.8128" shape="long" rot="R90" first="yes"/>
@@ -354,7 +354,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-20.955" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.985" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-4">
+<package name="DIP-4-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="2.54" y1="1.905" x2="-2.54" y2="1.905" width="0.2032" layer="21"/>
@@ -370,7 +370,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="4.445" y="-2.8575" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 <text x="-3.175" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 </package>
-<package name="DIP-300-6">
+<package name="DIP-6-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="3.81" y1="1.905" x2="-3.81" y2="1.905" width="0.2032" layer="21"/>
@@ -388,7 +388,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-2.54" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-4.445" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -408,7 +408,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-400-22">
+<package name="DIP-22-254P-1016W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 400 mil row spacing, JEDEC MS-010C</description>
 <wire x1="13.97" y1="2.8575" x2="-13.97" y2="2.8575" width="0.2032" layer="21"/>
@@ -442,7 +442,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-14.605" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.2075" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-400-24">
+<package name="DIP-24-254P-1016W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 400 mil row spacing, JEDEC MS-010C</description>
 <wire x1="15.5575" y1="-3.175" x2="15.5575" y2="3.175" width="0.2032" layer="21"/>
@@ -478,7 +478,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-15.875" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-12.065" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-400-28">
+<package name="DIP-28-254P-1016W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 400 mil row spacing, JEDEC MS-010C</description>
 <wire x1="17.78" y1="3.175" x2="-17.78" y2="3.175" width="0.2032" layer="21"/>
@@ -518,7 +518,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-18.415" y="-3.81" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-400-6">
+<package name="DIP-6-254P-1016W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 400 mil row spacing, JEDEC MS-010C</description>
 <wire x1="-4.445" y1="0.635" x2="-4.445" y2="2.8575" width="0.2032" layer="21"/>
@@ -542,7 +542,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <rectangle x1="-0.762" y1="2.794" x2="0.7621" y2="4.0641" layer="51"/>
 <rectangle x1="1.778" y1="2.794" x2="3.3021" y2="4.0641" layer="51"/>
 </package>
-<package name="DIP-600-24">
+<package name="DIP-24-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-15.24" y1="5.715" x2="-15.24" y2="1.016" width="0.2032" layer="21"/>
@@ -578,7 +578,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -618,7 +618,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-32">
+<package name="DIP-32-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="20.32" y1="5.715" x2="-20.32" y2="5.715" width="0.2032" layer="21"/>
@@ -662,7 +662,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-20.955" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-17.145" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-36">
+<package name="DIP-36-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="22.86" y1="5.715" x2="-22.86" y2="5.715" width="0.2032" layer="21"/>
@@ -710,7 +710,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-23.495" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-17.145" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -762,7 +762,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-42">
+<package name="DIP-42-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-27.6225" y1="-0.9525" x2="-27.6225" y2="-5.715" width="0.2032" layer="21"/>
@@ -816,7 +816,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-28.575" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-22.225" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-48">
+<package name="DIP-48-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-29.845" y1="-5.715" x2="29.845" y2="-5.715" width="0.2032" layer="21"/>
@@ -876,7 +876,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-30.48" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-52">
+<package name="DIP-52-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="-33.02" y1="0.9525" x2="-33.02" y2="-0.9525" width="0.1778" layer="21" curve="-180"/>
@@ -940,7 +940,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-33.655" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-28.575" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-900-24">
+<package name="DIP-24-254P-2286W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 900 mil row spacing, JEDEC MO-016D</description>
 <wire x1="-16.129" y1="-0.9525" x2="-16.129" y2="-9.4615" width="0.2032" layer="21"/>
@@ -976,7 +976,7 @@ NOTE: This library is used to globally update common IC packages in all other li
 <text x="-17.145" y="-10.16" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-12.065" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-900-64">
+<package name="DIP-64-254P-2286W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 900 mil row spacing, JEDEC MO-016D</description>
 <wire x1="-41.275" y1="-0.9525" x2="-41.275" y2="-9.4615" width="0.2032" layer="21"/>

--- a/ref-packages-lcc.lbr
+++ b/ref-packages-lcc.lbr
@@ -65,7 +65,7 @@
 <description>&lt;b&gt;Maintenence Library&lt;/b&gt;&lt;p&gt;
 NOTE: This library is used to globally update common IC packages in all other libraries.&lt;p&gt;</description>
 <packages>
-<package name="LCC-127P-1016W-1016L-254H-24">
+<package name="LCC-24-127P-1016W-1016L-254H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 10.16mm length, 10.16mm width, 2.54mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 10.16mm body length, 10.16mm body width, 2.54mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CH.&lt;/p&gt;
@@ -158,7 +158,7 @@ Leadless chip carrier. 1.27mm pitch, 10.16mm body length, 10.16mm body width, 2.
 <wire x1="5.18" y1="2.305" x2="5.18" y2="1.505" width="0.2032" layer="51" curve="180" cap="flat"/>
 <wire x1="5.18" y1="3.575" x2="5.18" y2="2.775" width="0.2032" layer="51" curve="180" cap="flat"/>
 </package>
-<package name="LCC-127P-1143W-1143L-254H-28">
+<package name="LCC-28-127P-1143W-1143L-254H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 11.43mm length, 11.43mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 11.43mm body length, 11.43mm body width, 2.54mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CC.&lt;/p&gt;
@@ -263,7 +263,7 @@ Leadless chip carrier. 1.27mm pitch, 11.43mm body length, 11.43mm body width, 2.
 <wire x1="5.815" y1="2.94" x2="5.815" y2="2.14" width="0.2032" layer="51" curve="180" cap="flat"/>
 <wire x1="5.815" y1="4.21" x2="5.815" y2="3.41" width="0.2032" layer="51" curve="180" cap="flat"/>
 </package>
-<package name="LCC-127P-1650W-1650L-304H-44">
+<package name="LCC-44-127P-1650W-1650L-304H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 16.51mm length, 16.51mm width, 3.05mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 16.51mm body length, 16.51mm body width, 3.05mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CD.&lt;/p&gt;
@@ -416,7 +416,7 @@ Leadless chip carrier. 1.27mm pitch, 16.51mm body length, 16.51mm body width, 3.
 <wire x1="8.355" y1="5.48" x2="8.355" y2="4.68" width="0.2032" layer="51" curve="180" cap="flat"/>
 <wire x1="8.355" y1="6.75" x2="8.355" y2="5.95" width="0.2032" layer="51" curve="180" cap="flat"/>
 </package>
-<package name="LCC-127P-1905W-1905L-304H-52">
+<package name="LCC-52-127P-1905W-1905L-304H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 19.05mm length, 19.05mm width, 3.05mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 19.05mm body length, 19.05mm body width, 3.05mm max height, 52 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CE.&lt;/p&gt;
@@ -593,7 +593,7 @@ Leadless chip carrier. 1.27mm pitch, 19.05mm body length, 19.05mm body width, 3.
 <wire x1="9.625" y1="6.75" x2="9.625" y2="5.95" width="0.2032" layer="51" curve="180" cap="flat"/>
 <wire x1="9.625" y1="8.02" x2="9.625" y2="7.22" width="0.2032" layer="51" curve="180" cap="flat"/>
 </package>
-<package name="LCC-127P-2413W-2413L-304H-68">
+<package name="LCC-68-127P-2413W-2413L-304H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 24.13mm length, 24.13mm width, 3.05mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 24.13mm body length, 24.13mm body width, 3.05mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CF.&lt;/p&gt;
@@ -818,7 +818,7 @@ Leadless chip carrier. 1.27mm pitch, 24.13mm body length, 24.13mm body width, 3.
 <wire x1="12.165" y1="9.29" x2="12.165" y2="8.49" width="0.2032" layer="51" curve="180" cap="flat"/>
 <wire x1="12.165" y1="10.56" x2="12.165" y2="9.76" width="0.2032" layer="51" curve="180" cap="flat"/>
 </package>
-<package name="LCC-127P-2920W-2920L-304H-84">
+<package name="LCC-84-127P-2920W-2920L-304H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 29.21mm length, 29.21mm width, 3.05mm max height, 84 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 29.21mm body length, 29.21mm body width, 3.05mm max height, 84 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CG.&lt;/p&gt;
@@ -1091,7 +1091,7 @@ Leadless chip carrier. 1.27mm pitch, 29.21mm body length, 29.21mm body width, 3.
 <wire x1="14.705" y1="11.83" x2="14.705" y2="11.03" width="0.2032" layer="51" curve="180" cap="flat"/>
 <wire x1="14.705" y1="13.1" x2="14.705" y2="12.3" width="0.2032" layer="51" curve="180" cap="flat"/>
 </package>
-<package name="LCC-127P-762W-762L-254H-16">
+<package name="LCC-16-127P-762W-762L-254H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 7.62mm length, 7.62mm width, 2.54mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 7.62mm body length, 7.62mm body width, 2.54mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CA.&lt;/p&gt;
@@ -1160,7 +1160,7 @@ Leadless chip carrier. 1.27mm pitch, 7.62mm body length, 7.62mm body width, 2.54
 <wire x1="3.91" y1="1.035" x2="3.91" y2="0.235" width="0.2032" layer="51" curve="180" cap="flat"/>
 <wire x1="3.91" y1="2.305" x2="3.91" y2="1.505" width="0.2032" layer="51" curve="180" cap="flat"/>
 </package>
-<package name="LCC-127P-888W-888L-254H-20">
+<package name="LCC-20-127P-888W-888L-254H">
 <description>&lt;b&gt;LCC (1.27mm pitch, 8.89mm length, 8.89mm width, 2.54mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Leadless chip carrier. 1.27mm pitch, 8.89mm body length, 8.89mm body width, 2.54mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 &lt;p/&gt;JEDEC MS-004B, variation CB.&lt;/p&gt;
@@ -1241,7 +1241,7 @@ Leadless chip carrier. 1.27mm pitch, 8.89mm body length, 8.89mm body width, 2.54
 <wire x1="4.545" y1="1.67" x2="4.545" y2="0.87" width="0.2032" layer="51" curve="180" cap="flat"/>
 <wire x1="4.545" y1="2.94" x2="4.545" y2="2.14" width="0.2032" layer="51" curve="180" cap="flat"/>
 </package>
-<package name="PLCC-127P-1079W-723L-355H-18">
+<package name="PLCC-18-127P-1079W-723L-355H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 7.24mm length, 10.79mm width, 3.56mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
 Rectangular plastic leaded chip carrier. 1.27mm pitch, 7.24mm body length, 10.79mm body width, 3.56mm max height, 18 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-016A, variation AA.&lt;/p&gt;
@@ -1299,7 +1299,7 @@ JEDEC MS-016A, variation AA.&lt;/p&gt;
 <wire x1="3.6195" y1="3.205" x2="3.6195" y2="5.3975" width="0.2032" layer="21"/>
 <wire x1="3.6195" y1="5.3975" x2="2.57" y2="5.3975" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1150W-1150L-457H-28">
+<package name="PLCC-28-127P-1150W-1150L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 11.51mm length, 11.51mm width, 4.57mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 11.51mm body length, 11.51mm body width, 4.57mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AB.&lt;/p&gt;
@@ -1377,7 +1377,7 @@ JEDEC MS-018A, variation AB.&lt;/p&gt;
 <wire x1="5.7531" y1="4.475" x2="5.7531" y2="5.7531" width="0.2032" layer="21"/>
 <wire x1="5.7531" y1="5.7531" x2="4.475" y2="5.7531" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1244W-736L-355H-18">
+<package name="PLCC-18-127P-1244W-736L-355H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 7.37mm length, 12.45mm width, 3.56mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
 Rectangular plastic leaded chip carrier. 1.27mm pitch, 7.37mm body length, 12.45mm body width, 3.56mm max height, 18 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-016A, variation AB.&lt;/p&gt;
@@ -1435,7 +1435,7 @@ JEDEC MS-016A, variation AB.&lt;/p&gt;
 <wire x1="3.683" y1="3.205" x2="3.683" y2="6.223" width="0.2032" layer="21"/>
 <wire x1="3.683" y1="6.223" x2="2.57" y2="6.223" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1244W-736L-355H-22">
+<package name="PLCC-22-127P-1244W-736L-355H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 7.37mm length, 12.45mm width, 3.56mm max height, 22 leads)&lt;/b&gt;&lt;p&gt;
 Rectangular plastic leaded chip carrier. 1.27mm pitch, 7.37mm body length, 12.45mm body width, 3.56mm max height, 22 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-016A, variation AC.&lt;/p&gt;
@@ -1501,7 +1501,7 @@ JEDEC MS-016A, variation AC.&lt;/p&gt;
 <wire x1="3.683" y1="4.475" x2="3.683" y2="6.223" width="0.2032" layer="21"/>
 <wire x1="3.683" y1="6.223" x2="2.57" y2="6.223" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1397W-1143L-355H-32">
+<package name="PLCC-32-127P-1397W-1143L-355H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 11.43mm length, 13.97mm width, 3.56mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Rectangular plastic leaded chip carrier. 1.27mm pitch, 11.43mm body length, 13.97mm body width, 3.56mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-016A, variation AE.&lt;/p&gt;
@@ -1587,7 +1587,7 @@ JEDEC MS-016A, variation AE.&lt;/p&gt;
 <wire x1="5.715" y1="5.745" x2="5.715" y2="6.985" width="0.2032" layer="21"/>
 <wire x1="5.715" y1="6.985" x2="4.475" y2="6.985" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1397W-888L-355H-28">
+<package name="PLCC-28-127P-1397W-888L-355H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 8.89mm length, 13.97mm width, 3.56mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Rectangular plastic leaded chip carrier. 1.27mm pitch, 8.89mm body length, 13.97mm body width, 3.56mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-016A, variation AD.&lt;/p&gt;
@@ -1665,7 +1665,7 @@ JEDEC MS-016A, variation AD.&lt;/p&gt;
 <wire x1="4.445" y1="5.745" x2="4.445" y2="6.985" width="0.2032" layer="21"/>
 <wire x1="4.445" y1="6.985" x2="3.205" y2="6.985" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1658W-1658L-457H-44">
+<package name="PLCC-44-127P-1658W-1658L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 16.59mm length, 16.59mm width, 4.57mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body width, 4.57mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AC.&lt;/p&gt;
@@ -1775,7 +1775,7 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <wire x1="8.2931" y1="7.015" x2="8.2931" y2="8.2931" width="0.2032" layer="21"/>
 <wire x1="8.2931" y1="8.2931" x2="7.015" y2="8.2931" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-1912W-1912L-457H-52">
+<package name="PLCC-52-127P-1912W-1912L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 19.13mm length, 19.13mm width, 4.57mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 19.13mm body length, 19.13mm body width, 4.57mm max height, 52 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AD.&lt;/p&gt;
@@ -1901,7 +1901,7 @@ JEDEC MS-018A, variation AD.&lt;/p&gt;
 <wire x1="9.5631" y1="8.285" x2="9.5631" y2="9.5631" width="0.2032" layer="21"/>
 <wire x1="9.5631" y1="9.5631" x2="8.285" y2="9.5631" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-2423W-2423L-457H-68">
+<package name="PLCC-68-127P-2423W-2423L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 24.23mm length, 24.23mm width, 4.57mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body width, 4.57mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AE.&lt;/p&gt;
@@ -2059,7 +2059,7 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <wire x1="12.1158" y1="10.825" x2="12.1158" y2="12.1158" width="0.2032" layer="21"/>
 <wire x1="12.1158" y1="12.1158" x2="10.825" y2="12.1158" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-2931W-2931L-457H-84">
+<package name="PLCC-84-127P-2931W-2931L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 29.31mm length, 29.31mm width, 4.57mm max height, 84 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 29.31mm body length, 29.31mm body width, 4.57mm max height, 84 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AF.&lt;/p&gt;
@@ -2249,7 +2249,7 @@ JEDEC MS-018A, variation AF.&lt;/p&gt;
 <wire x1="14.6558" y1="13.365" x2="14.6558" y2="14.6558" width="0.2032" layer="21"/>
 <wire x1="14.6558" y1="14.6558" x2="13.365" y2="14.6558" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-3439W-3439L-457H-100">
+<package name="PLCC-100-127P-3439W-3439L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 34.39mm length, 34.39mm width, 4.57mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 34.39mm body length, 34.39mm body width, 4.57mm max height, 100 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AG.&lt;/p&gt;
@@ -2471,7 +2471,7 @@ JEDEC MS-018A, variation AG.&lt;/p&gt;
 <wire x1="17.1958" y1="15.905" x2="17.1958" y2="17.1958" width="0.2032" layer="21"/>
 <wire x1="17.1958" y1="17.1958" x2="15.905" y2="17.1958" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-127P-896W-896L-457H-20">
+<package name="PLCC-20-127P-896W-896L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 8.97mm length, 8.97mm width, 4.57mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 8.97mm body length, 8.97mm body width, 4.57mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AA.&lt;/p&gt;
@@ -2533,7 +2533,7 @@ JEDEC MS-018A, variation AA.&lt;/p&gt;
 <wire x1="4.4831" y1="3.205" x2="4.4831" y2="4.4831" width="0.2032" layer="21"/>
 <wire x1="4.4831" y1="4.4831" x2="3.205" y2="4.4831" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-SMD-11X11-44">
+<package name="PLCC-SOCKET-SMD-44-11X11">
 <description>&lt;b&gt;PLCC socket (1.27mm pitch, 44 leads, SMD)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 1.27mm lead pitch, 44 leads.
 &lt;/p&gt;</description>
@@ -2785,7 +2785,7 @@ Plastic leaded chip carrier socket. 1.27mm lead pitch, 44 leads.
 <wire x1="11.049" y1="-11.049" x2="11.049" y2="11.049" width="0.2032" layer="21"/>
 <wire x1="11.049" y1="11.049" x2="-10.033" y2="11.049" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-SMD-17X17-68">
+<package name="PLCC-SOCKET-SMD-68-17X17">
 <description>&lt;b&gt;PLCC socket (1.27mm pitch, 68 leads, SMD)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 1.27mm lead pitch, 68 leads.
 &lt;/p&gt;</description>
@@ -3160,7 +3160,7 @@ Plastic leaded chip carrier socket. 1.27mm lead pitch, 68 leads.
 <wire x1="15.24" y1="-15.24" x2="15.24" y2="15.24" width="0.2032" layer="21"/>
 <wire x1="15.24" y1="15.24" x2="-13.97" y2="15.24" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-SMD-21X21-84">
+<package name="PLCC-SOCKET-SMD-84-21X21">
 <description>&lt;b&gt;PLCC socket (1.27mm pitch, 84 leads, SMD)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 1.27mm lead pitch, 84 leads.
 &lt;/p&gt;</description>
@@ -3616,7 +3616,7 @@ Plastic leaded chip carrier socket. 1.27mm lead pitch, 84 leads.
 <wire x1="17.78" y1="-17.78" x2="17.78" y2="17.78" width="0.2032" layer="21"/>
 <wire x1="17.78" y1="17.78" x2="-16.51" y2="17.78" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-SMD-5X5-20">
+<package name="PLCC-SOCKET-SMD-20-5X5">
 <description>&lt;b&gt;PLCC socket (1.27mm pitch, 20 leads, SMD)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 1.27mm lead pitch, 20 leads.
 &lt;/p&gt;</description>
@@ -3743,7 +3743,7 @@ Plastic leaded chip carrier socket. 1.27mm lead pitch, 20 leads.
 <wire x1="7.62" y1="-7.62" x2="7.62" y2="7.62" width="0.2032" layer="21"/>
 <wire x1="7.62" y1="7.62" x2="-6.35" y2="7.62" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-SMD-7X7-28">
+<package name="PLCC-SOCKET-SMD-28-7X7">
 <description>&lt;b&gt;PLCC socket (1.27mm pitch, 28 leads, SMD)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 1.27mm lead pitch, 28 leads.
 &lt;/p&gt;</description>
@@ -3914,7 +3914,7 @@ Plastic leaded chip carrier socket. 1.27mm lead pitch, 28 leads.
 <wire x1="8.89" y1="-8.89" x2="8.89" y2="8.89" width="0.2032" layer="21"/>
 <wire x1="8.89" y1="8.89" x2="-7.62" y2="8.89" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-SMD-7X9-32">
+<package name="PLCC-SOCKET-SMD-32-7X9">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 32 leads (7x9), SMD)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 32 leads.
 &lt;/p&gt;</description>
@@ -4105,7 +4105,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 32 leads.
 <wire x1="8.89" y1="-10.16" x2="8.89" y2="10.16" width="0.2032" layer="21"/>
 <wire x1="8.89" y1="10.16" x2="-7.62" y2="10.16" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-11X11-44">
+<package name="PLCC-SOCKET-TH-44-11X11">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 44 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 &lt;/p&gt;</description>
@@ -4356,7 +4356,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <wire x1="11.43" y1="-11.43" x2="11.43" y2="11.43" width="0.2032" layer="21"/>
 <wire x1="11.43" y1="11.43" x2="-10.16" y2="11.43" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-13X13-52">
+<package name="PLCC-SOCKET-TH-52-13X13">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 52 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 52 leads.
 &lt;/p&gt;</description>
@@ -4647,7 +4647,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 52 leads.
 <wire x1="12.7" y1="-12.7" x2="12.7" y2="12.7" width="0.2032" layer="21"/>
 <wire x1="12.7" y1="12.7" x2="-11.43" y2="12.7" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-17X17-68">
+<package name="PLCC-SOCKET-TH-68-17X17">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 68 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 &lt;/p&gt;</description>
@@ -5022,7 +5022,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 <wire x1="15.24" y1="-15.24" x2="15.24" y2="15.24" width="0.2032" layer="21"/>
 <wire x1="15.24" y1="15.24" x2="-13.97" y2="15.24" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-21X21-84">
+<package name="PLCC-SOCKET-TH-84-21X21">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 68 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 &lt;/p&gt;</description>
@@ -5477,7 +5477,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 <wire x1="17.78" y1="-17.78" x2="17.78" y2="17.78" width="0.2032" layer="21"/>
 <wire x1="17.78" y1="17.78" x2="-16.51" y2="17.78" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-5X5-20">
+<package name="PLCC-SOCKET-TH-20-5X5">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 20 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 20 leads.
 &lt;/p&gt;</description>
@@ -5604,7 +5604,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 20 leads.
 <wire x1="7.62" y1="-7.62" x2="7.62" y2="7.62" width="0.2032" layer="21"/>
 <wire x1="7.62" y1="7.62" x2="-6.35" y2="7.62" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-7X7-28">
+<package name="PLCC-SOCKET-TH-28-7X7">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 28 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 28 leads.
 &lt;/p&gt;</description>
@@ -5775,7 +5775,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 28 leads.
 <wire x1="8.89" y1="-8.89" x2="8.89" y2="8.89" width="0.2032" layer="21"/>
 <wire x1="8.89" y1="8.89" x2="-7.62" y2="8.89" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-7X9-32">
+<package name="PLCC-SOCKET-TH-32-7X9">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 32 leads (7x9), through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 32 leads.
 &lt;/p&gt;</description>

--- a/ref-packages-lqfp.lbr
+++ b/ref-packages-lqfp.lbr
@@ -65,7 +65,7 @@
 <description>&lt;b&gt;Maintenence Library&lt;/b&gt;&lt;p&gt;
 NOTE: This library is used to globally update common IC packages in all other libraries.&lt;p&gt;</description>
 <packages>
-<package name="LQFP-100P-1000W-1000L-160H-36">
+<package name="LQFP-36-100P-1000W-1000L-160H">
 <description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 36 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 36 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCA, L-PQFP-G.
@@ -151,7 +151,7 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-100P-1000W-1000L-160H-36-EP">
+<package name="LQFP-36-100P-1000W-1000L-160H-EP">
 <description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 36 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 36 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCA-HD, HL-PQFP-G.
@@ -237,7 +237,7 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-100P-1200W-1200L-160H-44">
+<package name="LQFP-44-100P-1200W-1200L-160H">
 <description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BDA, L-PQFP-G.
@@ -339,7 +339,7 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-100P-1200W-1200L-160H-44-EP">
+<package name="LQFP-44-100P-1200W-1200L-160H-EP">
 <description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BDA-HD, HL-PQFP-G.
@@ -441,7 +441,7 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-100P-1400W-1400L-160H-52">
+<package name="LQFP-52-100P-1400W-1400L-160H">
 <description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BEA, L-PQFP-G.
@@ -559,7 +559,7 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-100P-1400W-1400L-160H-52-EP">
+<package name="LQFP-52-100P-1400W-1400L-160H-EP">
 <description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BEA-HD, HL-PQFP-G.
@@ -677,7 +677,7 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-1000W-1000L-160H-80">
+<package name="LQFP-80-40P-1000W-1000L-160H">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCE, L-PQFP-G.
@@ -851,7 +851,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-1000W-1000L-160H-80-EP">
+<package name="LQFP-80-40P-1000W-1000L-160H-EP">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCE-HD, HL-PQFP-G.
@@ -1025,7 +1025,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-1200W-1200L-160H-100">
+<package name="LQFP-100-40P-1200W-1200L-160H">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BDE, L-PQFP-G.
@@ -1239,7 +1239,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-1200W-1200L-160H-100-EP">
+<package name="LQFP-100-40P-1200W-1200L-160H-EP">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BDE-HD, HL-PQFP-G.
@@ -1453,7 +1453,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-1400W-1400L-160H-120">
+<package name="LQFP-120-40P-1400W-1400L-160H">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 120 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BEE, L-PQFP-G.
@@ -1707,7 +1707,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-1400W-1400L-160H-120-EP">
+<package name="LQFP-120-40P-1400W-1400L-160H-EP">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 120 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BEE-HD, HL-PQFP-G.
@@ -1961,7 +1961,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-2000W-2000L-160H-176">
+<package name="LQFP-176-40P-2000W-2000L-160H">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 176 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BFC, L-PQFP-G.
@@ -2327,7 +2327,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-2000W-2000L-160H-176-EP">
+<package name="LQFP-176-40P-2000W-2000L-160H-EP">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 176 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BFC-HD, HL-PQFP-G.
@@ -2693,7 +2693,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-2400W-2400L-160H-216">
+<package name="LQFP-216-40P-2400W-2400L-160H">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.60mm max height, 216 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.60mm max height, 216 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BGB, L-PQFP-G.
@@ -3139,7 +3139,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm
 <wire x1="11.9" y1="-11.9" x2="11.9" y2="11.9" width="0.2032" layer="21"/>
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-2400W-2400L-160H-216-EP">
+<package name="LQFP-216-40P-2400W-2400L-160H-EP">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.60mm max height, 216 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.60mm max height, 216 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BGB-HD, HL-PQFP-G.
@@ -3585,7 +3585,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm
 <wire x1="11.9" y1="-11.9" x2="11.9" y2="11.9" width="0.2032" layer="21"/>
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-2800W-2800L-160H-256">
+<package name="LQFP-256-40P-2800W-2800L-160H">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 256 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 256 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BJC, L-PQFP-G.
@@ -4111,7 +4111,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-2800W-2800L-160H-256-EP">
+<package name="LQFP-256-40P-2800W-2800L-160H-EP">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 256 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 256 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BJC-HD, HL-PQFP-G.
@@ -4637,7 +4637,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-400W-400L-160H-32">
+<package name="LQFP-32-40P-400W-400L-160H">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.60mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BKC, L-PQFP-G.
@@ -4715,7 +4715,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm w
 <wire x1="1.9" y1="-1.9" x2="1.9" y2="1.9" width="0.2032" layer="21"/>
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-400W-400L-160H-32-EP">
+<package name="LQFP-32-40P-400W-400L-160H-EP">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.60mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BKC-HD, HL-PQFP-G.
@@ -4793,7 +4793,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm w
 <wire x1="1.9" y1="-1.9" x2="1.9" y2="1.9" width="0.2032" layer="21"/>
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-500W-500L-160H-40">
+<package name="LQFP-40-40P-500W-500L-160H">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.60mm max height, 40 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BAB, L-PQFP-G.
@@ -4887,7 +4887,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm w
 <wire x1="2.4" y1="-2.4" x2="2.4" y2="2.4" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-500W-500L-160H-40-EP">
+<package name="LQFP-40-40P-500W-500L-160H-EP">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.60mm max height, 40 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BAB-HD, HL-PQFP-G.
@@ -4981,7 +4981,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm w
 <wire x1="2.4" y1="-2.4" x2="2.4" y2="2.4" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-700W-700L-160H-64">
+<package name="LQFP-64-40P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBD, L-PQFP-G.
@@ -5123,7 +5123,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-40P-700W-700L-160H-64-EP">
+<package name="LQFP-64-40P-700W-700L-160H-EP">
 <description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBD-HD, HL-PQFP-G.
@@ -5265,7 +5265,7 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-1000W-1000L-160H-64">
+<package name="LQFP-64-50P-1000W-1000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
@@ -5407,7 +5407,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-1000W-1000L-160H-64-EP">
+<package name="LQFP-64-50P-1000W-1000L-160H-EP">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCD-HD, HL-PQFP-G.
@@ -5549,7 +5549,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-1200W-1200L-160H-80">
+<package name="LQFP-80-50P-1200W-1200L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BDD, L-PQFP-G.
@@ -5723,7 +5723,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-1200W-1200L-160H-80-EP">
+<package name="LQFP-80-50P-1200W-1200L-160H-EP">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BDD-HD, HL-PQFP-G.
@@ -5897,7 +5897,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-1400W-1400L-160H-100">
+<package name="LQFP-100-50P-1400W-1400L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BED, L-PQFP-G.
@@ -6111,7 +6111,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-1400W-1400L-160H-100-EP">
+<package name="LQFP-100-50P-1400W-1400L-160H-EP">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BED-HD, HL-PQFP-G.
@@ -6325,7 +6325,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-1400W-2000L-160H-128">
+<package name="LQFP-128-50P-1400W-2000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.60mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.60mm max height, 128 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BHB, L-PQFP-G.
@@ -6595,7 +6595,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-1400W-2000L-160H-128-EP">
+<package name="LQFP-128-50P-1400W-2000L-160H-EP">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.60mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.60mm max height, 128 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BHB-HD, HL-PQFP-G.
@@ -6865,7 +6865,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-2000W-2000L-160H-144">
+<package name="LQFP-144-50P-2000W-2000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
@@ -7167,7 +7167,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-2000W-2000L-160H-144-EP">
+<package name="LQFP-144-50P-2000W-2000L-160H-EP">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BFB-HD, HL-PQFP-G.
@@ -7469,7 +7469,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-2400W-2400L-160H-176">
+<package name="LQFP-176-50P-2400W-2400L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.60mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.60mm max height, 176 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BGA, L-PQFP-G.
@@ -7835,7 +7835,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm
 <wire x1="11.9" y1="-11.9" x2="11.9" y2="11.9" width="0.2032" layer="21"/>
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-2400W-2400L-160H-176-EP">
+<package name="LQFP-176-50P-2400W-2400L-160H-EP">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.60mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.60mm max height, 176 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BGA-HD, HL-PQFP-G.
@@ -8201,7 +8201,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm
 <wire x1="11.9" y1="-11.9" x2="11.9" y2="11.9" width="0.2032" layer="21"/>
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-2800W-2800L-160H-208">
+<package name="LQFP-208-50P-2800W-2800L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 208 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BJB, L-PQFP-G.
@@ -8631,7 +8631,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-2800W-2800L-160H-208-EP">
+<package name="LQFP-208-50P-2800W-2800L-160H-EP">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 208 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BJB-HD, HL-PQFP-G.
@@ -9061,7 +9061,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-400W-400L-160H-24">
+<package name="LQFP-24-50P-400W-400L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 24 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.60mm max height, 24 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BKB, L-PQFP-G.
@@ -9123,7 +9123,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm w
 <wire x1="1.9" y1="-1.9" x2="1.9" y2="1.9" width="0.2032" layer="21"/>
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-400W-400L-160H-24-EP">
+<package name="LQFP-24-50P-400W-400L-160H-EP">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 24 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.60mm max height, 24 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BKB-HD, HL-PQFP-G.
@@ -9185,7 +9185,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm w
 <wire x1="1.9" y1="-1.9" x2="1.9" y2="1.9" width="0.2032" layer="21"/>
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-500W-500L-160H-32">
+<package name="LQFP-32-50P-500W-500L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.60mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BAA, L-PQFP-G.
@@ -9263,7 +9263,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm w
 <wire x1="2.4" y1="-2.4" x2="2.4" y2="2.4" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-500W-500L-160H-32-EP">
+<package name="LQFP-32-50P-500W-500L-160H-EP">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.60mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BAA-HD, HL-PQFP-G.
@@ -9341,7 +9341,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm w
 <wire x1="2.4" y1="-2.4" x2="2.4" y2="2.4" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-700W-700L-160H-48">
+<package name="LQFP-48-50P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
@@ -9451,7 +9451,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-700W-700L-160H-48-EP">
+<package name="LQFP-48-50P-700W-700L-160H-EP">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC-HD, HL-PQFP-G.
@@ -9561,7 +9561,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-1000W-1000L-160H-52">
+<package name="LQFP-52-65P-1000W-1000L-160H">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCC, L-PQFP-G.
@@ -9679,7 +9679,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-1000W-1000L-160H-52-EP">
+<package name="LQFP-52-65P-1000W-1000L-160H-EP">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCC-HD, HL-PQFP-G.
@@ -9797,7 +9797,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-1200W-1200L-160H-64">
+<package name="LQFP-64-65P-1200W-1200L-160H">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BDC, L-PQFP-G.
@@ -9939,7 +9939,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-1200W-1200L-160H-64-EP">
+<package name="LQFP-64-65P-1200W-1200L-160H-EP">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BDC-HD, HL-PQFP-G.
@@ -10081,7 +10081,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-1400W-1400L-160H-80">
+<package name="LQFP-80-65P-1400W-1400L-160H">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BEC, L-PQFP-G.
@@ -10255,7 +10255,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-1400W-1400L-160H-80-EP">
+<package name="LQFP-80-65P-1400W-1400L-160H-EP">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BEC-HD, HL-PQFP-G.
@@ -10429,7 +10429,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-1400W-2000L-160H-100">
+<package name="LQFP-100-65P-1400W-2000L-160H">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.60mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BHA, L-PQFP-G.
@@ -10643,7 +10643,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-1400W-2000L-160H-100-EP">
+<package name="LQFP-100-65P-1400W-2000L-160H-EP">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.60mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BHA-HD, HL-PQFP-G.
@@ -10857,7 +10857,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-2000W-2000L-160H-112">
+<package name="LQFP-112-65P-2000W-2000L-160H">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 112 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BFA, L-PQFP-G.
@@ -11095,7 +11095,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-2000W-2000L-160H-112-EP">
+<package name="LQFP-112-65P-2000W-2000L-160H-EP">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 112 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BFA-HD, HL-PQFP-G.
@@ -11333,7 +11333,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-2800W-2800L-160H-160">
+<package name="LQFP-160-65P-2800W-2800L-160H">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 160 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BJA, L-PQFP-G.
@@ -11667,7 +11667,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 28mm length, 28mm
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-2800W-2800L-160H-160-EP">
+<package name="LQFP-160-65P-2800W-2800L-160H-EP">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 160 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BJA-HD, HL-PQFP-G.
@@ -12001,7 +12001,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 28mm length, 28mm
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-400W-400L-160H-20">
+<package name="LQFP-20-65P-400W-400L-160H">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 20 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.60mm max height, 20 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BKA, L-PQFP-G.
@@ -12055,7 +12055,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm w
 <wire x1="1.9" y1="-1.9" x2="1.9" y2="1.9" width="0.2032" layer="21"/>
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-400W-400L-160H-20-EP">
+<package name="LQFP-20-65P-400W-400L-160H-EP">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 20 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.60mm max height, 20 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BKA-HD, HL-PQFP-G.
@@ -12109,7 +12109,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm w
 <wire x1="1.9" y1="-1.9" x2="1.9" y2="1.9" width="0.2032" layer="21"/>
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-700W-700L-160H-40">
+<package name="LQFP-40-65P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 40 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBB, L-PQFP-G.
@@ -12203,7 +12203,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-65P-700W-700L-160H-40-EP">
+<package name="LQFP-40-65P-700W-700L-160H-EP">
 <description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 40 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBB-HD, HL-PQFP-G.
@@ -12297,7 +12297,7 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-80P-1000W-1000L-160H-44">
+<package name="LQFP-44-80P-1000W-1000L-160H">
 <description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCB, L-PQFP-G.
@@ -12399,7 +12399,7 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-80P-1000W-1000L-160H-44-EP">
+<package name="LQFP-44-80P-1000W-1000L-160H-EP">
 <description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCB-HD, HL-PQFP-G.
@@ -12501,7 +12501,7 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-80P-1200W-1200L-160H-52">
+<package name="LQFP-52-80P-1200W-1200L-160H">
 <description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BDB, L-PQFP-G.
@@ -12619,7 +12619,7 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-80P-1200W-1200L-160H-52-EP">
+<package name="LQFP-52-80P-1200W-1200L-160H-EP">
 <description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BDB-HD, HL-PQFP-G.
@@ -12737,7 +12737,7 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-80P-1400W-1400L-160H-64">
+<package name="LQFP-64-80P-1400W-1400L-160H">
 <description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BEB, L-PQFP-G.
@@ -12879,7 +12879,7 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-80P-1400W-1400L-160H-64-EP">
+<package name="LQFP-64-80P-1400W-1400L-160H-EP">
 <description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BEB-HD, HL-PQFP-G.
@@ -13021,7 +13021,7 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-80P-700W-700L-160H-32">
+<package name="LQFP-32-80P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.
@@ -13099,7 +13099,7 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-80P-700W-700L-160H-32-EP">
+<package name="LQFP-32-80P-700W-700L-160H-EP">
 <description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBA-HD, HL-PQFP-G.

--- a/ref-packages-qfp.lbr
+++ b/ref-packages-qfp.lbr
@@ -65,7 +65,7 @@
 <description>&lt;b&gt;Maintenence Library&lt;/b&gt;&lt;p&gt;
 NOTE: This library is used to globally update common IC packages in all other libraries.&lt;p&gt;</description>
 <packages>
-<package name="QFP-100P-1000W-1000L-245H-160F-36">
+<package name="QFP-36-100P-1000W-1000L-245H-160F">
 <description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 36 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 36 leads.
 &lt;p/&gt;JEDEC MS-022B, variation AA, PQFP-G.
@@ -151,7 +151,7 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-100P-1400W-1400L-245H-160F-52">
+<package name="QFP-52-100P-1400W-1400L-245H-160F">
 <description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-022B, variation BA, PQFP-G.
@@ -269,7 +269,7 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-100P-1400W-1400L-245H-195F-52">
+<package name="QFP-52-100P-1400W-1400L-245H-195F">
 <description>&lt;b&gt;QFP (1.00mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 52 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation BA-2, S-R-PQFP-G.
@@ -387,7 +387,7 @@ Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 14mm length, 14mm wi
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-100P-1400W-1400L-315H-160F-52">
+<package name="QFP-52-100P-1400W-1400L-315H-160F">
 <description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 14mm length, 14mm width, 3.15mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-022B, variation BD, PQFP-G.
@@ -505,7 +505,7 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-100P-1400W-1400L-340H-195F-52">
+<package name="QFP-52-100P-1400W-1400L-340H-195F">
 <description>&lt;b&gt;QFP (1.00mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 52 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation BB-2, S-R-PQFP-G.
@@ -623,7 +623,7 @@ Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 14mm length, 14mm wi
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-100P-1400W-2000L-315H-160F-64">
+<package name="QFP-64-100P-1400W-2000L-315H-160F">
 <description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-022B, variation GA-2, PQFP-G.
@@ -765,7 +765,7 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-100P-1400W-2000L-340H-160F-64">
+<package name="QFP-64-100P-1400W-2000L-340H-160F">
 <description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.40mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.40mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-022B, variation GA-1, PQFP-G.
@@ -907,7 +907,7 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-100P-1400W-2000L-345H-195F-64">
+<package name="QFP-64-100P-1400W-2000L-345H-195F">
 <description>&lt;b&gt;QFP (1.00mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.45mm max height, 64 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation CA-2, S-R-PQFP-G.
@@ -1049,7 +1049,7 @@ Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 20mm length, 14mm wi
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-100P-2000W-2000L-315H-160F-76">
+<package name="QFP-76-100P-2000W-2000L-315H-160F">
 <description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.15mm max height, 76 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 20mm width, 3.15mm max height, 76 leads.
 &lt;p/&gt;JEDEC MS-022B, variation CA-2, PQFP-G.
@@ -1215,7 +1215,7 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 20mm widt
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-100P-2000W-2000L-345H-160F-76">
+<package name="QFP-76-100P-2000W-2000L-345H-160F">
 <description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.45mm max height, 76 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 20mm width, 3.45mm max height, 76 leads.
 &lt;p/&gt;JEDEC MS-022B, variation CA-1, PQFP-G.
@@ -1381,7 +1381,7 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 20mm widt
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-40P-1000W-1000L-245H-130F-80">
+<package name="QFP-80-40P-1000W-1000L-245H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 10mm length, 10mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 10mm length, 10mm width, 2.45mm max height, 80 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation AB, S-R-PQFP.
@@ -1555,7 +1555,7 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 10mm lengt
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-40P-1200W-1200L-245H-130F-100">
+<package name="QFP-100-40P-1200W-1200L-245H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 12mm length, 12mm width, 2.45mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 12mm length, 12mm width, 2.45mm max height, 100 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation BC, S-R-PQFP.
@@ -1769,7 +1769,7 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 12mm lengt
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-40P-1400W-1400L-245H-130F-120">
+<package name="QFP-120-40P-1400W-1400L-245H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 14mm length, 14mm width, 2.45mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 14mm length, 14mm width, 2.45mm max height, 120 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation CC, S-R-PQFP.
@@ -2023,7 +2023,7 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 14mm lengt
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-40P-1400W-1400L-315H-130F-120">
+<package name="QFP-120-40P-1400W-1400L-315H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 14mm length, 14mm width, 3.15mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 14mm length, 14mm width, 3.15mm max height, 120 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation CD, S-R-PQFP.
@@ -2277,7 +2277,7 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 14mm lengt
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-40P-2000W-2000L-245H-130F-176">
+<package name="QFP-176-40P-2000W-2000L-245H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 20mm length, 20mm width, 2.45mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 20mm length, 20mm width, 2.45mm max height, 176 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation DC-2, S-R-PQFP.
@@ -2643,7 +2643,7 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 20mm lengt
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-40P-2000W-2000L-315H-130F-176">
+<package name="QFP-176-40P-2000W-2000L-315H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 20mm length, 20mm width, 3.15mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 20mm length, 20mm width, 3.15mm max height, 176 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation DD-2, S-R-PQFP.
@@ -3009,7 +3009,7 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 20mm lengt
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-40P-2400W-2400L-409H-130F-216">
+<package name="QFP-216-40P-2400W-2400L-410H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 24mm length, 24mm width, 4.10mm max height, 216 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 24mm length, 24mm width, 4.10mm max height, 216 leads, high standoff.
 &lt;p/&gt;JEDEC MS-029A, variation EB, S-R-PQFP.
@@ -3455,7 +3455,7 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 24mm lengt
 <wire x1="11.9" y1="-11.9" x2="11.9" y2="11.9" width="0.2032" layer="21"/>
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-40P-2800W-2800L-385H-130F-256">
+<package name="QFP-256-40P-2800W-2800L-385H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 256 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 256 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation FB-2, S-R-PQFP.
@@ -3981,7 +3981,7 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 28mm lengt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-40P-2800W-2800L-409H-130F-256">
+<package name="QFP-256-40P-2800W-2800L-410H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 28mm length, 28mm width, 4.10mm max height, 256 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 28mm length, 28mm width, 4.10mm max height, 256 leads, high standoff.
 &lt;p/&gt;JEDEC MS-029A, variation FB-1, S-R-PQFP.
@@ -4507,7 +4507,7 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 28mm lengt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-40P-3200W-3200L-409H-130F-296">
+<package name="QFP-296-40P-3200W-3200L-410H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 32mm length, 32mm width, 4.10mm max height, 296 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 32mm length, 32mm width, 4.10mm max height, 296 leads, high standoff.
 &lt;p/&gt;JEDEC MS-029A, variation GB, S-R-PQFP.
@@ -5113,7 +5113,7 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 32mm lengt
 <wire x1="15.9" y1="-15.9" x2="15.9" y2="15.9" width="0.2032" layer="21"/>
 <wire x1="15.9" y1="15.9" x2="-15.9" y2="15.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-40P-3600W-3600L-450H-130F-336">
+<package name="QFP-336-40P-3600W-3600L-450H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 36mm length, 36mm width, 4.50mm max height, 336 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 36mm length, 36mm width, 4.50mm max height, 336 leads, high standoff.
 &lt;p/&gt;JEDEC MS-029A, variation HB, S-R-PQFP.
@@ -5799,7 +5799,7 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 36mm lengt
 <wire x1="17.9" y1="-17.9" x2="17.9" y2="17.9" width="0.2032" layer="21"/>
 <wire x1="17.9" y1="17.9" x2="-17.9" y2="17.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-40P-4000W-4000L-450H-130F-376">
+<package name="QFP-376-40P-4000W-4000L-450H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 40mm length, 40mm width, 4.50mm max height, 376 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 40mm length, 40mm width, 4.50mm max height, 376 leads, high standoff.
 &lt;p/&gt;JEDEC MS-029A, variation JB, S-R-PQFP.
@@ -6565,7 +6565,7 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 40mm lengt
 <wire x1="19.9" y1="-19.9" x2="19.9" y2="19.9" width="0.2032" layer="21"/>
 <wire x1="19.9" y1="19.9" x2="-19.9" y2="19.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-1000W-1000L-245H-130F-64">
+<package name="QFP-64-50P-1000W-1000L-245H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 10mm length, 10mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 10mm length, 10mm width, 2.45mm max height, 64 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation AA, S-R-PQFP.
@@ -6707,7 +6707,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 10mm lengt
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-1200W-1200L-245H-130F-80">
+<package name="QFP-80-50P-1200W-1200L-245H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 12mm length, 12mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 12mm length, 12mm width, 2.45mm max height, 80 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation BA, S-R-PQFP.
@@ -6881,7 +6881,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 12mm lengt
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-1200W-1200L-315H-130F-80">
+<package name="QFP-80-50P-1200W-1200L-315H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 12mm length, 12mm width, 3.15mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 12mm length, 12mm width, 3.15mm max height, 80 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation BB, S-R-PQFP.
@@ -7055,7 +7055,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 12mm lengt
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-1400W-1400L-245H-130F-100">
+<package name="QFP-100-50P-1400W-1400L-245H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 14mm length, 14mm width, 2.45mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 14mm length, 14mm width, 2.45mm max height, 100 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation CA, S-R-PQFP.
@@ -7269,7 +7269,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 14mm lengt
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-1400W-1400L-315H-130F-100">
+<package name="QFP-100-50P-1400W-1400L-315H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 14mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 14mm length, 14mm width, 3.15mm max height, 100 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation CB, S-R-PQFP.
@@ -7483,7 +7483,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 14mm lengt
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-1400W-2000L-315H-130F-128">
+<package name="QFP-128-50P-1400W-2000L-315H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 20mm length, 14mm width, 3.15mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 20mm length, 14mm width, 3.15mm max height, 128 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation KA, S-R-PQFP.
@@ -7753,7 +7753,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 20mm lengt
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-2000W-2000L-245H-130F-144">
+<package name="QFP-144-50P-2000W-2000L-245H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 20mm length, 20mm width, 2.45mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 20mm length, 20mm width, 2.45mm max height, 144 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation DA-2, S-R-PQFP.
@@ -8055,7 +8055,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 20mm lengt
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-2000W-2000L-315H-130F-144">
+<package name="QFP-144-50P-2000W-2000L-315H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 20mm length, 20mm width, 3.15mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 20mm length, 20mm width, 3.15mm max height, 144 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation DB-2, S-R-PQFP.
@@ -8357,7 +8357,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 20mm lengt
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-2400W-2400L-409H-130F-176">
+<package name="QFP-176-50P-2400W-2400L-410H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 24mm length, 24mm width, 4.10mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 24mm length, 24mm width, 4.10mm max height, 176 leads, high standoff.
 &lt;p/&gt;JEDEC MS-029A, variation EA, S-R-PQFP.
@@ -8723,7 +8723,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 24mm lengt
 <wire x1="11.9" y1="-11.9" x2="11.9" y2="11.9" width="0.2032" layer="21"/>
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-2800W-2800L-385H-130F-208">
+<package name="QFP-208-50P-2800W-2800L-385H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads, low standoff.
 &lt;p/&gt;JEDEC MS-029A, variation FA-2, S-R-PQFP.
@@ -9153,7 +9153,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm lengt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-2800W-2800L-409H-130F-208">
+<package name="QFP-208-50P-2800W-2800L-410H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 4.10mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 4.10mm max height, 208 leads, high standoff.
 &lt;p/&gt;JEDEC MS-029A, variation FA-1, S-R-PQFP.
@@ -9583,7 +9583,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm lengt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-3200W-3200L-409H-130F-240">
+<package name="QFP-240-50P-3200W-3200L-410H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 32mm length, 32mm width, 4.10mm max height, 240 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 32mm length, 32mm width, 4.10mm max height, 240 leads, high standoff.
 &lt;p/&gt;JEDEC MS-029A, variation GA, S-R-PQFP.
@@ -10077,7 +10077,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 32mm lengt
 <wire x1="15.9" y1="-15.9" x2="15.9" y2="15.9" width="0.2032" layer="21"/>
 <wire x1="15.9" y1="15.9" x2="-15.9" y2="15.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-3600W-3600L-450H-130F-272">
+<package name="QFP-272-50P-3600W-3600L-450H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 36mm length, 36mm width, 4.50mm max height, 272 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 36mm length, 36mm width, 4.50mm max height, 272 leads, high standoff.
 &lt;p/&gt;JEDEC MS-029A, variation HA, S-R-PQFP.
@@ -10635,7 +10635,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 36mm lengt
 <wire x1="17.9" y1="-17.9" x2="17.9" y2="17.9" width="0.2032" layer="21"/>
 <wire x1="17.9" y1="17.9" x2="-17.9" y2="17.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-50P-4000W-4000L-450H-130F-304">
+<package name="QFP-304-50P-4000W-4000L-450H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 40mm length, 40mm width, 4.50mm max height, 304 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 40mm length, 40mm width, 4.50mm max height, 304 leads, high standoff.
 &lt;p/&gt;JEDEC MS-029A, variation JA, S-R-PQFP.
@@ -11257,7 +11257,7 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 40mm lengt
 <wire x1="19.9" y1="-19.9" x2="19.9" y2="19.9" width="0.2032" layer="21"/>
 <wire x1="19.9" y1="19.9" x2="-19.9" y2="19.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1000W-1000L-245H-160F-52">
+<package name="QFP-52-65P-1000W-1000L-245H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-022B, variation AC, PQFP-G.
@@ -11375,7 +11375,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1000W-1000L-245H-195F-52">
+<package name="QFP-52-65P-1000W-1000L-245H-195F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation AC-2, S-R-PQFP-G.
@@ -11493,7 +11493,7 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 10mm length, 10mm wi
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1000W-1000L-340H-195F-52">
+<package name="QFP-52-65P-1000W-1000L-340H-195F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 3.40mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 3.40mm max height, 52 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation AD-2, S-R-PQFP-G.
@@ -11611,7 +11611,7 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 10mm length, 10mm wi
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1400W-1400L-245H-160F-80">
+<package name="QFP-80-65P-1400W-1400L-245H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-022B, variation BC, PQFP-G.
@@ -11785,7 +11785,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1400W-1400L-245H-195F-80">
+<package name="QFP-80-65P-1400W-1400L-245H-195F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation BE-2, S-R-PQFP-G.
@@ -11959,7 +11959,7 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 14mm length, 14mm wi
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1400W-1400L-315H-160F-80">
+<package name="QFP-80-65P-1400W-1400L-315H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm width, 3.15mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-022B, variation BF, PQFP-G.
@@ -12133,7 +12133,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1400W-1400L-340H-195F-80">
+<package name="QFP-80-65P-1400W-1400L-340H-195F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 80 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation BF-2, S-R-PQFP-G.
@@ -12307,7 +12307,7 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 14mm length, 14mm wi
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1400W-2000L-315H-160F-100">
+<package name="QFP-100-65P-1400W-2000L-315H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-022B, variation GC-2, PQFP-G.
@@ -12521,7 +12521,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1400W-2000L-340H-160F-100">
+<package name="QFP-100-65P-1400W-2000L-340H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.40mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-022B, variation GC-1, PQFP-G.
@@ -12735,7 +12735,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-1400W-2000L-340H-195F-100">
+<package name="QFP-100-65P-1400W-2000L-340H-195F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation CC-2, S-R-PQFP-G.
@@ -12949,7 +12949,7 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 20mm length, 14mm wi
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-2000W-2000L-315H-160F-112">
+<package name="QFP-112-65P-2000W-2000L-315H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.15mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 20mm width, 3.15mm max height, 112 leads.
 &lt;p/&gt;JEDEC MS-022B, variation CC-2, PQFP-G.
@@ -13187,7 +13187,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 20mm widt
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-2000W-2000L-345H-160F-112">
+<package name="QFP-112-65P-2000W-2000L-345H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.45mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 20mm width, 3.45mm max height, 112 leads.
 &lt;p/&gt;JEDEC MS-022B, variation CC-1, PQFP-G.
@@ -13425,7 +13425,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 20mm widt
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-2800W-2800L-385H-160F-144">
+<package name="QFP-144-65P-2800W-2800L-385H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DC-2, PQFP-G.
@@ -13727,7 +13727,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-2800W-2800L-385H-160F-160">
+<package name="QFP-160-65P-2800W-2800L-385H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 160 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DD-2, PQFP-G.
@@ -14061,7 +14061,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-2800W-2800L-392H-195F-144">
+<package name="QFP-144-65P-2800W-2800L-392H-195F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 144 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation DC-2, S-R-PQFP-G.
@@ -14363,7 +14363,7 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 28mm length, 28mm wi
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-2800W-2800L-392H-195F-160">
+<package name="QFP-160-65P-2800W-2800L-392H-195F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 160 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation DD-2, S-R-PQFP-G.
@@ -14697,7 +14697,7 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 28mm length, 28mm wi
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-2800W-2800L-409H-160F-144">
+<package name="QFP-144-65P-2800W-2800L-410H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 4.10mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DC-1, PQFP-G.
@@ -14999,7 +14999,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-2800W-2800L-409H-160F-160">
+<package name="QFP-160-65P-2800W-2800L-410H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 4.10mm max height, 160 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DD-1, PQFP-G.
@@ -15333,7 +15333,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-3200W-3200L-392H-195F-184">
+<package name="QFP-184-65P-3200W-3200L-392H-195F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 32mm length, 32mm width, 3.92mm max height, 184 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 32mm length, 32mm width, 3.92mm max height, 184 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation EA-2, S-R-PQFP-G.
@@ -15715,7 +15715,7 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 32mm length, 32mm wi
 <wire x1="15.9" y1="-15.9" x2="15.9" y2="15.9" width="0.2032" layer="21"/>
 <wire x1="15.9" y1="15.9" x2="-15.9" y2="15.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-3200W-3200L-409H-160F-184">
+<package name="QFP-184-65P-3200W-3200L-410H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 32mm length, 32mm width, 4.10mm max height, 184 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 32mm length, 32mm width, 4.10mm max height, 184 leads.
 &lt;p/&gt;JEDEC MS-022B, variation EA, PQFP-G.
@@ -16097,7 +16097,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 32mm length, 32mm widt
 <wire x1="15.9" y1="-15.9" x2="15.9" y2="15.9" width="0.2032" layer="21"/>
 <wire x1="15.9" y1="15.9" x2="-15.9" y2="15.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-4000W-4000L-440H-195F-232">
+<package name="QFP-232-65P-4000W-4000L-440H-195F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 40mm length, 40mm width, 4.40mm max height, 232 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 40mm length, 40mm width, 4.40mm max height, 232 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation FA-2, S-R-PQFP-G.
@@ -16575,7 +16575,7 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 40mm length, 40mm wi
 <wire x1="19.9" y1="-19.9" x2="19.9" y2="19.9" width="0.2032" layer="21"/>
 <wire x1="19.9" y1="19.9" x2="-19.9" y2="19.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-65P-4000W-4000L-450H-160F-232">
+<package name="QFP-232-65P-4000W-4000L-450H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 40mm length, 40mm width, 4.50mm max height, 232 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 40mm length, 40mm width, 4.50mm max height, 232 leads.
 &lt;p/&gt;JEDEC MS-022B, variation FA, PQFP-G.
@@ -17053,7 +17053,7 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 40mm length, 40mm widt
 <wire x1="19.9" y1="-19.9" x2="19.9" y2="19.9" width="0.2032" layer="21"/>
 <wire x1="19.9" y1="19.9" x2="-19.9" y2="19.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1000W-1000L-245H-160F-44">
+<package name="QFP-44-80P-1000W-1000L-245H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-022B, variation AB, PQFP-G.
@@ -17155,7 +17155,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1000W-1000L-245H-195F-44">
+<package name="QFP-44-80P-1000W-1000L-245H-195F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation AA-2, S-R-PQFP-G.
@@ -17257,7 +17257,7 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 10mm length, 10mm wi
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1000W-1000L-340H-195F-44">
+<package name="QFP-44-80P-1000W-1000L-340H-195F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 10mm length, 10mm width, 3.40mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 10mm length, 10mm width, 3.40mm max height, 44 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation AB-2, S-R-PQFP-G.
@@ -17359,7 +17359,7 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 10mm length, 10mm wi
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1400W-1400L-245H-160F-64">
+<package name="QFP-64-80P-1400W-1400L-245H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-022B, variation BB, PQFP-G.
@@ -17501,7 +17501,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1400W-1400L-245H-195F-64">
+<package name="QFP-64-80P-1400W-1400L-245H-195F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation BC-2, S-R-PQFP-G.
@@ -17643,7 +17643,7 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 14mm length, 14mm wi
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1400W-1400L-315H-160F-64">
+<package name="QFP-64-80P-1400W-1400L-315H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm width, 3.15mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-022B, variation BE, PQFP-G.
@@ -17785,7 +17785,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1400W-1400L-340H-195F-64">
+<package name="QFP-64-80P-1400W-1400L-340H-195F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 64 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation BD-2, S-R-PQFP-G.
@@ -17927,7 +17927,7 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 14mm length, 14mm wi
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1400W-2000L-315H-160F-80">
+<package name="QFP-80-80P-1400W-2000L-315H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-022B, variation GB-2, PQFP-G.
@@ -18109,7 +18109,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1400W-2000L-340H-160F-80">
+<package name="QFP-80-80P-1400W-2000L-340H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.40mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.40mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-022B, variation GB-1, PQFP-G.
@@ -18291,7 +18291,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-1400W-2000L-340H-195F-80">
+<package name="QFP-80-80P-1400W-2000L-340H-195F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 80 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation CB-2, S-R-PQFP-G.
@@ -18473,7 +18473,7 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 20mm length, 14mm wi
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-2000W-2000L-315H-160F-88">
+<package name="QFP-88-80P-2000W-2000L-315H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.15mm max height, 88 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 20mm width, 3.15mm max height, 88 leads.
 &lt;p/&gt;JEDEC MS-022B, variation CB-2, PQFP-G.
@@ -18663,7 +18663,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 20mm widt
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-2000W-2000L-345H-160F-88">
+<package name="QFP-88-80P-2000W-2000L-345H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.45mm max height, 88 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 20mm width, 3.45mm max height, 88 leads.
 &lt;p/&gt;JEDEC MS-022B, variation CB-1, PQFP-G.
@@ -18853,7 +18853,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 20mm widt
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-2800W-2800L-385H-160F-120">
+<package name="QFP-120-80P-2800W-2800L-385H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 120 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DA-2, PQFP-G.
@@ -19107,7 +19107,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-2800W-2800L-385H-160F-128">
+<package name="QFP-128-80P-2800W-2800L-385H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 128 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DB-2, PQFP-G.
@@ -19377,7 +19377,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-2800W-2800L-392H-195F-120">
+<package name="QFP-120-80P-2800W-2800L-392H-195F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 120 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation DA-2, S-R-PQFP-G.
@@ -19631,7 +19631,7 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 28mm length, 28mm wi
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-2800W-2800L-392H-195F-128">
+<package name="QFP-128-80P-2800W-2800L-392H-195F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 128 leads, low standoff.
 &lt;p/&gt;JEDEC MO-112B, variation DB-2, S-R-PQFP-G.
@@ -19901,7 +19901,7 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 28mm length, 28mm wi
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-2800W-2800L-409H-160F-120">
+<package name="QFP-120-80P-2800W-2800L-410H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm width, 4.10mm max height, 120 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DA-1, PQFP-G.
@@ -20155,7 +20155,7 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="-13.9" x2="13.9" y2="13.9" width="0.2032" layer="21"/>
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
-<package name="QFP-80P-2800W-2800L-409H-160F-128">
+<package name="QFP-128-80P-2800W-2800L-410H-160F">
 <description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm width, 4.10mm max height, 128 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DB-1, PQFP-G.

--- a/ref-packages-sop.lbr
+++ b/ref-packages-sop.lbr
@@ -72,7 +72,7 @@
 </layers>
 <library>
 <packages>
-<package name="SOP-127-530X620-8">
+<package name="SOP-8-127P-530W-620L">
 <description>&lt;b&gt;SOP (1.27mm pitch, 5.30mm width, 6.20mm length, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. Lead pitch 1.27mm, body width 5.3mm, body length 6.2mm, 8 leads. Non-standard.</description>
 <circle x="-2.5550" y="-1.3500" radius="0.3175" width="0" layer="21"/>
@@ -105,7 +105,7 @@ Small outline package. Lead pitch 1.27mm, body width 5.3mm, body length 6.2mm, 8
 <wire x1="3.2000" y1="1.9050" x2="-3.2000" y2="1.9050" width="0.2032" layer="21"/>
 <wire x1="3.2000" y1="1.9050" x2="3.2000" y2="2.5500" width="0.2032" layer="51"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -139,7 +139,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -185,7 +185,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -235,7 +235,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-530W-1030L-210H-125F-14">
+<package name="SOP-14-127P-530W-1030L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -280,7 +280,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="5.125" y1="-2.625" x2="-5.125" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="2.625" x2="-5.125" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-530W-1030L-210H-125F-16">
+<package name="SOP-16-127P-530W-1030L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -329,7 +329,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="5.125" y1="-2.625" x2="-5.125" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="2.625" x2="-5.125" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-530W-1280L-210H-125F-18">
+<package name="SOP-18-127P-530W-1280L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 12.80mm length, 5.30mm width, 2.10mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 12.80mm length, 5.30mm width, 2.10mm max height, 18 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -382,7 +382,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="6.375" y1="-2.625" x2="-6.375" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="2.625" x2="-6.375" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-530W-1280L-210H-125F-20">
+<package name="SOP-20-127P-530W-1280L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 12.80mm length, 5.30mm width, 2.10mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 12.80mm length, 5.30mm width, 2.10mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -439,7 +439,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="6.375" y1="-2.625" x2="-6.375" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="2.625" x2="-6.375" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-530W-1540L-210H-125F-22">
+<package name="SOP-22-127P-530W-1540L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 15.40mm length, 5.30mm width, 2.10mm max height, 22 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 15.40mm length, 5.30mm width, 2.10mm max height, 22 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -500,7 +500,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="7.675" y1="-2.625" x2="-7.675" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="2.625" x2="-7.675" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-530W-1540L-210H-125F-24">
+<package name="SOP-24-127P-530W-1540L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 15.40mm length, 5.30mm width, 2.10mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 15.40mm length, 5.30mm width, 2.10mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -565,7 +565,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="7.675" y1="-2.625" x2="-7.675" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="2.625" x2="-7.675" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-530W-530L-210H-125F-8">
+<package name="SOP-8-127P-530W-530L-210H-125F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 EIAJ EDR-7320.&lt;/p&gt;
@@ -598,7 +598,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="2.625" y1="-2.625" x2="-2.625" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="2.625" x2="-2.625" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -647,7 +647,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1155L-265H-140F-18">
+<package name="SOP-18-127P-750W-1155L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
@@ -700,7 +700,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -757,7 +757,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -822,7 +822,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -895,7 +895,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-2050L-265H-140F-32">
+<package name="SOP-32-127P-750W-2050L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 20.50mm length, 7.50mm width, 2.65mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 20.50mm length, 7.50mm width, 2.65mm max height, 32 leads.&lt;/p&gt;
 
@@ -976,7 +976,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 20.50mm length
 <wire x1="10.225" y1="-3.725" x2="-10.225" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="10.225" y1="3.725" x2="-10.225" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-2300L-265H-140F-36">
+<package name="SOP-36-127P-750W-2300L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 23.00mm length, 7.50mm width, 2.65mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 23.00mm length, 7.50mm width, 2.65mm max height, 36 leads.&lt;/p&gt;
 
@@ -1065,7 +1065,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 23.00mm length
 <wire x1="11.475" y1="-3.725" x2="-11.475" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="11.475" y1="3.725" x2="-11.475" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-530L-265H-140F-8">
+<package name="SOP-8-127P-750W-530L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads.&lt;/p&gt;
 
@@ -1098,7 +1098,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 5.30mm length,
 <wire x1="2.625" y1="-3.725" x2="-2.625" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="3.725" x2="-2.625" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-900L-265H-140F-14">
+<package name="SOP-14-127P-750W-900L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads.&lt;/p&gt;
 
@@ -1143,7 +1143,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length,
 <wire x1="4.475" y1="-3.725" x2="-4.475" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="4.475" y1="3.725" x2="-4.475" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-840W-1280L-254H-180F-20">
+<package name="SOP-20-127P-840W-1280L-254H-180F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 12.80mm length, 8.40mm width, 2.54mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body length,
 8.40mm body width, 2.54mm max height, 20 leads.
@@ -1197,7 +1197,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <wire x1="6.3" y1="-4.1" x2="6.3" y2="4.1" width="0.2032" layer="21"/>
 <wire x1="6.3" y1="4.1" x2="-6.3" y2="4.1" width="0.2032" layer="21"/>&gt;
 </package>
-<package name="SOP-127P-840W-1540L-254H-180F-24">
+<package name="SOP-24-127P-840W-1540L-254H-180F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 15.40mm length, 8.40mm width, 2.54mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body length,
 8.40mm body width, 2.54mm max height, 24 leads.
@@ -1259,7 +1259,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body l
 <wire x1="7.6" y1="-4.1" x2="7.6" y2="4.1" width="0.2032" layer="21"/>
 <wire x1="7.6" y1="4.1" x2="-7.6" y2="4.1" width="0.2032" layer="21"/>&gt;
 </package>
-<package name="SOP-127P-840W-1540L-305H-180F-24">
+<package name="SOP-24-127P-840W-1540L-305H-180F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 15.40mm length, 8.40mm width, 3.05mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body length,
 8.40mm body width, 3.05mm max height, 24 leads.
@@ -1321,7 +1321,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body l
 <wire x1="7.6" y1="-4.1" x2="7.6" y2="4.1" width="0.2032" layer="21"/>
 <wire x1="7.6" y1="4.1" x2="-7.6" y2="4.1" width="0.2032" layer="21"/>&gt;
 </package>
-<package name="SOP-127P-840W-1790L-254H-180F-28">
+<package name="SOP-28-127P-840W-1790L-254H-180F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
 8.40mm body width, 2.54mm max height, 28 leads.
@@ -1391,7 +1391,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body l
 <wire x1="8.85" y1="-4.1" x2="8.85" y2="4.1" width="0.2032" layer="21"/>
 <wire x1="8.85" y1="4.1" x2="-8.85" y2="4.1" width="0.2032" layer="21"/>&gt;
 </package>
-<package name="SOP-127P-840W-1790L-305H-180F-28">
+<package name="SOP-28-127P-840W-1790L-305H-180F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 3.05mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
 8.40mm body width, 3.05mm max height, 28 leads.
@@ -1461,7 +1461,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body l
 <wire x1="8.85" y1="-4.1" x2="8.85" y2="4.1" width="0.2032" layer="21"/>
 <wire x1="8.85" y1="4.1" x2="-8.85" y2="4.1" width="0.2032" layer="21"/>&gt;
 </package>
-<package name="SOP-127P-890W-1540L-265H-155F-24">
+<package name="SOP-24-127P-890W-1540L-265H-155F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 15.40mm length, 8.90mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 15.40mm body length,
 8.90mm body width, 2.65mm max height, 24 leads.
@@ -1527,7 +1527,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 15.40mm body 
 <wire x1="7.675" y1="-4.425" x2="-7.675" y2="-4.425" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="4.425" x2="-7.675" y2="4.425" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-890W-1790L-265H-155F-28">
+<package name="SOP-28-127P-890W-1790L-265H-155F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 17.90mm length, 8.90mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body length,
 8.90mm body width, 2.65mm max height, 28 leads.
@@ -1601,7 +1601,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <wire x1="8.925" y1="-4.425" x2="-8.925" y2="-4.425" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="4.425" x2="-8.925" y2="4.425" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-890W-2050L-265H-155F-32">
+<package name="SOP-32-127P-890W-2050L-265H-155F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 20.50mm length, 8.90mm width, 2.65mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body length,
 8.90mm body width, 2.65mm max height, 32 leads.
@@ -1683,7 +1683,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body 
 <wire x1="10.225" y1="-4.425" x2="-10.225" y2="-4.425" width="0.0508" layer="51"/>
 <wire x1="10.225" y1="4.425" x2="-10.225" y2="4.425" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-890W-2300L-265H-155F-36">
+<package name="SOP-36-127P-890W-2300L-265H-155F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 23.00mm length, 8.90mm width, 2.65mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 23.00mm body length,
 8.90mm body width, 2.65mm max height, 36 leads.

--- a/ref-packages-ssop.lbr
+++ b/ref-packages-ssop.lbr
@@ -72,7 +72,7 @@
 </layers>
 <library>
 <packages>
-<package name="SSOP-065-530-14">
+<package name="SSOP-14-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 14 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 14 leads. JEDEC MO-150B. Variation AB.</description>
 <circle x="-1.935" y="-1.8988" radius="0.3175" width="0" layer="21"/>
@@ -111,7 +111,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 14 leads. JED
 <wire x1="2.5" y1="-2.6" x2="2.5" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="2.5" y1="2.6" x2="-2.5" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-16">
+<package name="SSOP-16-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 16 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 16 leads. JEDEC MO-150B. Variation AC.</description>
 <circle x="-2.235" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -154,7 +154,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 16 leads. JED
 <wire x1="3.15" y1="-2.6" x2="3.15" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.6" x2="-3.1" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-18">
+<package name="SSOP-18-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 18 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 18 leads. JEDEC MO-150B. Variation AD.</description>
 <circle x="-2.585" y="-1.8988" radius="0.3175" width="0" layer="21"/>
@@ -201,7 +201,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 18 leads. JED
 <wire x1="3.15" y1="-2.6" x2="3.15" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.6" x2="-3.15" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-20">
+<package name="SSOP-20-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 20 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JEDEC MO-150B. Variation AE.</description>
 <circle x="-2.885" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -252,7 +252,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <wire x1="3.8" y1="-2.6" x2="3.8" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.6" x2="-3.75" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-24">
+<package name="SSOP-24-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 24 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JEDEC MO-150B. Variation AG.</description>
 <circle x="-3.535" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -311,7 +311,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <wire x1="4.45" y1="-2.6" x2="4.45" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="4.45" y1="2.6" x2="-4.4" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-28">
+<package name="SSOP-28-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 28 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JEDEC MO-150B. Variation AH.</description>
 <circle x="-4.185" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -378,7 +378,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <wire x1="5.1" y1="-2.6" x2="5.1" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="5.1" y1="2.6" x2="-5.05" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-8">
+<package name="SSOP-8-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 8 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 8 leads. JEDEC MO-150B. Variation AA.</description>
 <circle x="-0.96" y="-1.8988" radius="0.3175" width="0" layer="21"/>
@@ -405,7 +405,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 8 leads. JEDE
 <wire x1="1.525" y1="-2.6" x2="1.525" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="1.525" y1="2.6" x2="-1.525" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-440W-1130L-120H-100F-56">
+<package name="SSOP-56-40P-440W-1130L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 11.3mm length, 4.4mm width, 1.20mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 11.3mm length, 4.4mm width, 1.20mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-194B, variation AF, R-PDSO-G.&lt;/p&gt;
@@ -530,7 +530,7 @@ JEDEC MO-194B, variation AF, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.55" y1="-2.1" x2="5.55" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="5.55" y1="2.1" x2="-5.55" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-440W-360L-120H-100F-14">
+<package name="SSOP-14-40P-440W-360L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 3.6mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 3.6mm length, 4.4mm width, 1.20mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-194B, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -571,7 +571,7 @@ JEDEC MO-194B, variation AA, R-PDSO-G.&lt;/p&gt;
 <wire x1="1.7" y1="-2.1" x2="1.7" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="1.7" y1="2.1" x2="-1.7" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-440W-360L-120H-100F-16">
+<package name="SSOP-16-40P-440W-360L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 3.6mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 3.6mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-194B, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -616,7 +616,7 @@ JEDEC MO-194B, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="1.7" y1="-2.1" x2="1.7" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="1.7" y1="2.1" x2="-1.7" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-440W-500L-120H-100F-20">
+<package name="SSOP-20-40P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-194B, variation AC, R-PDSO-G.&lt;/p&gt;
@@ -669,7 +669,7 @@ JEDEC MO-194B, variation AC, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-440W-500L-120H-100F-24">
+<package name="SSOP-24-40P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation CA, R-PDSO-G.&lt;/p&gt;
@@ -730,7 +730,7 @@ JEDEC MO-153F, variation CA, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-440W-500L-200H-100F-24">
+<package name="SSOP-24-40P-440W-500L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 2.00mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 2.00mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation CA, R-PDSO-G.&lt;/p&gt;
@@ -791,7 +791,7 @@ JEDEC MO-152C, variation CA, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-440W-650L-120H-100F-32">
+<package name="SSOP-32-40P-440W-650L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 1.20mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation CB, R-PDSO-G.&lt;/p&gt;
@@ -868,7 +868,7 @@ JEDEC MO-153F, variation CB, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.15" y1="-2.1" x2="3.15" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.1" x2="-3.15" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-440W-650L-200H-100F-32">
+<package name="SSOP-32-40P-440W-650L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 2.00mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 2.00mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation CB, R-PDSO-G.&lt;/p&gt;
@@ -945,7 +945,7 @@ JEDEC MO-152C, variation CB, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.15" y1="-2.1" x2="3.15" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.1" x2="-3.15" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-440W-780L-120H-100F-36">
+<package name="SSOP-36-40P-440W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 1.20mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation CC, R-PDSO-G.&lt;/p&gt;
@@ -1030,7 +1030,7 @@ JEDEC MO-153F, variation CC, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.1" x2="3.8" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.1" x2="-3.8" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-440W-780L-200H-100F-36">
+<package name="SSOP-36-40P-440W-780L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 2.00mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 2.00mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation CC, R-PDSO-G.&lt;/p&gt;
@@ -1115,7 +1115,7 @@ JEDEC MO-152C, variation CC, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.1" x2="3.8" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.1" x2="-3.8" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-440W-970L-120H-100F-48">
+<package name="SSOP-48-40P-440W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 9.7mm length, 4.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 9.7mm length, 4.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation CD, R-PDSO-G.&lt;/p&gt;
@@ -1224,7 +1224,7 @@ JEDEC MO-153F, variation CD, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.1" x2="4.75" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.1" x2="-4.75" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-440W-970L-200H-100F-48">
+<package name="SSOP-48-40P-440W-970L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 9.7mm length, 4.4mm width, 2.00mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 9.7mm length, 4.4mm width, 2.00mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation CD, R-PDSO-G.&lt;/p&gt;
@@ -1333,7 +1333,7 @@ JEDEC MO-152C, variation CD, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.1" x2="4.75" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.1" x2="-4.75" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-610W-1100L-120H-100F-52">
+<package name="SSOP-52-40P-610W-1100L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 11.0mm length, 6.1mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 11.0mm length, 6.1mm width, 1.20mm max height, 52 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation FC, R-PDSO-G.&lt;/p&gt;
@@ -1450,7 +1450,7 @@ JEDEC MO-153F, variation FC, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-2.95" x2="5.4" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="2.95" x2="-5.4" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-610W-1100L-200H-100F-52">
+<package name="SSOP-52-40P-610W-1100L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 11.0mm length, 6.1mm width, 2.00mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 11.0mm length, 6.1mm width, 2.00mm max height, 52 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation FC, R-PDSO-G.&lt;/p&gt;
@@ -1567,7 +1567,7 @@ JEDEC MO-152C, variation FC, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-2.95" x2="5.4" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="2.95" x2="-5.4" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-610W-1250L-120H-100F-56">
+<package name="SSOP-56-40P-610W-1250L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 12.5mm length, 6.1mm width, 1.20mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 12.5mm length, 6.1mm width, 1.20mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation FD, R-PDSO-G.&lt;/p&gt;
@@ -1692,7 +1692,7 @@ JEDEC MO-153F, variation FD, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-2.95" x2="6.15" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="2.95" x2="-6.15" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-610W-1250L-200H-100F-56">
+<package name="SSOP-56-40P-610W-1250L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 12.5mm length, 6.1mm width, 2.00mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 12.5mm length, 6.1mm width, 2.00mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation FD, R-PDSO-G.&lt;/p&gt;
@@ -1817,7 +1817,7 @@ JEDEC MO-152C, variation FD, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-2.95" x2="6.15" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="2.95" x2="-6.15" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-610W-1400L-120H-100F-64">
+<package name="SSOP-64-40P-610W-1400L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 14.0mm length, 6.1mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 14.0mm length, 6.1mm width, 1.20mm max height, 64 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation FE, R-PDSO-G.&lt;/p&gt;
@@ -1958,7 +1958,7 @@ JEDEC MO-153F, variation FE, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-2.95" x2="6.9" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="2.95" x2="-6.9" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-610W-1400L-200H-100F-64">
+<package name="SSOP-64-40P-610W-1400L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 14.0mm length, 6.1mm width, 2.00mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 14.0mm length, 6.1mm width, 2.00mm max height, 64 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation FE, R-PDSO-G.&lt;/p&gt;
@@ -2099,7 +2099,7 @@ JEDEC MO-152C, variation FE, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-2.95" x2="6.9" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="2.95" x2="-6.9" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-610W-1700L-120H-100F-80">
+<package name="SSOP-80-40P-610W-1700L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 17.0mm length, 6.1mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 17.0mm length, 6.1mm width, 1.20mm max height, 80 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation FF, R-PDSO-G.&lt;/p&gt;
@@ -2272,7 +2272,7 @@ JEDEC MO-153F, variation FF, R-PDSO-G.&lt;/p&gt;
 <wire x1="8.4" y1="-2.95" x2="8.4" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="8.4" y1="2.95" x2="-8.4" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-610W-1700L-200H-100F-80">
+<package name="SSOP-80-40P-610W-1700L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 17.0mm length, 6.1mm width, 2.00mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 17.0mm length, 6.1mm width, 2.00mm max height, 80 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation FF, R-PDSO-G.&lt;/p&gt;
@@ -2445,7 +2445,7 @@ JEDEC MO-152C, variation FF, R-PDSO-G.&lt;/p&gt;
 <wire x1="8.4" y1="-2.95" x2="8.4" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="8.4" y1="2.95" x2="-8.4" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-610W-2080L-120H-100F-100">
+<package name="SSOP-100-40P-610W-2080L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 20.8mm length, 6.1mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 20.8mm length, 6.1mm width, 1.20mm max height, 100 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-194B, variation BB, R-PDSO-G.&lt;/p&gt;
@@ -2658,7 +2658,7 @@ JEDEC MO-194B, variation BB, R-PDSO-G.&lt;/p&gt;
 <wire x1="10.3" y1="-2.95" x2="10.3" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="10.3" y1="2.95" x2="-10.3" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-610W-780L-120H-100F-36">
+<package name="SSOP-36-40P-610W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 7.8mm length, 6.1mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 7.8mm length, 6.1mm width, 1.20mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation FA, R-PDSO-G.&lt;/p&gt;
@@ -2743,7 +2743,7 @@ JEDEC MO-153F, variation FA, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.95" x2="3.8" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.95" x2="-3.8" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-610W-780L-200H-100F-36">
+<package name="SSOP-36-40P-610W-780L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 7.8mm length, 6.1mm width, 2.00mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 7.8mm length, 6.1mm width, 2.00mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation FA, R-PDSO-G.&lt;/p&gt;
@@ -2828,7 +2828,7 @@ JEDEC MO-152C, variation FA, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.95" x2="3.8" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.95" x2="-3.8" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-610W-970L-120H-100F-48">
+<package name="SSOP-48-40P-610W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 9.7mm length, 6.1mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 9.7mm length, 6.1mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation FB, R-PDSO-G.&lt;/p&gt;
@@ -2937,7 +2937,7 @@ JEDEC MO-153F, variation FB, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.95" x2="4.75" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.95" x2="-4.75" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-610W-970L-200H-100F-48">
+<package name="SSOP-48-40P-610W-970L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 9.7mm length, 6.1mm width, 2.00mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 9.7mm length, 6.1mm width, 2.00mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation FB, R-PDSO-G.&lt;/p&gt;
@@ -3046,7 +3046,7 @@ JEDEC MO-152C, variation FB, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.95" x2="4.75" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.95" x2="-4.75" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-800W-1100L-120H-100F-52">
+<package name="SSOP-52-40P-800W-1100L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 11.0mm length, 8.0mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 11.0mm length, 8.0mm width, 1.20mm max height, 52 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation JB, R-PDSO-G.&lt;/p&gt;
@@ -3163,7 +3163,7 @@ JEDEC MO-153F, variation JB, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-3.9" x2="5.4" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="3.9" x2="-5.4" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-800W-1100L-200H-100F-52">
+<package name="SSOP-52-40P-800W-1100L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 11.0mm length, 8.0mm width, 2.00mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 11.0mm length, 8.0mm width, 2.00mm max height, 52 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation JB, R-PDSO-G.&lt;/p&gt;
@@ -3280,7 +3280,7 @@ JEDEC MO-152C, variation JB, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-3.9" x2="5.4" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="3.9" x2="-5.4" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-800W-1250L-120H-100F-56">
+<package name="SSOP-56-40P-800W-1250L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 12.5mm length, 8.0mm width, 1.20mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 12.5mm length, 8.0mm width, 1.20mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation JC, R-PDSO-G.&lt;/p&gt;
@@ -3405,7 +3405,7 @@ JEDEC MO-153F, variation JC, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-3.9" x2="6.15" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="3.9" x2="-6.15" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-800W-1250L-120H-100F-60">
+<package name="SSOP-60-40P-800W-1250L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 12.5mm length, 8.0mm width, 1.20mm max height, 60 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 12.5mm length, 8.0mm width, 1.20mm max height, 60 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation JC-1, R-PDSO-G.&lt;/p&gt;
@@ -3538,7 +3538,7 @@ JEDEC MO-153F, variation JC-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-3.9" x2="6.15" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="3.9" x2="-6.15" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-800W-1250L-200H-100F-56">
+<package name="SSOP-56-40P-800W-1250L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 12.5mm length, 8.0mm width, 2.00mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 12.5mm length, 8.0mm width, 2.00mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation JC, R-PDSO-G.&lt;/p&gt;
@@ -3663,7 +3663,7 @@ JEDEC MO-152C, variation JC, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-3.9" x2="6.15" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="3.9" x2="-6.15" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-800W-1250L-200H-100F-60">
+<package name="SSOP-60-40P-800W-1250L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 12.5mm length, 8.0mm width, 2.00mm max height, 60 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 12.5mm length, 8.0mm width, 2.00mm max height, 60 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation JC-1, R-PDSO-G.&lt;/p&gt;
@@ -3796,7 +3796,7 @@ JEDEC MO-152C, variation JC-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-3.9" x2="6.15" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="3.9" x2="-6.15" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-800W-1400L-120H-100F-64">
+<package name="SSOP-64-40P-800W-1400L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 14.0mm length, 8.0mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 14.0mm length, 8.0mm width, 1.20mm max height, 64 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation JD, R-PDSO-G.&lt;/p&gt;
@@ -3937,7 +3937,7 @@ JEDEC MO-153F, variation JD, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-3.9" x2="6.9" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="3.9" x2="-6.9" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-800W-1400L-120H-100F-68">
+<package name="SSOP-68-40P-800W-1400L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 14.0mm length, 8.0mm width, 1.20mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 14.0mm length, 8.0mm width, 1.20mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation JD-1, R-PDSO-G.&lt;/p&gt;
@@ -4086,7 +4086,7 @@ JEDEC MO-153F, variation JD-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-3.9" x2="6.9" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="3.9" x2="-6.9" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-800W-1400L-200H-100F-64">
+<package name="SSOP-64-40P-800W-1400L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 14.0mm length, 8.0mm width, 2.00mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 14.0mm length, 8.0mm width, 2.00mm max height, 64 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation JD, R-PDSO-G.&lt;/p&gt;
@@ -4227,7 +4227,7 @@ JEDEC MO-152C, variation JD, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-3.9" x2="6.9" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="3.9" x2="-6.9" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-800W-1400L-200H-100F-68">
+<package name="SSOP-68-40P-800W-1400L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 14.0mm length, 8.0mm width, 2.00mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 14.0mm length, 8.0mm width, 2.00mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation JD-1, R-PDSO-G.&lt;/p&gt;
@@ -4376,7 +4376,7 @@ JEDEC MO-152C, variation JD-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-3.9" x2="6.9" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="3.9" x2="-6.9" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-800W-970L-120H-100F-48">
+<package name="SSOP-48-40P-800W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.40mm pitch, 1.0mm lead length, 9.7mm length, 8.0mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.40mm pitch, 1.0mm lead length 9.7mm length, 8.0mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation JA, R-PDSO-G.&lt;/p&gt;
@@ -4485,7 +4485,7 @@ JEDEC MO-153F, variation JA, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-3.9" x2="4.75" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="3.9" x2="-4.75" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-800W-970L-200H-100F-48">
+<package name="SSOP-48-40P-800W-970L-200H-100F">
 <description>&lt;b&gt;SSOP (0.40mm pitch, 1.0mm lead length, 9.7mm length, 8.0mm width, 2.00mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.40mm pitch, 1.0mm lead length 9.7mm length, 8.0mm width, 2.00mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation JA, R-PDSO-G.&lt;/p&gt;
@@ -4594,7 +4594,7 @@ JEDEC MO-152C, variation JA, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-3.9" x2="4.75" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="3.9" x2="-4.75" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-889W-1079L-120H-80F-52">
+<package name="SSOP-52-40P-889W-1079L-120H-80F">
 <description>&lt;b&gt;TSOP (0.40mm pitch, 0.8mm lead length, 10.79mm length, 8.89mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.40mm pitch, 0.8mm lead length 10.79mm length, 8.89mm width, 1.20mm max height, 52 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-249A, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -4711,7 +4711,7 @@ JEDEC MO-249A, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.295" y1="-4.345" x2="5.295" y2="4.345" width="0.2032" layer="21"/>
 <wire x1="5.295" y1="4.345" x2="-5.295" y2="4.345" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-889W-1143L-120H-80F-56">
+<package name="SSOP-56-40P-889W-1143L-120H-80F">
 <description>&lt;b&gt;TSOP (0.40mm pitch, 0.8mm lead length, 11.43mm length, 8.89mm width, 1.20mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.40mm pitch, 0.8mm lead length 11.43mm length, 8.89mm width, 1.20mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-249A, variation BC, R-PDSO-G.&lt;/p&gt;
@@ -4836,7 +4836,7 @@ JEDEC MO-249A, variation BC, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.615" y1="-4.345" x2="5.615" y2="4.345" width="0.2032" layer="21"/>
 <wire x1="5.615" y1="4.345" x2="-5.615" y2="4.345" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-889W-1333L-120H-80F-64">
+<package name="SSOP-64-40P-889W-1333L-120H-80F">
 <description>&lt;b&gt;TSOP (0.40mm pitch, 0.8mm lead length, 13.33mm length, 8.89mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.40mm pitch, 0.8mm lead length 13.33mm length, 8.89mm width, 1.20mm max height, 64 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-249A, variation DD, R-PDSO-G.&lt;/p&gt;
@@ -4977,7 +4977,7 @@ JEDEC MO-249A, variation DD, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.565" y1="-4.345" x2="6.565" y2="4.345" width="0.2032" layer="21"/>
 <wire x1="6.565" y1="4.345" x2="-6.565" y2="4.345" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-40P-889W-1397L-120H-80F-68">
+<package name="SSOP-68-40P-889W-1397L-120H-80F">
 <description>&lt;b&gt;TSOP (0.40mm pitch, 0.8mm lead length, 13.97mm length, 8.89mm width, 1.20mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.40mm pitch, 0.8mm lead length 13.97mm length, 8.89mm width, 1.20mm max height, 68 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-249A, variation EA, R-PDSO-G.&lt;/p&gt;
@@ -5126,7 +5126,7 @@ JEDEC MO-249A, variation EA, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.885" y1="-4.345" x2="6.885" y2="4.345" width="0.2032" layer="21"/>
 <wire x1="6.885" y1="4.345" x2="-6.885" y2="4.345" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1240W-1000L-120H-80F-40">
+<package name="SSOP-40-50P-1240W-1000L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 10.0mm length, 12.4mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 10.0mm length, 12.4mm width, 1.20mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation CA, R-PDSO-G.&lt;/p&gt;
@@ -5219,7 +5219,7 @@ JEDEC MO-142D, variation CA, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.9" y1="-6.1" x2="4.9" y2="6.1" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="6.1" x2="-4.9" y2="6.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1240W-1200L-120H-80F-48">
+<package name="SSOP-48-50P-1240W-1200L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 12.0mm length, 12.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 12.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation DA, R-PDSO-G.&lt;/p&gt;
@@ -5328,7 +5328,7 @@ JEDEC MO-142D, variation DA, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.9" y1="-6.1" x2="5.9" y2="6.1" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="6.1" x2="-5.9" y2="6.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1240W-600L-120H-80F-24">
+<package name="SSOP-24-50P-1240W-600L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 6.0mm length, 12.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 6.0mm length, 12.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -5389,7 +5389,7 @@ JEDEC MO-142D, variation AA, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.9" y1="-6.1" x2="2.9" y2="6.1" width="0.2032" layer="21"/>
 <wire x1="2.9" y1="6.1" x2="-2.9" y2="6.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1240W-800L-120H-80F-32">
+<package name="SSOP-32-50P-1240W-800L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 8.0mm length, 12.4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 8.0mm length, 12.4mm width, 1.20mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation BA, R-PDSO-G.&lt;/p&gt;
@@ -5466,7 +5466,7 @@ JEDEC MO-142D, variation BA, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.9" y1="-6.1" x2="3.9" y2="6.1" width="0.2032" layer="21"/>
 <wire x1="3.9" y1="6.1" x2="-3.9" y2="6.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1440W-1000L-120H-80F-40">
+<package name="SSOP-40-50P-1440W-1000L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 10.0mm length, 14.4mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 10.0mm length, 14.4mm width, 1.20mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation CB, R-PDSO-G.&lt;/p&gt;
@@ -5559,7 +5559,7 @@ JEDEC MO-142D, variation CB, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.9" y1="-7.1" x2="4.9" y2="7.1" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="7.1" x2="-4.9" y2="7.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1440W-1200L-120H-80F-48">
+<package name="SSOP-48-50P-1440W-1200L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 12.0mm length, 14.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 14.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation DB, R-PDSO-G.&lt;/p&gt;
@@ -5668,7 +5668,7 @@ JEDEC MO-142D, variation DB, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.9" y1="-7.1" x2="5.9" y2="7.1" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="7.1" x2="-5.9" y2="7.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1440W-1400L-120H-80F-56">
+<package name="SSOP-56-50P-1440W-1400L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 14.0mm length, 14.4mm width, 1.20mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 14.0mm length, 14.4mm width, 1.20mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation EA, R-PDSO-G.&lt;/p&gt;
@@ -5793,7 +5793,7 @@ JEDEC MO-142D, variation EA, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-7.1" x2="6.9" y2="7.1" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="7.1" x2="-6.9" y2="7.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1440W-600L-120H-80F-24">
+<package name="SSOP-24-50P-1440W-600L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 6.0mm length, 14.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 6.0mm length, 14.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -5854,7 +5854,7 @@ JEDEC MO-142D, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.9" y1="-7.1" x2="2.9" y2="7.1" width="0.2032" layer="21"/>
 <wire x1="2.9" y1="7.1" x2="-2.9" y2="7.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1440W-800L-120H-80F-32">
+<package name="SSOP-32-50P-1440W-800L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 8.0mm length, 14.4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 8.0mm length, 14.4mm width, 1.20mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation BB, R-PDSO-G.&lt;/p&gt;
@@ -5931,7 +5931,7 @@ JEDEC MO-142D, variation BB, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.9" y1="-7.1" x2="3.9" y2="7.1" width="0.2032" layer="21"/>
 <wire x1="3.9" y1="7.1" x2="-3.9" y2="7.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1540W-1200L-70H-100F-48">
+<package name="SSOP-48-50P-1540W-1200L-70H-100F">
 <description>&lt;b&gt;WSOP (0.50mm pitch, 1.3mm lead length, 12.0mm length, 15.4mm width, 0.70mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Very very thin small outline package. 0.50mm pitch, 1.3mm lead length 12.0mm length, 15.4mm width, 0.70mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-259A, variation AA, WR-PDSO1.&lt;/p&gt;
@@ -6040,7 +6040,7 @@ JEDEC MO-259A, variation AA, WR-PDSO1.&lt;/p&gt;
 <wire x1="5.9" y1="-7.6" x2="5.9" y2="7.6" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="7.6" x2="-5.9" y2="7.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1640W-1000L-120H-80F-40">
+<package name="SSOP-40-50P-1640W-1000L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 10.0mm length, 16.4mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 10.0mm length, 16.4mm width, 1.20mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation CC, R-PDSO-G.&lt;/p&gt;
@@ -6133,7 +6133,7 @@ JEDEC MO-142D, variation CC, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.9" y1="-8.1" x2="4.9" y2="8.1" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="8.1" x2="-4.9" y2="8.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1640W-1200L-120H-80F-48">
+<package name="SSOP-48-50P-1640W-1200L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 12.0mm length, 16.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 16.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation DC, R-PDSO-G.&lt;/p&gt;
@@ -6242,7 +6242,7 @@ JEDEC MO-142D, variation DC, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.9" y1="-8.1" x2="5.9" y2="8.1" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="8.1" x2="-5.9" y2="8.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1640W-1400L-120H-80F-56">
+<package name="SSOP-56-50P-1640W-1400L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 14.0mm length, 16.4mm width, 1.20mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 14.0mm length, 16.4mm width, 1.20mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation EB, R-PDSO-G.&lt;/p&gt;
@@ -6367,7 +6367,7 @@ JEDEC MO-142D, variation EB, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-8.1" x2="6.9" y2="8.1" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="8.1" x2="-6.9" y2="8.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1640W-600L-120H-80F-24">
+<package name="SSOP-24-50P-1640W-600L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 6.0mm length, 16.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 6.0mm length, 16.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation AC, R-PDSO-G.&lt;/p&gt;
@@ -6428,7 +6428,7 @@ JEDEC MO-142D, variation AC, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.9" y1="-8.1" x2="2.9" y2="8.1" width="0.2032" layer="21"/>
 <wire x1="2.9" y1="8.1" x2="-2.9" y2="8.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1640W-800L-120H-80F-32">
+<package name="SSOP-32-50P-1640W-800L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 8.0mm length, 16.4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 8.0mm length, 16.4mm width, 1.20mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation BC, R-PDSO-G.&lt;/p&gt;
@@ -6505,7 +6505,7 @@ JEDEC MO-142D, variation BC, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.9" y1="-8.1" x2="3.9" y2="8.1" width="0.2032" layer="21"/>
 <wire x1="3.9" y1="8.1" x2="-3.9" y2="8.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1840W-1000L-120H-80F-40">
+<package name="SSOP-40-50P-1840W-1000L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 10.0mm length, 18.4mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 10.0mm length, 18.4mm width, 1.20mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation CD, R-PDSO-G.&lt;/p&gt;
@@ -6598,7 +6598,7 @@ JEDEC MO-142D, variation CD, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.9" y1="-9.1" x2="4.9" y2="9.1" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="9.1" x2="-4.9" y2="9.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1840W-1200L-120H-80F-48">
+<package name="SSOP-48-50P-1840W-1200L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
@@ -6707,7 +6707,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.9" y1="-9.1" x2="5.9" y2="9.1" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="9.1" x2="-5.9" y2="9.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1840W-1400L-120H-80F-56">
+<package name="SSOP-56-50P-1840W-1400L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 14.0mm length, 18.4mm width, 1.20mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 14.0mm length, 18.4mm width, 1.20mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation EC, R-PDSO-G.&lt;/p&gt;
@@ -6832,7 +6832,7 @@ JEDEC MO-142D, variation EC, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-9.1" x2="6.9" y2="9.1" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="9.1" x2="-6.9" y2="9.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1840W-600L-120H-80F-24">
+<package name="SSOP-24-50P-1840W-600L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 6.0mm length, 18.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 6.0mm length, 18.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation AD, R-PDSO-G.&lt;/p&gt;
@@ -6893,7 +6893,7 @@ JEDEC MO-142D, variation AD, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.9" y1="-9.1" x2="2.9" y2="9.1" width="0.2032" layer="21"/>
 <wire x1="2.9" y1="9.1" x2="-2.9" y2="9.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1840W-800L-120H-80F-32">
+<package name="SSOP-32-50P-1840W-800L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 8.0mm length, 18.4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 8.0mm length, 18.4mm width, 1.20mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation BD, R-PDSO-G.&lt;/p&gt;
@@ -6970,7 +6970,7 @@ JEDEC MO-142D, variation BD, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.9" y1="-9.1" x2="3.9" y2="9.1" width="0.2032" layer="21"/>
 <wire x1="3.9" y1="9.1" x2="-3.9" y2="9.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-230W-200L-100H-40F-8">
+<package name="SSOP-8-50P-230W-200L-100H-40F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.40mm lead length, 2.0mm length, 2.3mm width, 1.00mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.50mm pitch, 0.40mm lead length 2.0mm length, 2.3mm width, 1.00mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation CA, VSR-PDSO.&lt;/p&gt;
@@ -7003,7 +7003,7 @@ JEDEC MO-187F, variation CA, VSR-PDSO.&lt;/p&gt;
 <wire x1="0.975" y1="-1.125" x2="-0.975" y2="-1.125" width="0.0508" layer="51"/>
 <wire x1="0.975" y1="1.125" x2="-0.975" y2="1.125" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-50P-300W-300L-110H-95F-10">
+<package name="SSOP-10-50P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
@@ -7036,7 +7036,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <wire x1="1.4" y1="-1.4" x2="1.4" y2="1.4" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="1.4" x2="-1.4" y2="1.4" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-440W-1100L-120H-100F-44">
+<package name="SSOP-44-50P-440W-1100L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 11.0mm length, 4.4mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 11.0mm length, 4.4mm width, 1.20mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation BE, R-PDSO-G.&lt;/p&gt;
@@ -7137,7 +7137,7 @@ JEDEC MO-153F, variation BE, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-2.1" x2="5.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="2.1" x2="-5.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-440W-1250L-120H-100F-50">
+<package name="SSOP-50-50P-440W-1250L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 12.5mm length, 4.4mm width, 1.20mm max height, 50 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 12.5mm length, 4.4mm width, 1.20mm max height, 50 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation BF, R-PDSO-G.&lt;/p&gt;
@@ -7250,7 +7250,7 @@ JEDEC MO-153F, variation BF, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-2.1" x2="6.15" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="2.1" x2="-6.15" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-440W-500L-120H-100F-20">
+<package name="SSOP-20-50P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation BA, R-PDSO-G.&lt;/p&gt;
@@ -7303,7 +7303,7 @@ JEDEC MO-153F, variation BA, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-440W-500L-200H-100F-20">
+<package name="SSOP-20-50P-440W-500L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 2.00mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 2.00mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation BA, R-PDSO-G.&lt;/p&gt;
@@ -7356,7 +7356,7 @@ JEDEC MO-152C, variation BA, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-440W-650L-120H-100F-24">
+<package name="SSOP-24-50P-440W-650L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation BB, R-PDSO-G.&lt;/p&gt;
@@ -7417,7 +7417,7 @@ JEDEC MO-153F, variation BB, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.15" y1="-2.1" x2="3.15" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.1" x2="-3.15" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-440W-650L-200H-100F-24">
+<package name="SSOP-24-50P-440W-650L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 2.00mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 2.00mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation BB, R-PDSO-G.&lt;/p&gt;
@@ -7478,7 +7478,7 @@ JEDEC MO-152C, variation BB, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.15" y1="-2.1" x2="3.15" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.1" x2="-3.15" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-440W-780L-120H-100F-28">
+<package name="SSOP-28-50P-440W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 1.20mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 1.20mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation BC, R-PDSO-G.&lt;/p&gt;
@@ -7547,7 +7547,7 @@ JEDEC MO-153F, variation BC, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.1" x2="3.8" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.1" x2="-3.8" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-440W-780L-120H-100F-30">
+<package name="SSOP-30-50P-440W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 1.20mm max height, 30 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 1.20mm max height, 30 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation BC-1, R-PDSO-G.&lt;/p&gt;
@@ -7620,7 +7620,7 @@ JEDEC MO-153F, variation BC-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.1" x2="3.8" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.1" x2="-3.8" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-440W-780L-200H-100F-28">
+<package name="SSOP-28-50P-440W-780L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 2.00mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 2.00mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation BC, R-PDSO-G.&lt;/p&gt;
@@ -7689,7 +7689,7 @@ JEDEC MO-152C, variation BC, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.1" x2="3.8" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.1" x2="-3.8" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-440W-970L-120H-100F-36">
+<package name="SSOP-36-50P-440W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 9.7mm length, 4.4mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 9.7mm length, 4.4mm width, 1.20mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation BD, R-PDSO-G.&lt;/p&gt;
@@ -7774,7 +7774,7 @@ JEDEC MO-153F, variation BD, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.1" x2="4.75" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.1" x2="-4.75" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-440W-970L-120H-100F-38">
+<package name="SSOP-38-50P-440W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 9.7mm length, 4.4mm width, 1.20mm max height, 38 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 9.7mm length, 4.4mm width, 1.20mm max height, 38 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation BD-1, R-PDSO-G.&lt;/p&gt;
@@ -7863,7 +7863,7 @@ JEDEC MO-153F, variation BD-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.1" x2="4.75" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.1" x2="-4.75" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-440W-970L-200H-100F-36">
+<package name="SSOP-36-50P-440W-970L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 9.7mm length, 4.4mm width, 2.00mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 9.7mm length, 4.4mm width, 2.00mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation BD, R-PDSO-G.&lt;/p&gt;
@@ -7948,7 +7948,7 @@ JEDEC MO-152C, variation BD, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.1" x2="4.75" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.1" x2="-4.75" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-1100L-120H-100F-40">
+<package name="SSOP-40-50P-610W-1100L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 11.0mm length, 6.1mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 11.0mm length, 6.1mm width, 1.20mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation EC, R-PDSO-G.&lt;/p&gt;
@@ -8041,7 +8041,7 @@ JEDEC MO-153F, variation EC, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-2.95" x2="5.4" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="2.95" x2="-5.4" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-1100L-120H-100F-44">
+<package name="SSOP-44-50P-610W-1100L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 11.0mm length, 6.1mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 11.0mm length, 6.1mm width, 1.20mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation EC-1, R-PDSO-G.&lt;/p&gt;
@@ -8142,7 +8142,7 @@ JEDEC MO-153F, variation EC-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-2.95" x2="5.4" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="2.95" x2="-5.4" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-1100L-200H-100F-40">
+<package name="SSOP-40-50P-610W-1100L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 11.0mm length, 6.1mm width, 2.00mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 11.0mm length, 6.1mm width, 2.00mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation EC, R-PDSO-G.&lt;/p&gt;
@@ -8235,7 +8235,7 @@ JEDEC MO-152C, variation EC, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-2.95" x2="5.4" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="2.95" x2="-5.4" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-1100L-200H-100F-44">
+<package name="SSOP-44-50P-610W-1100L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 11.0mm length, 6.1mm width, 2.00mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 11.0mm length, 6.1mm width, 2.00mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation EC-1, R-PDSO-G.&lt;/p&gt;
@@ -8336,7 +8336,7 @@ JEDEC MO-152C, variation EC-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-2.95" x2="5.4" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="2.95" x2="-5.4" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-1250L-120H-100F-48">
+<package name="SSOP-48-50P-610W-1250L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 12.5mm length, 6.1mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 12.5mm length, 6.1mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation ED, R-PDSO-G.&lt;/p&gt;
@@ -8445,7 +8445,7 @@ JEDEC MO-153F, variation ED, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-2.95" x2="6.15" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="2.95" x2="-6.15" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-1250L-200H-100F-48">
+<package name="SSOP-48-50P-610W-1250L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 12.5mm length, 6.1mm width, 2.00mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 12.5mm length, 6.1mm width, 2.00mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation ED, R-PDSO-G.&lt;/p&gt;
@@ -8554,7 +8554,7 @@ JEDEC MO-152C, variation ED, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-2.95" x2="6.15" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="2.95" x2="-6.15" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-1400L-120H-100F-56">
+<package name="SSOP-56-50P-610W-1400L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 14.0mm length, 6.1mm width, 1.20mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 14.0mm length, 6.1mm width, 1.20mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation EE, R-PDSO-G.&lt;/p&gt;
@@ -8679,7 +8679,7 @@ JEDEC MO-153F, variation EE, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-2.95" x2="6.9" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="2.95" x2="-6.9" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-1400L-200H-100F-56">
+<package name="SSOP-56-50P-610W-1400L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 14.0mm length, 6.1mm width, 2.00mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 14.0mm length, 6.1mm width, 2.00mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation EE, R-PDSO-G.&lt;/p&gt;
@@ -8804,7 +8804,7 @@ JEDEC MO-152C, variation EE, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-2.95" x2="6.9" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="2.95" x2="-6.9" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-1700L-120H-100F-64">
+<package name="SSOP-64-50P-610W-1700L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 17.0mm length, 6.1mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 17.0mm length, 6.1mm width, 1.20mm max height, 64 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation EF, R-PDSO-G.&lt;/p&gt;
@@ -8945,7 +8945,7 @@ JEDEC MO-153F, variation EF, R-PDSO-G.&lt;/p&gt;
 <wire x1="8.4" y1="-2.95" x2="8.4" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="8.4" y1="2.95" x2="-8.4" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-1700L-200H-100F-54">
+<package name="SSOP-54-50P-610W-1700L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 17.0mm length, 6.1mm width, 2.00mm max height, 54 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 17.0mm length, 6.1mm width, 2.00mm max height, 54 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation EF, R-PDSO-G.&lt;/p&gt;
@@ -9066,7 +9066,7 @@ JEDEC MO-152C, variation EF, R-PDSO-G.&lt;/p&gt;
 <wire x1="8.4" y1="-2.95" x2="8.4" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="8.4" y1="2.95" x2="-8.4" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-780L-120H-100F-28">
+<package name="SSOP-28-50P-610W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 7.8mm length, 6.1mm width, 1.20mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 7.8mm length, 6.1mm width, 1.20mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation EA, R-PDSO-G.&lt;/p&gt;
@@ -9135,7 +9135,7 @@ JEDEC MO-153F, variation EA, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.95" x2="3.8" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.95" x2="-3.8" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-780L-200H-100F-28">
+<package name="SSOP-28-50P-610W-780L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 7.8mm length, 6.1mm width, 2.00mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 7.8mm length, 6.1mm width, 2.00mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation EA, R-PDSO-G.&lt;/p&gt;
@@ -9204,7 +9204,7 @@ JEDEC MO-152C, variation EA, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.95" x2="3.8" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.95" x2="-3.8" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-970L-120H-100F-36">
+<package name="SSOP-36-50P-610W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 9.7mm length, 6.1mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 9.7mm length, 6.1mm width, 1.20mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation EB, R-PDSO-G.&lt;/p&gt;
@@ -9289,7 +9289,7 @@ JEDEC MO-153F, variation EB, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.95" x2="4.75" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.95" x2="-4.75" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-610W-970L-200H-100F-36">
+<package name="SSOP-36-50P-610W-970L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 9.7mm length, 6.1mm width, 2.00mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 9.7mm length, 6.1mm width, 2.00mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation EB, R-PDSO-G.&lt;/p&gt;
@@ -9374,7 +9374,7 @@ JEDEC MO-152C, variation EB, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.95" x2="4.75" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.95" x2="-4.75" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-800W-1100L-120H-100F-40">
+<package name="SSOP-40-50P-800W-1100L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 11.0mm length, 8.0mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 11.0mm length, 8.0mm width, 1.20mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation HB, R-PDSO-G.&lt;/p&gt;
@@ -9467,7 +9467,7 @@ JEDEC MO-153F, variation HB, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-3.9" x2="5.4" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="3.9" x2="-5.4" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-800W-1100L-200H-100F-40">
+<package name="SSOP-40-50P-800W-1100L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 11.0mm length, 8.0mm width, 2.00mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 11.0mm length, 8.0mm width, 2.00mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation HB, R-PDSO-G.&lt;/p&gt;
@@ -9560,7 +9560,7 @@ JEDEC MO-152C, variation HB, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-3.9" x2="5.4" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="3.9" x2="-5.4" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-800W-1250L-120H-100F-48">
+<package name="SSOP-48-50P-800W-1250L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 12.5mm length, 8.0mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 12.5mm length, 8.0mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation HC, R-PDSO-G.&lt;/p&gt;
@@ -9669,7 +9669,7 @@ JEDEC MO-153F, variation HC, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-3.9" x2="6.15" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="3.9" x2="-6.15" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-800W-1250L-200H-100F-48">
+<package name="SSOP-48-50P-800W-1250L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 12.5mm length, 8.0mm width, 2.00mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 12.5mm length, 8.0mm width, 2.00mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation HC, R-PDSO-G.&lt;/p&gt;
@@ -9778,7 +9778,7 @@ JEDEC MO-152C, variation HC, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-3.9" x2="6.15" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="3.9" x2="-6.15" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-800W-1400L-120H-100F-56">
+<package name="SSOP-56-50P-800W-1400L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 14.0mm length, 8.0mm width, 1.20mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 14.0mm length, 8.0mm width, 1.20mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation HD, R-PDSO-G.&lt;/p&gt;
@@ -9903,7 +9903,7 @@ JEDEC MO-153F, variation HD, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-3.9" x2="6.9" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="3.9" x2="-6.9" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-800W-1400L-200H-100F-56">
+<package name="SSOP-56-50P-800W-1400L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 14.0mm length, 8.0mm width, 2.00mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 14.0mm length, 8.0mm width, 2.00mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation HD, R-PDSO-G.&lt;/p&gt;
@@ -10028,7 +10028,7 @@ JEDEC MO-152C, variation HD, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-3.9" x2="6.9" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="3.9" x2="-6.9" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-800W-970L-120H-100F-36">
+<package name="SSOP-36-50P-800W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 9.7mm length, 8.0mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 9.7mm length, 8.0mm width, 1.20mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation HA, R-PDSO-G.&lt;/p&gt;
@@ -10113,7 +10113,7 @@ JEDEC MO-153F, variation HA, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-3.9" x2="4.75" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="3.9" x2="-4.75" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-800W-970L-200H-100F-36">
+<package name="SSOP-36-50P-800W-970L-200H-100F">
 <description>&lt;b&gt;SSOP (0.50mm pitch, 1.0mm lead length, 9.7mm length, 8.0mm width, 2.00mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.50mm pitch, 1.0mm lead length 9.7mm length, 8.0mm width, 2.00mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation HA, R-PDSO-G.&lt;/p&gt;
@@ -10198,7 +10198,7 @@ JEDEC MO-152C, variation HA, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-3.9" x2="4.75" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="3.9" x2="-4.75" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-889W-1143L-120H-80F-44">
+<package name="SSOP-44-50P-889W-1143L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 11.43mm length, 8.89mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 11.43mm length, 8.89mm width, 1.20mm max height, 44 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-249A, variation BB, R-PDSO-G.&lt;/p&gt;
@@ -10299,7 +10299,7 @@ JEDEC MO-249A, variation BB, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.615" y1="-4.345" x2="5.615" y2="4.345" width="0.2032" layer="21"/>
 <wire x1="5.615" y1="4.345" x2="-5.615" y2="4.345" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-889W-1333L-120H-80F-52">
+<package name="SSOP-52-50P-889W-1333L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 13.33mm length, 8.89mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 13.33mm length, 8.89mm width, 1.20mm max height, 52 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-249A, variation DC, R-PDSO-G.&lt;/p&gt;
@@ -10416,7 +10416,7 @@ JEDEC MO-249A, variation DC, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.565" y1="-4.345" x2="6.565" y2="4.345" width="0.2032" layer="21"/>
 <wire x1="6.565" y1="4.345" x2="-6.565" y2="4.345" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-280W-295L-135H-60F-8">
+<package name="SSOP-8-65P-280W-295L-135H-60F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.60mm lead length, 3.0mm length, 2.8mm width, 1.35mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.60mm lead length 3.0mm length, 2.8mm width, 1.35mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation DA, LSR-PDSO.&lt;/p&gt;
@@ -10449,7 +10449,7 @@ JEDEC MO-187F, variation DA, LSR-PDSO.&lt;/p&gt;
 <wire x1="1.45" y1="-1.375" x2="-1.45" y2="-1.375" width="0.0508" layer="51"/>
 <wire x1="1.45" y1="1.375" x2="-1.45" y2="1.375" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -10478,7 +10478,7 @@ JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
 <wire x1="1.4" y1="-1.4" x2="1.4" y2="1.4" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="1.4" x2="-1.4" y2="1.4" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-300L-120H-100F-8">
+<package name="SSOP-8-65P-440W-300L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -10507,7 +10507,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <wire x1="1.4" y1="-2.1" x2="1.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="2.1" x2="-1.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-300L-200H-100F-8">
+<package name="SSOP-8-65P-440W-300L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 3.0mm length, 4.4mm width, 2.00mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm length, 4.4mm width, 2.00mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -10536,7 +10536,7 @@ JEDEC MO-152C, variation AA, R-PDSO-G.&lt;/p&gt;
 <wire x1="1.4" y1="-2.1" x2="1.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="2.1" x2="-1.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-14">
+<package name="SSOP-14-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
@@ -10577,7 +10577,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-16">
+<package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -10622,7 +10622,7 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-500L-200H-100F-14">
+<package name="SSOP-14-65P-440W-500L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 2.00mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 2.00mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation AB-1, R-PDSO-G.&lt;/p&gt;
@@ -10663,7 +10663,7 @@ JEDEC MO-152C, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-500L-200H-100F-16">
+<package name="SSOP-16-65P-440W-500L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 2.00mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 2.00mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -10708,7 +10708,7 @@ JEDEC MO-152C, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-650L-120H-100F-20">
+<package name="SSOP-20-65P-440W-650L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
@@ -10761,7 +10761,7 @@ JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.15" y1="-2.1" x2="3.15" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.1" x2="-3.15" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-650L-200H-100F-20">
+<package name="SSOP-20-65P-440W-650L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 2.00mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 2.00mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation AC, R-PDSO-G.&lt;/p&gt;
@@ -10814,7 +10814,7 @@ JEDEC MO-152C, variation AC, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.15" y1="-2.1" x2="3.15" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.1" x2="-3.15" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-780L-120H-100F-24">
+<package name="SSOP-24-65P-440W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
@@ -10875,7 +10875,7 @@ JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.1" x2="3.8" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.1" x2="-3.8" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-780L-200H-100F-24">
+<package name="SSOP-24-65P-440W-780L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 2.00mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 2.00mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation AD, R-PDSO-G.&lt;/p&gt;
@@ -10936,7 +10936,7 @@ JEDEC MO-152C, variation AD, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.1" x2="3.8" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.1" x2="-3.8" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-970L-120H-100F-28">
+<package name="SSOP-28-65P-440W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 4.4mm width, 1.20mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 4.4mm width, 1.20mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
@@ -11005,7 +11005,7 @@ JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.1" x2="4.75" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.1" x2="-4.75" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-970L-200H-100F-28">
+<package name="SSOP-28-65P-440W-970L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 4.4mm width, 2.00mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 4.4mm width, 2.00mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation AE, R-PDSO-G.&lt;/p&gt;
@@ -11074,7 +11074,7 @@ JEDEC MO-152C, variation AE, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.1" x2="4.75" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.1" x2="-4.75" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-1100L-120H-100F-32">
+<package name="SSOP-32-65P-610W-1100L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 11.0mm length, 6.1mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 11.0mm length, 6.1mm width, 1.20mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation DC, R-PDSO-G.&lt;/p&gt;
@@ -11151,7 +11151,7 @@ JEDEC MO-153F, variation DC, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-2.95" x2="5.4" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="2.95" x2="-5.4" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-1100L-200H-100F-32">
+<package name="SSOP-32-65P-610W-1100L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 11.0mm length, 6.1mm width, 2.00mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 11.0mm length, 6.1mm width, 2.00mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation DC, R-PDSO-G.&lt;/p&gt;
@@ -11228,7 +11228,7 @@ JEDEC MO-152C, variation DC, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-2.95" x2="5.4" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="2.95" x2="-5.4" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-1250L-120H-100F-36">
+<package name="SSOP-36-65P-610W-1250L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 12.5mm length, 6.1mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 12.5mm length, 6.1mm width, 1.20mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation DD, R-PDSO-G.&lt;/p&gt;
@@ -11313,7 +11313,7 @@ JEDEC MO-153F, variation DD, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-2.95" x2="6.15" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="2.95" x2="-6.15" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-1250L-120H-100F-38">
+<package name="SSOP-38-65P-610W-1250L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 12.5mm length, 6.1mm width, 1.20mm max height, 38 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 12.5mm length, 6.1mm width, 1.20mm max height, 38 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation DD-1, R-PDSO-G.&lt;/p&gt;
@@ -11402,7 +11402,7 @@ JEDEC MO-153F, variation DD-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-2.95" x2="6.15" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="2.95" x2="-6.15" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-1250L-200H-100F-36">
+<package name="SSOP-36-65P-610W-1250L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 12.5mm length, 6.1mm width, 2.00mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 12.5mm length, 6.1mm width, 2.00mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation DD, R-PDSO-G.&lt;/p&gt;
@@ -11487,7 +11487,7 @@ JEDEC MO-152C, variation DD, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-2.95" x2="6.15" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="2.95" x2="-6.15" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-1400L-120H-100F-40">
+<package name="SSOP-40-65P-610W-1400L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 14.0mm length, 6.1mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 14.0mm length, 6.1mm width, 1.20mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation DE, R-PDSO-G.&lt;/p&gt;
@@ -11580,7 +11580,7 @@ JEDEC MO-153F, variation DE, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-2.95" x2="6.9" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="2.95" x2="-6.9" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-1400L-200H-100F-40">
+<package name="SSOP-40-65P-610W-1400L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 14.0mm length, 6.1mm width, 2.00mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 14.0mm length, 6.1mm width, 2.00mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation DE, R-PDSO-G.&lt;/p&gt;
@@ -11673,7 +11673,7 @@ JEDEC MO-152C, variation DE, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-2.95" x2="6.9" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="2.95" x2="-6.9" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-780L-120H-100F-24">
+<package name="SSOP-24-65P-610W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 7.8mm length, 6.1mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm length, 6.1mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation DA, R-PDSO-G.&lt;/p&gt;
@@ -11734,7 +11734,7 @@ JEDEC MO-153F, variation DA, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.95" x2="3.8" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.95" x2="-3.8" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-780L-200H-100F-24">
+<package name="SSOP-24-65P-610W-780L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 7.8mm length, 6.1mm width, 2.00mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm length, 6.1mm width, 2.00mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation DA, R-PDSO-G.&lt;/p&gt;
@@ -11795,7 +11795,7 @@ JEDEC MO-152C, variation DA, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.95" x2="3.8" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.95" x2="-3.8" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-970L-120H-100F-28">
+<package name="SSOP-28-65P-610W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 6.1mm width, 1.20mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 6.1mm width, 1.20mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation DB, R-PDSO-G.&lt;/p&gt;
@@ -11864,7 +11864,7 @@ JEDEC MO-153F, variation DB, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.95" x2="4.75" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.95" x2="-4.75" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-970L-120H-100F-30">
+<package name="SSOP-30-65P-610W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 6.1mm width, 1.20mm max height, 30 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 6.1mm width, 1.20mm max height, 30 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation DB-1, R-PDSO-G.&lt;/p&gt;
@@ -11937,7 +11937,7 @@ JEDEC MO-153F, variation DB-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.95" x2="4.75" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.95" x2="-4.75" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-970L-200H-100F-28">
+<package name="SSOP-28-65P-610W-970L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 6.1mm width, 2.00mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 6.1mm width, 2.00mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation DB, R-PDSO-G.&lt;/p&gt;
@@ -12006,7 +12006,7 @@ JEDEC MO-152C, variation DB, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.95" x2="4.75" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.95" x2="-4.75" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-610W-970L-200H-100F-30">
+<package name="SSOP-30-65P-610W-970L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 6.1mm width, 2.00mm max height, 30 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 6.1mm width, 2.00mm max height, 30 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation DB-1, R-PDSO-G.&lt;/p&gt;
@@ -12079,7 +12079,7 @@ JEDEC MO-152C, variation DB-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.95" x2="4.75" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.95" x2="-4.75" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-800W-1100L-120H-100F-32">
+<package name="SSOP-32-65P-800W-1100L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 11.0mm length, 8.0mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 11.0mm length, 8.0mm width, 1.20mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation GB, R-PDSO-G.&lt;/p&gt;
@@ -12156,7 +12156,7 @@ JEDEC MO-153F, variation GB, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-3.9" x2="5.4" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="3.9" x2="-5.4" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-800W-1100L-200H-100F-32">
+<package name="SSOP-32-65P-800W-1100L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 11.0mm length, 8.0mm width, 2.00mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 11.0mm length, 8.0mm width, 2.00mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation GB, R-PDSO-G.&lt;/p&gt;
@@ -12233,7 +12233,7 @@ JEDEC MO-152C, variation GB, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.4" y1="-3.9" x2="5.4" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="5.4" y1="3.9" x2="-5.4" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-800W-1250L-120H-100F-36">
+<package name="SSOP-36-65P-800W-1250L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 12.5mm length, 8.0mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 12.5mm length, 8.0mm width, 1.20mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation GC, R-PDSO-G.&lt;/p&gt;
@@ -12318,7 +12318,7 @@ JEDEC MO-153F, variation GC, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-3.9" x2="6.15" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="3.9" x2="-6.15" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-800W-1250L-200H-100F-36">
+<package name="SSOP-36-65P-800W-1250L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 12.5mm length, 8.0mm width, 2.00mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 12.5mm length, 8.0mm width, 2.00mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation GC, R-PDSO-G.&lt;/p&gt;
@@ -12403,7 +12403,7 @@ JEDEC MO-152C, variation GC, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.15" y1="-3.9" x2="6.15" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.15" y1="3.9" x2="-6.15" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-800W-1400L-120H-100F-40">
+<package name="SSOP-40-65P-800W-1400L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 14.0mm length, 8.0mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 14.0mm length, 8.0mm width, 1.20mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation GD, R-PDSO-G.&lt;/p&gt;
@@ -12496,7 +12496,7 @@ JEDEC MO-153F, variation GD, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-3.9" x2="6.9" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="3.9" x2="-6.9" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-800W-1400L-200H-100F-40">
+<package name="SSOP-40-65P-800W-1400L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 14.0mm length, 8.0mm width, 2.00mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 14.0mm length, 8.0mm width, 2.00mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation GD, R-PDSO-G.&lt;/p&gt;
@@ -12589,7 +12589,7 @@ JEDEC MO-152C, variation GD, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.9" y1="-3.9" x2="6.9" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="3.9" x2="-6.9" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-800W-970L-120H-100F-28">
+<package name="SSOP-28-65P-800W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 8.0mm width, 1.20mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 8.0mm width, 1.20mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation GA, R-PDSO-G.&lt;/p&gt;
@@ -12658,7 +12658,7 @@ JEDEC MO-153F, variation GA, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-3.9" x2="4.75" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="3.9" x2="-4.75" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-800W-970L-200H-100F-28">
+<package name="SSOP-28-65P-800W-970L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 8.0mm width, 2.00mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 8.0mm width, 2.00mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation GA, R-PDSO-G.&lt;/p&gt;
@@ -12727,7 +12727,7 @@ JEDEC MO-152C, variation GA, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-3.9" x2="4.75" y2="3.9" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="3.9" x2="-4.75" y2="3.9" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-889W-1079L-120H-80F-32">
+<package name="SSOP-32-65P-889W-1079L-120H-80F">
 <description>&lt;b&gt;TSOP (0.65mm pitch, 0.8mm lead length, 10.79mm length, 8.89mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.65mm pitch, 0.8mm lead length 10.79mm length, 8.89mm width, 1.20mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-249A, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -12804,7 +12804,7 @@ JEDEC MO-249A, variation AA, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.295" y1="-4.345" x2="5.295" y2="4.345" width="0.2032" layer="21"/>
 <wire x1="5.295" y1="4.345" x2="-5.295" y2="4.345" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-889W-1206L-120H-80F-36">
+<package name="SSOP-36-65P-889W-1206L-120H-80F">
 <description>&lt;b&gt;TSOP (0.65mm pitch, 0.8mm lead length, 12.06mm length, 8.89mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.65mm pitch, 0.8mm lead length 12.06mm length, 8.89mm width, 1.20mm max height, 36 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-249A, variation CA, R-PDSO-G.&lt;/p&gt;
@@ -12889,7 +12889,7 @@ JEDEC MO-249A, variation CA, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.93" y1="-4.345" x2="5.93" y2="4.345" width="0.2032" layer="21"/>
 <wire x1="5.93" y1="4.345" x2="-5.93" y2="4.345" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-889W-1333L-120H-80F-40">
+<package name="SSOP-40-65P-889W-1333L-120H-80F">
 <description>&lt;b&gt;TSOP (0.65mm pitch, 0.8mm lead length, 13.33mm length, 8.89mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.65mm pitch, 0.8mm lead length 13.33mm length, 8.89mm width, 1.20mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-249A, variation DB, R-PDSO-G.&lt;/p&gt;
@@ -12982,7 +12982,7 @@ JEDEC MO-249A, variation DB, R-PDSO-G.&lt;/p&gt;
 <wire x1="6.565" y1="-4.345" x2="6.565" y2="4.345" width="0.2032" layer="21"/>
 <wire x1="6.565" y1="4.345" x2="-6.565" y2="4.345" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-80P-889W-1143L-120H-80F-28">
+<package name="SSOP-28-80P-889W-1143L-120H-80F">
 <description>&lt;b&gt;TSOP (0.80mm pitch, 0.8mm lead length, 11.43mm length, 8.89mm width, 1.20mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.80mm pitch, 0.8mm lead length 11.43mm length, 8.89mm width, 1.20mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-249A, variation BA, R-PDSO-G.&lt;/p&gt;
@@ -13051,7 +13051,7 @@ JEDEC MO-249A, variation BA, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.615" y1="-4.345" x2="5.615" y2="4.345" width="0.2032" layer="21"/>
 <wire x1="5.615" y1="4.345" x2="-5.615" y2="4.345" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-80P-889W-1333L-120H-80F-32">
+<package name="SSOP-32-80P-889W-1333L-120H-80F">
 <description>&lt;b&gt;TSOP (0.80mm pitch, 0.8mm lead length, 13.33mm length, 8.89mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.80mm pitch, 0.8mm lead length 13.33mm length, 8.89mm width, 1.20mm max height, 32 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-249A, variation DA, R-PDSO-G.&lt;/p&gt;

--- a/ref-packages-tqfp.lbr
+++ b/ref-packages-tqfp.lbr
@@ -65,7 +65,7 @@
 <description>&lt;b&gt;Maintenence Library&lt;/b&gt;&lt;p&gt;
 NOTE: This library is used to globally update common IC packages in all other libraries.&lt;p&gt;</description>
 <packages>
-<package name="TQFP-100P-1000W-1000L-120H-36">
+<package name="TQFP-36-100P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 36 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACA, T-PQFP-G.
@@ -151,7 +151,7 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-100P-1000W-1000L-120H-36-EP">
+<package name="TQFP-36-100P-1000W-1000L-120H-EP">
 <description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 36 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACA-HD, HT-PQFP-G.
@@ -237,7 +237,7 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-100P-1200W-1200L-120H-44">
+<package name="TQFP-44-100P-1200W-1200L-120H">
 <description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ADA, T-PQFP-G.
@@ -339,7 +339,7 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-100P-1200W-1200L-120H-44-EP">
+<package name="TQFP-44-100P-1200W-1200L-120H-EP">
 <description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ADA-HD, HT-PQFP-G.
@@ -441,7 +441,7 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-100P-1400W-1400L-120H-52">
+<package name="TQFP-52-100P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEA, T-PQFP-G.
@@ -559,7 +559,7 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-100P-1400W-1400L-120H-52-EP">
+<package name="TQFP-52-100P-1400W-1400L-120H-EP">
 <description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEA-HD, HT-PQFP-G.
@@ -677,7 +677,7 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-1000W-1000L-120H-80">
+<package name="TQFP-80-40P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACE, T-PQFP-G.
@@ -851,7 +851,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-1000W-1000L-120H-80-EP">
+<package name="TQFP-80-40P-1000W-1000L-120H-EP">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACE-HD, HT-PQFP-G.
@@ -1025,7 +1025,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-1200W-1200L-120H-100">
+<package name="TQFP-100-40P-1200W-1200L-120H">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ADE, T-PQFP-G.
@@ -1239,7 +1239,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-1200W-1200L-120H-100-EP">
+<package name="TQFP-100-40P-1200W-1200L-120H-EP">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ADE-HD, HT-PQFP-G.
@@ -1453,7 +1453,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-1400W-1400L-120H-120">
+<package name="TQFP-120-40P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 120 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEE, T-PQFP-G.
@@ -1707,7 +1707,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-1400W-1400L-120H-120-EP">
+<package name="TQFP-120-40P-1400W-1400L-120H-EP">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 120 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEE-HD, HT-PQFP-G.
@@ -1961,7 +1961,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-2000W-2000L-120H-176">
+<package name="TQFP-176-40P-2000W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 176 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFC, T-PQFP-G.
@@ -2327,7 +2327,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-2000W-2000L-120H-176-EP">
+<package name="TQFP-176-40P-2000W-2000L-120H-EP">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 176 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFC-HD, HT-PQFP-G.
@@ -2693,7 +2693,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-2400W-2400L-120H-216">
+<package name="TQFP-216-40P-2400W-2400L-120H">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.20mm max height, 216 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.20mm max height, 216 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AGB, T-PQFP-G.
@@ -3139,7 +3139,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24m
 <wire x1="11.9" y1="-11.9" x2="11.9" y2="11.9" width="0.2032" layer="21"/>
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-2400W-2400L-120H-216-EP">
+<package name="TQFP-216-40P-2400W-2400L-120H-EP">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.20mm max height, 216 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.20mm max height, 216 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AGB-HD, HT-PQFP-G.
@@ -3585,7 +3585,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24m
 <wire x1="11.9" y1="-11.9" x2="11.9" y2="11.9" width="0.2032" layer="21"/>
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-400W-400L-120H-32">
+<package name="TQFP-32-40P-400W-400L-120H">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.20mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AKC, T-PQFP-G.
@@ -3663,7 +3663,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm 
 <wire x1="1.9" y1="-1.9" x2="1.9" y2="1.9" width="0.2032" layer="21"/>
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-400W-400L-120H-32-EP">
+<package name="TQFP-32-40P-400W-400L-120H-EP">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.20mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AKC-HD, HT-PQFP-G.
@@ -3741,7 +3741,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm 
 <wire x1="1.9" y1="-1.9" x2="1.9" y2="1.9" width="0.2032" layer="21"/>
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-500W-500L-120H-40">
+<package name="TQFP-40-40P-500W-500L-120H">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.20mm max height, 40 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AAB, T-PQFP-G.
@@ -3835,7 +3835,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm 
 <wire x1="2.4" y1="-2.4" x2="2.4" y2="2.4" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-500W-500L-120H-40-EP">
+<package name="TQFP-40-40P-500W-500L-120H-EP">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.20mm max height, 40 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AAB-HD, HT-PQFP-G.
@@ -3929,7 +3929,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm 
 <wire x1="2.4" y1="-2.4" x2="2.4" y2="2.4" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-700W-700L-120H-64">
+<package name="TQFP-64-40P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABD, T-PQFP-G.
@@ -4071,7 +4071,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-40P-700W-700L-120H-64-EP">
+<package name="TQFP-64-40P-700W-700L-120H-EP">
 <description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABD-HD, HT-PQFP-G.
@@ -4213,7 +4213,7 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1000W-1000L-120H-64">
+<package name="TQFP-64-50P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.
@@ -4355,7 +4355,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1000W-1000L-120H-64-EP">
+<package name="TQFP-64-50P-1000W-1000L-120H-EP">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACD-HD, HT-PQFP-G.
@@ -4497,7 +4497,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1200W-1200L-120H-80">
+<package name="TQFP-80-50P-1200W-1200L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ADD, T-PQFP-G.
@@ -4671,7 +4671,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1200W-1200L-120H-80-EP">
+<package name="TQFP-80-50P-1200W-1200L-120H-EP">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ADD-HD, HT-PQFP-G.
@@ -4845,7 +4845,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -5059,7 +5059,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-1400L-120H-100-EP">
+<package name="TQFP-100-50P-1400W-1400L-120H-EP">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED-HD, HT-PQFP-G.
@@ -5273,7 +5273,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-2000L-120H-128">
+<package name="TQFP-128-50P-1400W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.20mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.20mm max height, 128 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AHB, T-PQFP-G.
@@ -5543,7 +5543,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14m
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-1400W-2000L-120H-128-EP">
+<package name="TQFP-128-50P-1400W-2000L-120H-EP">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.20mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.20mm max height, 128 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AHB-HD, HT-PQFP-G.
@@ -5813,7 +5813,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14m
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-2000W-2000L-120H-144">
+<package name="TQFP-144-50P-2000W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
@@ -6115,7 +6115,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-2000W-2000L-120H-144-EP">
+<package name="TQFP-144-50P-2000W-2000L-120H-EP">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFB-HD, HT-PQFP-G.
@@ -6417,7 +6417,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-2400W-2400L-120H-176">
+<package name="TQFP-176-50P-2400W-2400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.20mm max height, 176 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AGA, T-PQFP-G.
@@ -6783,7 +6783,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24m
 <wire x1="11.9" y1="-11.9" x2="11.9" y2="11.9" width="0.2032" layer="21"/>
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-2400W-2400L-120H-176-EP">
+<package name="TQFP-176-50P-2400W-2400L-120H-EP">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.20mm max height, 176 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AGA-HD, HT-PQFP-G.
@@ -7149,7 +7149,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24m
 <wire x1="11.9" y1="-11.9" x2="11.9" y2="11.9" width="0.2032" layer="21"/>
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-400W-400L-120H-24">
+<package name="TQFP-24-50P-400W-400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.20mm max height, 24 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AKB, T-PQFP-G.
@@ -7211,7 +7211,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm 
 <wire x1="1.9" y1="-1.9" x2="1.9" y2="1.9" width="0.2032" layer="21"/>
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-400W-400L-120H-24-EP">
+<package name="TQFP-24-50P-400W-400L-120H-EP">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.20mm max height, 24 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AKB-HD, HT-PQFP-G.
@@ -7273,7 +7273,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm 
 <wire x1="1.9" y1="-1.9" x2="1.9" y2="1.9" width="0.2032" layer="21"/>
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-500W-500L-120H-32">
+<package name="TQFP-32-50P-500W-500L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.20mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AAA, T-PQFP-G.
@@ -7351,7 +7351,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm 
 <wire x1="2.4" y1="-2.4" x2="2.4" y2="2.4" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-500W-500L-120H-32-EP">
+<package name="TQFP-32-50P-500W-500L-120H-EP">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.20mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AAA-HD, HT-PQFP-G.
@@ -7429,7 +7429,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm 
 <wire x1="2.4" y1="-2.4" x2="2.4" y2="2.4" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-700W-700L-120H-48">
+<package name="TQFP-48-50P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
@@ -7539,7 +7539,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-50P-700W-700L-120H-48-EP">
+<package name="TQFP-48-50P-700W-700L-120H-EP">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABC-HD, HT-PQFP-G.
@@ -7649,7 +7649,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-1000W-1000L-120H-52">
+<package name="TQFP-52-65P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACC, T-PQFP-G.
@@ -7767,7 +7767,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-1000W-1000L-120H-52-EP">
+<package name="TQFP-52-65P-1000W-1000L-120H-EP">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACC-HD, HT-PQFP-G.
@@ -7885,7 +7885,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-1200W-1200L-120H-64">
+<package name="TQFP-64-65P-1200W-1200L-120H">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ADC, T-PQFP-G.
@@ -8027,7 +8027,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-1200W-1200L-120H-64-EP">
+<package name="TQFP-64-65P-1200W-1200L-120H-EP">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ADC-HD, HT-PQFP-G.
@@ -8169,7 +8169,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-1400W-1400L-120H-80">
+<package name="TQFP-80-65P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEC, T-PQFP-G.
@@ -8343,7 +8343,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-1400W-1400L-120H-80-EP">
+<package name="TQFP-80-65P-1400W-1400L-120H-EP">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEC-HD, HT-PQFP-G.
@@ -8517,7 +8517,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-1400W-2000L-120H-100">
+<package name="TQFP-100-65P-1400W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AHA, T-PQFP-G.
@@ -8731,7 +8731,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14m
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-1400W-2000L-120H-100-EP">
+<package name="TQFP-100-65P-1400W-2000L-120H-EP">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AHA-HD, HT-PQFP-G.
@@ -8945,7 +8945,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14m
 <wire x1="9.9" y1="-6.9" x2="9.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-2000W-2000L-120H-112">
+<package name="TQFP-112-65P-2000W-2000L-120H">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 112 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFA, T-PQFP-G.
@@ -9183,7 +9183,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-2000W-2000L-120H-112-EP">
+<package name="TQFP-112-65P-2000W-2000L-120H-EP">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 112 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AFA-HD, HT-PQFP-G.
@@ -9421,7 +9421,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-400W-400L-120H-20">
+<package name="TQFP-20-65P-400W-400L-120H">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.20mm max height, 20 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AKA, T-PQFP-G.
@@ -9475,7 +9475,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm 
 <wire x1="1.9" y1="-1.9" x2="1.9" y2="1.9" width="0.2032" layer="21"/>
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-400W-400L-120H-20-EP">
+<package name="TQFP-20-65P-400W-400L-120H-EP">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.20mm max height, 20 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AKA-HD, HT-PQFP-G.
@@ -9529,7 +9529,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm 
 <wire x1="1.9" y1="-1.9" x2="1.9" y2="1.9" width="0.2032" layer="21"/>
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-700W-700L-120H-40">
+<package name="TQFP-40-65P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 40 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABB, T-PQFP-G.
@@ -9623,7 +9623,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-65P-700W-700L-120H-40-EP">
+<package name="TQFP-40-65P-700W-700L-120H-EP">
 <description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 40 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABB-HD, HT-PQFP-G.
@@ -9717,7 +9717,7 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1000W-1000L-120H-44">
+<package name="TQFP-44-80P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
@@ -9819,7 +9819,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1000W-1000L-120H-44-EP">
+<package name="TQFP-44-80P-1000W-1000L-120H-EP">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACB-HD, HT-PQFP-G.
@@ -9921,7 +9921,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1200W-1200L-120H-52">
+<package name="TQFP-52-80P-1200W-1200L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ADB, T-PQFP-G.
@@ -10039,7 +10039,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1200W-1200L-120H-52-EP">
+<package name="TQFP-52-80P-1200W-1200L-120H-EP">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ADB-HD, HT-PQFP-G.
@@ -10157,7 +10157,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1400W-1400L-120H-64">
+<package name="TQFP-64-80P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.
@@ -10299,7 +10299,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1400W-1400L-120H-64-EP">
+<package name="TQFP-64-80P-1400W-1400L-120H-EP">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEB-HD, HT-PQFP-G.
@@ -10441,7 +10441,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-700W-700L-120H-32">
+<package name="TQFP-32-80P-700W-700L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.
@@ -10519,7 +10519,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="-3.4" x2="3.4" y2="3.4" width="0.2032" layer="21"/>
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-700W-700L-120H-32-EP">
+<package name="TQFP-32-80P-700W-700L-120H-EP">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ABA-HD, HT-PQFP-G.

--- a/ref-packages.lbr
+++ b/ref-packages.lbr
@@ -393,7 +393,7 @@ Exposed pad variation BC</description>
 <vertex x="-1.7" y="-2.15"/>
 </polygon>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 

--- a/relay.lbr
+++ b/relay.lbr
@@ -5499,7 +5499,7 @@ Form-A</description>
 <text x="-8.35" y="-3" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="0.35" y="6" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 </package>
-<package name="DIP-300-6">
+<package name="DIP-6-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="3.81" y1="1.905" x2="-3.81" y2="1.905" width="0.2032" layer="21"/>
@@ -5517,7 +5517,7 @@ Form-A</description>
 <text x="-2.54" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-4.445" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -10404,7 +10404,7 @@ source: http://www.mew-europe.com/..  pti_en.pdf</description>
 <gate name="G$1" symbol="PHOTO-RELAY-2LED-2D1S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="D1" pad="6"/>
@@ -10462,7 +10462,7 @@ source: http://www.mew-europe.com/..  pti_en.pdf</description>
 <gate name="G$1" symbol="PHOTO-RELAY-2LED-2D1S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="D1" pad="6"/>
@@ -10484,7 +10484,7 @@ source: http://www.mew-europe.com/..  pti_en.pdf</description>
 <gate name="-2" symbol="PHOTO-RELAY-2S" x="2.54" y="-7.62" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="-1" pin="A" pad="1"/>
 <connect gate="-1" pin="D1" pad="8"/>
@@ -11539,7 +11539,7 @@ International Rectifier</description>
 <gate name="G$1" symbol="PHOTO-RELAY-1S2D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="D1" pad="6"/>
@@ -11572,7 +11572,7 @@ International Rectifier</description>
 <gate name="G$1" symbol="PHOTOMOS-2D2S-NCNO" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="2"/>
 <connect gate="G$1" pin="K" pad="3"/>
@@ -11768,7 +11768,7 @@ American Zettler, Inc.</description>
 <gate name="G$1" symbol="PHOTOTRIAC-Z" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="DS1" pad="6"/>
@@ -11927,7 +11927,7 @@ Single-Pole, Normally Closed</description>
 <gate name="G$1" symbol="PHOTO-RELAY-1S2D_NC" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="D1" pad="6"/>
@@ -12002,7 +12002,7 @@ Single-Pole, Normally Open</description>
 <gate name="G$1" symbol="PHOTO-RELAY-2D1S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-6">
+<device name="" package="DIP-6-254P-762W">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="D1" pad="6"/>

--- a/resistor-bourns.lbr
+++ b/resistor-bourns.lbr
@@ -74,7 +74,7 @@
 <description>&lt;b&gt;Bourns Resistor Networks&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -321,7 +321,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <rectangle x1="-2.765" y1="2.8361" x2="-2.315" y2="3.8111" layer="51"/>
 <rectangle x1="-4.035" y1="2.8361" x2="-3.585" y2="3.8111" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -1525,7 +1525,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="08R" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
@@ -1554,7 +1554,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G" symbol="R1NVXX" x="0" y="-17.78" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="1" pad="1"/>
 <connect gate="A" pin="2" pad="8"/>
@@ -1577,7 +1577,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="15R" x="0" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -1622,7 +1622,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="O" symbol="R1NVXX" x="0" y="-55.88" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1" pad="1"/>
 <connect gate="A" pin="2" pad="16"/>
@@ -1653,7 +1653,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="B" symbol="RX08" x="0" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="B" pin="1" pad="1"/>
 <connect gate="B" pin="10" pad="10"/>
@@ -1691,7 +1691,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="H" symbol="R1NV" x="0" y="-20.32" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1" pad="1"/>
 <connect gate="A" pin="2" pad="16"/>

--- a/resistor-dil.lbr
+++ b/resistor-dil.lbr
@@ -74,7 +74,7 @@
 <description>&lt;b&gt;Resistors in DIL Packages&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -100,7 +100,7 @@
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -611,7 +611,7 @@
 <gate name="1" symbol="15R" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="1" pin="1" pad="1"/>
 <connect gate="1" pin="10" pad="10"/>
@@ -649,7 +649,7 @@
 <gate name="H" symbol="R1PV" x="0" y="-15.24" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1" pad="1"/>
 <connect gate="A" pin="2" pad="16"/>
@@ -687,7 +687,7 @@
 <gate name="H" symbol="R1NV" x="0" y="-12.7" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1" pad="1"/>
 <connect gate="A" pin="2" pad="16"/>
@@ -732,7 +732,7 @@
 <gate name="O" symbol="R1NVXX" x="35.56" y="12.7" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="1" pad="1"/>
 <connect gate="A" pin="2" pad="16"/>
@@ -763,7 +763,7 @@
 <gate name="A" symbol="13R" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="1" pad="1"/>
 <connect gate="A" pin="10" pad="10"/>
@@ -804,7 +804,7 @@
 <gate name="M" symbol="R1NVXX" x="20.32" y="-2.54" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="1" pad="1"/>
 <connect gate="A" pin="2" pad="14"/>
@@ -839,7 +839,7 @@
 <gate name="G" symbol="R1NV" x="0" y="-30.48" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="1" pad="1"/>
 <connect gate="A" pin="2" pad="14"/>
@@ -874,7 +874,7 @@
 <gate name="G" symbol="R1PV" x="0" y="-12.7" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="1" pad="1"/>
 <connect gate="A" pin="2" pad="14"/>

--- a/rf-micro-devices.lbr
+++ b/rf-micro-devices.lbr
@@ -78,7 +78,7 @@
 http://www.rfmd.com&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="LQFP-50P-500W-500L-160H-32">
+<package name="LQFP-32-50P-500W-500L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.60mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BAA, L-PQFP-G.
@@ -988,7 +988,7 @@ body 2x2mm, pitch 0.65mm</description>
 <gate name="B" symbol="RF2915P" x="-5.08" y="-63.5" addlevel="must"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-500W-500L-160H-32">
+<device name="" package="LQFP-32-50P-500W-500L-160H">
 <connects>
 <connect gate="A" pin="CBP1-" pad="15"/>
 <connect gate="A" pin="CBP2+" pad="18"/>
@@ -1036,7 +1036,7 @@ body 2x2mm, pitch 0.65mm</description>
 <gate name="B" symbol="RF2915P" x="-5.08" y="-63.5" addlevel="must"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-500W-500L-160H-32">
+<device name="" package="LQFP-32-50P-500W-500L-160H">
 <connects>
 <connect gate="A" pin="CBP1-" pad="15"/>
 <connect gate="A" pin="CBP2+" pad="18"/>

--- a/silicon-labs.lbr
+++ b/silicon-labs.lbr
@@ -76,7 +76,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="TQFP-50P-1400W-1400L-120H-100">
+<package name="TQFP-100-50P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
@@ -347,7 +347,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <rectangle x1="-0.25" y1="-1.25" x2="0.25" y2="-0.75" layer="31"/>
 <rectangle x1="0.75" y1="-1.25" x2="1.25" y2="-0.75" layer="31"/>
 </package>
-<package name="LQFP-80P-700W-700L-160H-32">
+<package name="LQFP-32-80P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.
@@ -858,7 +858,7 @@ C8051F120/1/2/3/4/5/6/7</description>
 <gate name="G$1" symbol="CP8051F120" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1400W-1400L-120H-100">
+<device name="" package="TQFP-100-50P-1400W-1400L-120H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="!RST!/WR/P0.7" pad="55"/>
@@ -975,7 +975,7 @@ C8051F310/1/2/3/4/5/6/7 CROSSBAR</description>
 <gate name="G$1" symbol="8051F310/2/4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-80P-700W-700L-160H-32">
+<device name="" package="LQFP-32-80P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!/C2CK" pad="5"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -1072,7 +1072,7 @@ Single/Dual Battery, 0.9-3.6 V, 64/32 kB, smaRTClock, 10-Bit ADC MCU</descriptio
 <gate name="G$1" symbol="C8051F920/30" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-80P-700W-700L-160H-32">
+<device name="" package="LQFP-32-80P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!/C2CK" pad="6"/>
 <connect gate="G$1" pin="DCEN" pad="4"/>

--- a/st-microelectronics.lbr
+++ b/st-microelectronics.lbr
@@ -517,7 +517,7 @@ http://www.st.com&lt;p&gt;
 <vertex x="-15.875" y="17.145"/>
 </polygon>
 </package>
-<package name="LQFP-50P-2000W-2000L-160H-144">
+<package name="LQFP-144-50P-2000W-2000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
@@ -917,7 +917,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <rectangle x1="-12.3101" y1="6.54" x2="-11.8199" y2="8.0599" layer="51"/>
 <rectangle x1="-13.5801" y1="6.54" x2="-13.0899" y2="8.0599" layer="51"/>
 </package>
-<package name="QFP-65P-2800W-2800L-409H-160F-144">
+<package name="QFP-144-65P-2800W-2800L-410H-160F">
 <description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 4.10mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-022B, variation DC-1, PQFP-G.
@@ -1499,7 +1499,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <rectangle x1="-1.75" y1="-2.5" x2="-1.25" y2="-2.25" layer="51"/>
 <rectangle x1="1.25" y1="-2.5" x2="1.75" y2="-2.25" layer="51"/>
 </package>
-<package name="SSOP-50P-1840W-1000L-120H-80F-40">
+<package name="SSOP-40-50P-1840W-1000L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 10.0mm length, 18.4mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 10.0mm length, 18.4mm width, 1.20mm max height, 40 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation CD, R-PDSO-G.&lt;/p&gt;
@@ -1592,7 +1592,7 @@ JEDEC MO-142D, variation CD, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.9" y1="-9.1" x2="4.9" y2="9.1" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="9.1" x2="-4.9" y2="9.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-50P-1840W-1200L-120H-80F-48">
+<package name="SSOP-48-50P-1840W-1200L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4mm width, 1.20mm max height, 48 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
@@ -1701,7 +1701,7 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.9" y1="-9.1" x2="5.9" y2="9.1" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="9.1" x2="-5.9" y2="9.1" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1000W-1000L-120H-44">
+<package name="TQFP-44-80P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
@@ -1824,7 +1824,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <wire x1="1" y1="-0.625" x2="-1" y2="-0.625" width="0.2032" layer="51"/>
 <wire x1="1" y1="0.625" x2="1" y2="-0.625" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -1844,7 +1844,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -1872,7 +1872,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -1902,7 +1902,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -1934,7 +1934,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-24">
+<package name="DIP-24-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="15.24" y1="-1.905" x2="15.24" y2="1.905" width="0.2032" layer="21"/>
@@ -1970,7 +1970,7 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -2004,7 +2004,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -2061,7 +2061,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -2126,7 +2126,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1790L-265H-140F-28">
+<package name="SOP-28-127P-750W-1790L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
@@ -2199,7 +2199,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-840W-1790L-305H-180F-28">
+<package name="SOP-28-127P-840W-1790L-305H-180F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 3.05mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
 8.40mm body width, 3.05mm max height, 28 leads.
@@ -2269,7 +2269,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body l
 <wire x1="8.85" y1="-4.1" x2="8.85" y2="4.1" width="0.2032" layer="21"/>
 <wire x1="8.85" y1="4.1" x2="-8.85" y2="4.1" width="0.2032" layer="21"/>&gt;
 </package>
-<package name="SSOP-65P-440W-300L-120H-100F-8">
+<package name="SSOP-8-65P-440W-300L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -3895,7 +3895,7 @@ body 2x2x1mm</description>
 <gate name="L297" symbol="L297" x="-2.54" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="L297" pin="A" pad="4"/>
 <connect gate="L297" pin="B" pad="6"/>
@@ -3960,7 +3960,7 @@ body 2x2x1mm</description>
 <gate name="G$1" symbol="L293D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="1-2EN" pad="1"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -3996,7 +3996,7 @@ body 2x2x1mm</description>
 <gate name="-4" symbol="D-2-1" x="10.16" y="-10.16" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-1" pin="K" pad="1"/>
 <connect gate="-2" pin="K" pad="2"/>
@@ -4025,7 +4025,7 @@ body 2x2x1mm</description>
 <gate name="-6" symbol="D-2-1" x="7.62" y="-15.24" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-1" pin="K" pad="5"/>
 <connect gate="-2" pin="K" pad="4"/>
@@ -4586,7 +4586,7 @@ Siemens compatible</description>
 <gate name="P3" symbol="F168_P3" x="35.56" y="-2.54" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="QFP-65P-2800W-2800L-409H-160F-144">
+<device name="" package="QFP-144-65P-2800W-2800L-410H-160F">
 <connects>
 <connect gate="P0" pin="P0H0/AD8" pad="108"/>
 <connect gate="P0" pin="P0H1/AD9" pad="111"/>
@@ -4754,7 +4754,7 @@ Siemens compatible</description>
 <gate name="NC5" symbol="NC" x="30.48" y="-20.32" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1200L-120H-80F-48">
+<device name="" package="SSOP-48-50P-1840W-1200L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!BYTE" pad="47"/>
 <connect gate="G$1" pin="!CE" pad="26"/>
@@ -4883,7 +4883,7 @@ SPI bus, 1 K x 8</description>
 <gate name="P" symbol="PWRN" x="12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!HOLD" pad="7"/>
 <connect gate="G$1" pin="!S" pad="1"/>
@@ -4908,7 +4908,7 @@ SPI bus, 1 K x 8</description>
 <gate name="P" symbol="PWRN" x="12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!HOLD" pad="7"/>
 <connect gate="G$1" pin="!S" pad="1"/>
@@ -4932,7 +4932,7 @@ SPI bus, 1 K x 8</description>
 <gate name="B" symbol="STA013PW" x="-2.54" y="-25.4" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="!RESET" pad="26"/>
 <connect gate="A" pin="!SRC_INT" pad="8"/>
@@ -4992,7 +4992,7 @@ SPI bus, 1 K x 8</description>
 <gate name="NC16" symbol="NC" x="25.4" y="-30.48" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="A" pin="!RESET" pad="25"/>
 <connect gate="A" pin="!SRC_INT" pad="40"/>
@@ -5053,7 +5053,7 @@ with ADPCM capability</description>
 <gate name="B" symbol="STA015PW" x="48.26" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="!RESET" pad="26"/>
 <connect gate="A" pin="!TESTEN" pad="24"/>
@@ -5102,7 +5102,7 @@ with ADPCM capability</description>
 <gate name="NC4" symbol="NC" x="58.42" y="-40.64" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="A" pin="!RESET" pad="25"/>
 <connect gate="A" pin="!TESTEN" pad="22"/>
@@ -5162,7 +5162,7 @@ Satellite receiver</description>
 <gate name="G$1" symbol="STV5730A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="21"/>
 <connect gate="G$1" pin="AVDD" pad="5"/>
@@ -5229,7 +5229,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="G$1" symbol="L620X" x="0" y="0"/>
 </gates>
 <devices>
-<device name="1" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="1" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CBOOT1" pad="12"/>
 <connect gate="G$1" pin="CBOOT2" pad="19"/>
@@ -5252,7 +5252,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="2" package="DIP-300-18">
+<device name="2" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="CBOOT1" pad="11"/>
 <connect gate="G$1" pin="CBOOT2" pad="17"/>
@@ -5338,7 +5338,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="G$1" symbol="L6204" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="BOOTSTRAP" pad="11"/>
 <connect gate="G$1" pin="ENABLE1" pad="3"/>
@@ -5365,7 +5365,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DD" package="SOP-127P-750W-1790L-265H-140F-28">
+<device name="DD" package="SOP-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="BOOTSTRAP" pad="15"/>
 <connect gate="G$1" pin="ENABLE1" pad="3"/>
@@ -5435,7 +5435,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="P5" symbol="GND" x="30.48" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="5"/>
 <connect gate="G$1" pin="D2" pad="7"/>
@@ -5475,7 +5475,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="P5" symbol="GND" x="33.02" y="-7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="D1" pad="17"/>
 <connect gate="G$1" pin="D2" pad="16"/>
@@ -5534,7 +5534,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="P1" symbol="L6205" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="P1" pin="EN_A" pad="20"/>
 <connect gate="P1" pin="EN_B" pad="11"/>
@@ -5588,7 +5588,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="P1" pin="EN_A" pad="20"/>
 <connect gate="P1" pin="EN_B" pad="11"/>
@@ -5654,7 +5654,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="EN_A" pad="23"/>
 <connect gate="G$1" pin="EN_B" pad="14"/>
@@ -5685,7 +5685,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-24">
+<device name="N" package="DIP-24-254P-762W">
 <connects>
 <connect gate="G$1" pin="EN_A" pad="23"/>
 <connect gate="G$1" pin="EN_B" pad="14"/>
@@ -5756,7 +5756,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="G3" symbol="GND" x="10.16" y="-22.86" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="COMP-IN" pad="10"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -5791,7 +5791,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="G3" symbol="GND" x="5.08" y="-22.86" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="P" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="." pin="ALARM" pad="14"/>
 <connect gate="." pin="COMP-IN" pad="12"/>
@@ -5867,7 +5867,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="G$1" symbol="M29F032" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1000L-120H-80F-40">
+<device name="" package="SSOP-40-50P-1840W-1000L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!CE" pad="9"/>
 <connect gate="G$1" pin="!OE" pad="37"/>
@@ -5923,7 +5923,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="G$1" symbol="M41ST95W" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-305H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-305H-180F">
 <connects>
 <connect gate="G$1" pin="!E!" pad="27"/>
 <connect gate="G$1" pin="!ECON!" pad="15"/>
@@ -5956,7 +5956,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="G$1" symbol="M41S94" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-840W-1790L-305H-180F-28">
+<device name="" package="SOP-28-127P-840W-1790L-305H-180F">
 <connects>
 <connect gate="G$1" pin="!E!" pad="27"/>
 <connect gate="G$1" pin="!IRQ!/FT/OUT" pad="26"/>
@@ -6005,7 +6005,7 @@ FOR USB DOWNSTREAM PORTS</description>
 <gate name="G$1" symbol="M25PE20" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!S!" pad="1"/>
 <connect gate="G$1" pin="C" pad="6"/>
@@ -6029,7 +6029,7 @@ FOR USB DOWNSTREAM PORTS</description>
 <gate name="G$1" symbol="L6920" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="D" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!LBO!" pad="3"/>
 <connect gate="G$1" pin="!SHDN!" pad="5"/>

--- a/telefunken.lbr
+++ b/telefunken.lbr
@@ -88,7 +88,7 @@
 <text x="-2.54" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <rectangle x1="-1" y1="-1.1" x2="-0.5" y2="1.1" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -212,7 +212,7 @@
 <gate name="G$1" symbol="U217B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="+" pad="3"/>
 <connect gate="G$1" pin="-" pad="4"/>

--- a/texas.lbr
+++ b/texas.lbr
@@ -402,7 +402,7 @@
 <vertex x="0.37" y="-0.38"/>
 </polygon>
 </package>
-<package name="PLCC-127P-896W-896L-457H-20">
+<package name="PLCC-20-127P-896W-896L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 8.97mm length, 8.97mm width, 4.57mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier. 1.27mm pitch, 8.97mm body length, 8.97mm body width, 4.57mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MS-018A, variation AA.&lt;/p&gt;
@@ -539,7 +539,7 @@ from tsl230.pdf TAOS004 - MAY 1999</description>
 <vertex x="-5.207" y="5.461"/>
 </polygon>
 </package>
-<package name="SSOP-65P-610W-970L-200H-100F-28">
+<package name="SSOP-28-65P-610W-970L-200H-100F">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 6.1mm width, 2.00mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 6.1mm width, 2.00mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-152C, variation DB, R-PDSO-G.&lt;/p&gt;
@@ -608,7 +608,7 @@ JEDEC MO-152C, variation DB, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.95" x2="4.75" y2="2.95" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.95" x2="-4.75" y2="2.95" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-065-530-20">
+<package name="SSOP-20-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 20 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JEDEC MO-150B. Variation AE.</description>
 <circle x="-2.885" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -659,7 +659,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <wire x1="3.8" y1="-2.6" x2="3.8" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.6" x2="-3.75" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-970L-120H-100F-28">
+<package name="SSOP-28-65P-440W-970L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 9.7mm length, 4.4mm width, 1.20mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm length, 4.4mm width, 1.20mm max height, 28 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
@@ -728,7 +728,7 @@ JEDEC MO-153F, variation AE, R-PDSO-G.&lt;/p&gt;
 <wire x1="4.75" y1="-2.1" x2="4.75" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="4.75" y1="2.1" x2="-4.75" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-300L-120H-100F-8">
+<package name="SSOP-8-65P-440W-300L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
@@ -757,7 +757,7 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <wire x1="1.4" y1="-2.1" x2="1.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="1.4" y1="2.1" x2="-1.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-16">
+<package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -823,7 +823,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <wire x1="1.45" y1="0.65" x2="1.45" y2="-0.65" width="0.2032" layer="51"/>
 <wire x1="1.45" y1="0.65" x2="0.5" y2="0.65" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -843,7 +843,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -869,7 +869,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -897,7 +897,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -929,7 +929,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SSOP-50P-440W-780L-120H-100F-30">
+<package name="SSOP-30-50P-440W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.50mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 1.20mm max height, 30 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 1.20mm max height, 30 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation BC-1, R-PDSO-G.&lt;/p&gt;
@@ -1002,7 +1002,7 @@ JEDEC MO-153F, variation BC-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.1" x2="3.8" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.1" x2="-3.8" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -1036,7 +1036,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-900L-265H-140F-14">
+<package name="SOP-14-127P-750W-900L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads.&lt;/p&gt;
 
@@ -1081,7 +1081,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length,
 <wire x1="4.475" y1="-3.725" x2="-4.475" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="4.475" y1="3.725" x2="-4.475" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -1130,7 +1130,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -1187,7 +1187,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1155L-265H-140F-18">
+<package name="SOP-18-127P-750W-1155L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
@@ -1240,7 +1240,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -1290,7 +1290,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-065-530-16">
+<package name="SSOP-16-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 16 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 16 leads. JEDEC MO-150B. Variation AC.</description>
 <circle x="-2.235" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -1333,7 +1333,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 16 leads. JED
 <wire x1="3.15" y1="-2.6" x2="3.15" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.6" x2="-3.1" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-780L-120H-100F-24">
+<package name="SSOP-24-65P-440W-780L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
@@ -1394,7 +1394,7 @@ JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="-2.1" x2="3.8" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="3.8" y1="2.1" x2="-3.8" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-750W-1540L-265H-140F-24">
+<package name="SOP-24-127P-750W-1540L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
@@ -1459,7 +1459,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-065-530-24">
+<package name="SSOP-24-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 24 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JEDEC MO-150B. Variation AG.</description>
 <circle x="-3.535" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -1748,7 +1748,7 @@ falls within MO-195</description>
 <text x="-3" y="3.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3" y="-4.25" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SSOP-65P-280W-295L-135H-60F-8">
+<package name="SSOP-8-65P-280W-295L-135H-60F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.60mm lead length, 3.0mm length, 2.8mm width, 1.35mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.60mm lead length 3.0mm length, 2.8mm width, 1.35mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation DA, LSR-PDSO.&lt;/p&gt;
@@ -1781,7 +1781,7 @@ JEDEC MO-187F, variation DA, LSR-PDSO.&lt;/p&gt;
 <wire x1="1.45" y1="-1.375" x2="-1.45" y2="-1.375" width="0.0508" layer="51"/>
 <wire x1="1.45" y1="1.375" x2="-1.45" y2="1.375" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-50P-230W-200L-100H-40F-8">
+<package name="SSOP-8-50P-230W-200L-100H-40F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.40mm lead length, 2.0mm length, 2.3mm width, 1.00mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.50mm pitch, 0.40mm lead length 2.0mm length, 2.3mm width, 1.00mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation CA, VSR-PDSO.&lt;/p&gt;
@@ -1854,7 +1854,7 @@ RGV (S-PQFP-N16), body 4 x 4 mm, pitch 0.65 mm</description>
 <rectangle x1="0.25" y1="-1" x2="1" y2="-0.25" layer="31"/>
 <rectangle x1="-1" y1="-1" x2="-0.25" y2="-0.25" layer="31"/>
 </package>
-<package name="SSOP-65P-440W-500L-120H-100F-14">
+<package name="SSOP-14-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
@@ -1895,7 +1895,7 @@ JEDEC MO-153F, variation AB-1, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-440W-650L-120H-100F-20">
+<package name="SSOP-20-65P-440W-650L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AC, R-PDSO-G.&lt;/p&gt;
@@ -2202,7 +2202,7 @@ body 14x14 mm, pitch 0.8 mm</description>
 <rectangle x1="-0.5" y1="-2" x2="0.5" y2="-1" layer="31"/>
 <rectangle x1="1" y1="-2" x2="2" y2="-1" layer="31"/>
 </package>
-<package name="TQFP-80P-1400W-1400L-120H-64">
+<package name="TQFP-64-80P-1400W-1400L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.
@@ -3022,7 +3022,7 @@ DGQ Package, Texas Instruments</description>
 <smd name="11" x="0" y="0" dx="1.88" dy="1.98" layer="1" rot="R90" thermals="no"/>
 <rectangle x1="-1.8" y1="-1.5" x2="-1.3" y2="-1" layer="21"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -3614,7 +3614,7 @@ Exposed Pad,  PWP0014A</description>
 <smd name="15" x="0" y="0" dx="3.1" dy="3" layer="1"/>
 <rectangle x1="-3" y1="-2.1" x2="-2.4" y2="-1.5" layer="21"/>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -3778,7 +3778,7 @@ Quad Flat Package, 0.50 mm Pitch&lt;br&gt;</description>
 <text x="-2.5" y="3.25" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2.5" y="-4" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="LQFP-80P-700W-700L-160H-32">
+<package name="LQFP-32-80P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 32 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.
@@ -4292,7 +4292,7 @@ body 1.55 x 1.55 mm</description>
 <text x="-0.75" y="1.15" size="0.6096" layer="25" ratio="18">&gt;NAME</text>
 <text x="-0.75" y="-1.5" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SSOP-50P-300W-300L-110H-95F-10">
+<package name="SSOP-10-50P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
@@ -7939,7 +7939,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="G$1" symbol="BQ2054" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="BAT" pad="3"/>
 <connect gate="G$1" pin="ICOMP" pad="5"/>
@@ -7970,7 +7970,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="G$1" symbol="BQ2054" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BAT" pad="3"/>
 <connect gate="G$1" pin="ICOMP" pad="5"/>
@@ -8001,7 +8001,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="G$1" symbol="BQ2058" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="B1N" pad="8"/>
 <connect gate="G$1" pin="B1P" pad="9"/>
@@ -8032,7 +8032,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="G$1" symbol="BQ2002" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BAT" pad="3"/>
 <connect gate="G$1" pin="CC" pad="8"/>
@@ -8055,7 +8055,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="G$1" symbol="BQ2002" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="BAT" pad="3"/>
 <connect gate="G$1" pin="CC" pad="8"/>
@@ -8079,7 +8079,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="P" symbol="VCCGND" x="35.56" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-20">
+<device name="" package="DIP-20-254P-762W">
 <connects>
 <connect gate="N" pin="!EARMUTE" pad="10"/>
 <connect gate="N" pin="!LINSEL" pad="15"/>
@@ -8115,7 +8115,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="P" symbol="VCCGND" x="30.48" y="-2.54" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="DW" pin="!EARMUTE" pad="10"/>
 <connect gate="DW" pin="!LINSEL" pad="15"/>
@@ -8241,7 +8241,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="G$1" symbol="L293E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="1-2EN" pad="1"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -8272,7 +8272,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="G$1" symbol="BQ2000" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-8">
+<device name="" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!LED" pad="3"/>
 <connect gate="G$1" pin="BAT" pad="4"/>
@@ -8295,7 +8295,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="G$1" symbol="BQ2000" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!LED" pad="3"/>
 <connect gate="G$1" pin="BAT" pad="4"/>
@@ -8318,7 +8318,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="G$1" symbol="BQ2000" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!LED" pad="3"/>
 <connect gate="G$1" pin="BAT" pad="4"/>
@@ -8343,7 +8343,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="NC2" symbol="NC" x="33.02" y="17.78" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-896W-896L-457H-20">
+<device name="" package="PLCC-20-127P-896W-896L-457H">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="6"/>
 <connect gate="G$1" pin="!SHDOWN" pad="9"/>
@@ -8378,7 +8378,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="G$1" symbol="UC1526" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="5"/>
 <connect gate="G$1" pin="!SHDOWN" pad="8"/>
@@ -8415,7 +8415,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="NC4" symbol="NC" x="27.94" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-900L-265H-140F-14">
+<device name="" package="SOP-14-127P-750W-900L-265H-140F">
 <connects>
 <connect gate="G$1" pin="COMP" pad="1"/>
 <connect gate="G$1" pin="GND" pad="9"/>
@@ -8444,7 +8444,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="G$1" symbol="UC1843-8" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COMP" pad="1"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -8477,7 +8477,7 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <gate name="NC10" symbol="NC" x="40.64" y="-33.02" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-127P-896W-896L-457H-20">
+<device name="" package="PLCC-20-127P-896W-896L-457H">
 <connects>
 <connect gate="G$1" pin="COMP" pad="2"/>
 <connect gate="G$1" pin="GND" pad="13"/>
@@ -8539,7 +8539,7 @@ www.ti.com df1706.pdf</description>
 <gate name="A" symbol="DF1706" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-610W-970L-200H-100F-28">
+<device name="" package="SSOP-28-65P-610W-970L-200H-100F">
 <connects>
 <connect gate="A" pin="!MUTE" pad="15"/>
 <connect gate="A" pin="!RST" pad="14"/>
@@ -8583,7 +8583,7 @@ SINGLE-ENDED ANALOG INPUT/OUTPUT AND S/PDIF</description>
 <gate name="A" symbol="PCM2900" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-610W-970L-200H-100F-28">
+<device name="" package="SSOP-28-65P-610W-970L-200H-100F">
 <connects>
 <connect gate="A" pin="!SSPND" pad="28"/>
 <connect gate="A" pin="AGNDC" pad="11"/>
@@ -8628,7 +8628,7 @@ SINGLE-ENDED ANALOG INPUT/OUTPUT AND S/PDIF</description>
 <gate name="A" symbol="PCM2902" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-610W-970L-200H-100F-28">
+<device name="" package="SSOP-28-65P-610W-970L-200H-100F">
 <connects>
 <connect gate="A" pin="!SSPND" pad="28"/>
 <connect gate="A" pin="AGNDC" pad="11"/>
@@ -8674,7 +8674,7 @@ Phase Lock Loop (PLL).</description>
 <gate name="A" symbol="PLL1700" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-065-530-20">
+<device name="" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="A" pin="!MCKO" pad="11"/>
 <connect gate="A" pin="DNGP" pad="7"/>
@@ -8709,7 +8709,7 @@ Phase Lock Loop (PLL).</description>
 <gate name="A" symbol="TAS3001" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="A" pin="!RES" pad="19"/>
 <connect gate="A" pin="AVDD_PLL" pad="13"/>
@@ -8816,7 +8816,7 @@ www.ti.com; tas3002.pdf</description>
 <gate name="G$1" symbol="TPS5420" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BOOT" pad="1"/>
 <connect gate="G$1" pin="ENA" pad="5"/>
@@ -8858,7 +8858,7 @@ www.ti.com; tas3002.pdf</description>
 <gate name="G$1" symbol="MC33063" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COMP" pad="5"/>
 <connect gate="G$1" pin="DRIVE" pad="8"/>
@@ -9002,7 +9002,7 @@ BUTTERWORTH FOURTH-ORDER LOW-PASS</description>
 <gate name="G$1" symbol="TLC04/MF4A-50" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="6"/>
 <connect gate="G$1" pin="CLKIN" pad="1"/>
@@ -9026,7 +9026,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <gate name="G$1" symbol="TLV320AIC12" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-440W-780L-120H-100F-30">
+<device name="" package="SSOP-30-50P-440W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!PWRDN!" pad="8"/>
 <connect gate="G$1" pin="!RESET!" pad="24"/>
@@ -9072,7 +9072,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <gate name="G$1" symbol="TLV320AIC14" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-440W-780L-120H-100F-30">
+<device name="" package="SSOP-30-50P-440W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!PWRDN!" pad="8"/>
 <connect gate="G$1" pin="!RESET!" pad="24"/>
@@ -9118,7 +9118,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <gate name="P" symbol="VCC-GND" x="27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -9141,7 +9141,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -9164,7 +9164,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DB" package="SSOP-065-530-16">
+<device name="DB" package="SSOP-16-65P-530W">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -9187,7 +9187,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -9218,7 +9218,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <gate name="G$1" symbol="PCA9539" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DB" package="SSOP-065-530-24">
+<device name="DB" package="SSOP-24-65P-530W">
 <connects>
 <connect gate="G$1" pin="!INT" pad="1"/>
 <connect gate="G$1" pin="!RESET" pad="3"/>
@@ -9249,7 +9249,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-127P-750W-1540L-265H-140F-24">
+<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="1"/>
 <connect gate="G$1" pin="!RESET" pad="3"/>
@@ -9280,7 +9280,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-780L-120H-100F-24">
+<device name="PW" package="SSOP-24-65P-440W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="1"/>
 <connect gate="G$1" pin="!RESET" pad="3"/>
@@ -9319,7 +9319,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <gate name="G$1" symbol="P82B96" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="PW" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="RX" pad="2"/>
@@ -9334,7 +9334,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="RX" pad="2"/>
@@ -9349,7 +9349,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="RX" pad="2"/>
@@ -9392,7 +9392,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <gate name="G$1" symbol="SN65HVD1050" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CANH" pad="7"/>
 <connect gate="G$1" pin="CANL" pad="6"/>
@@ -9416,7 +9416,7 @@ use TLV5626 for internal ref</description>
 <gate name="G$1" symbol="TLV5625" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="3"/>
 <connect gate="G$1" pin="AGND" pad="5"/>
@@ -9439,7 +9439,7 @@ use TLV5626 for internal ref</description>
 <gate name="G$1" symbol="UC2909" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DW" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CA-" pad="13"/>
 <connect gate="G$1" pin="CAO" pad="14"/>
@@ -9466,7 +9466,7 @@ use TLV5626 for internal ref</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-20">
+<device name="N" package="DIP-20-254P-762W">
 <connects>
 <connect gate="G$1" pin="CA-" pad="13"/>
 <connect gate="G$1" pin="CAO" pad="14"/>
@@ -9501,7 +9501,7 @@ use TLV5626 for internal ref</description>
 <gate name="G$1" symbol="TPS2375/77" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLASS" pad="2"/>
 <connect gate="G$1" pin="DET" pad="3"/>
@@ -9515,7 +9515,7 @@ use TLV5626 for internal ref</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="PW" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="CLASS" pad="2"/>
 <connect gate="G$1" pin="DET" pad="3"/>
@@ -9676,7 +9676,7 @@ LOW-POWER, FOR PORTABLE AUDIO/TELEPHONY</description>
 <gate name="G$1" symbol="TXS0102" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DCT" package="SSOP-65P-280W-295L-135H-60F-8">
+<device name="DCT" package="SSOP-8-65P-280W-295L-135H-60F">
 <connects>
 <connect gate="G$1" pin="A1" pad="5"/>
 <connect gate="G$1" pin="A2" pad="4"/>
@@ -9691,7 +9691,7 @@ LOW-POWER, FOR PORTABLE AUDIO/TELEPHONY</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DCU" package="SSOP-50P-230W-200L-100H-40F-8">
+<device name="DCU" package="SSOP-8-50P-230W-200L-100H-40F">
 <connects>
 <connect gate="G$1" pin="A1" pad="5"/>
 <connect gate="G$1" pin="A2" pad="4"/>
@@ -9763,7 +9763,7 @@ Up to 27 dBm (0.5 W) Output Power</description>
 <gate name="G$1" symbol="CDCLVC1104" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="PW" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="1G" pad="2"/>
 <connect gate="G$1" pin="CLKIN" pad="1"/>
@@ -9787,7 +9787,7 @@ Up to 27 dBm (0.5 W) Output Power</description>
 <gate name="G$1" symbol="CDCLVC1102" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="PW" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="1G" pad="2"/>
 <connect gate="G$1" pin="CLKIN" pad="1"/>
@@ -9809,7 +9809,7 @@ Up to 27 dBm (0.5 W) Output Power</description>
 <gate name="G$1" symbol="CDCLVC1103" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="PW" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="1G" pad="2"/>
 <connect gate="G$1" pin="CLKIN" pad="1"/>
@@ -9832,7 +9832,7 @@ Up to 27 dBm (0.5 W) Output Power</description>
 <gate name="G$1" symbol="CDCLVC1106" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="PW" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="1G" pad="2"/>
 <connect gate="G$1" pin="CLKIN" pad="1"/>
@@ -9862,7 +9862,7 @@ Up to 27 dBm (0.5 W) Output Power</description>
 <gate name="G$1" symbol="CDCLVC1108" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="1G" pad="2"/>
 <connect gate="G$1" pin="CLKIN" pad="1"/>
@@ -9894,7 +9894,7 @@ Up to 27 dBm (0.5 W) Output Power</description>
 <gate name="G$1" symbol="CDCLVC1110" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-650L-120H-100F-20">
+<device name="PW" package="SSOP-20-65P-440W-650L-120H-100F">
 <connects>
 <connect gate="G$1" pin="1G" pad="2"/>
 <connect gate="G$1" pin="CLKIN" pad="1"/>
@@ -9930,7 +9930,7 @@ Up to 27 dBm (0.5 W) Output Power</description>
 <gate name="G$1" symbol="CDCLVC1112" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-780L-120H-100F-24">
+<device name="PW" package="SSOP-24-65P-440W-780L-120H-100F">
 <connects>
 <connect gate="G$1" pin="1G" pad="2"/>
 <connect gate="G$1" pin="CLKIN" pad="1"/>
@@ -10116,7 +10116,7 @@ with I2C Interface</description>
 <gate name="G$1" symbol="PGA2311" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-16">
+<device name="P" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!MUTE!" pad="8"/>
@@ -10139,7 +10139,7 @@ with I2C Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!MUTE!" pad="8"/>
@@ -10192,7 +10192,7 @@ with I2C Interface</description>
 <gate name="G$1" symbol="DRV134" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="S+" pad="7"/>
@@ -10944,7 +10944,7 @@ with Battery Management for Energy Harvester Applications</description>
 <gate name="G$1" symbol="TLV5637" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="3"/>
 <connect gate="G$1" pin="AGND" pad="5"/>
@@ -10986,7 +10986,7 @@ with Battery Management for Energy Harvester Applications</description>
 <gate name="G$1" symbol="LM56" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="OUT1" pad="7"/>
@@ -11137,7 +11137,7 @@ High Performance 24-Bit, 216kHz Sampling</description>
 <gate name="P" symbol="VCC-GND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-14">
+<device name="" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="CONT" pad="2"/>
@@ -11166,7 +11166,7 @@ High Performance 24-Bit, 216kHz Sampling</description>
 <gate name="G$1" symbol="SN65LBC173AN" x="5.08" y="2.54"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="/G" pad="12"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -11189,7 +11189,7 @@ High Performance 24-Bit, 216kHz Sampling</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="/G" pad="12"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -11241,7 +11241,7 @@ High Performance 24-Bit, 216kHz Sampling</description>
 <gate name="G$1" symbol="TLV5614-EP" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="6"/>
 <connect gate="G$1" pin="!LDAC!" pad="3"/>
@@ -11304,7 +11304,7 @@ Low-Noise, Very Low Drift, Precision</description>
 <gate name="G$1" symbol="REF50XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DGK" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="DGK" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="DNC@1" pad="1"/>
 <connect gate="G$1" pin="DNC@8" pad="8"/>
@@ -11342,7 +11342,7 @@ Low-Noise, Very Low Drift, Precision</description>
 </technology>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="DNC@1" pad="1"/>
 <connect gate="G$1" pin="DNC@8" pad="8"/>
@@ -11388,7 +11388,7 @@ Low-Noise, Very Low Drift, Precision</description>
 <gate name="G$1" symbol="LM35" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="OUT" pad="1"/>
@@ -11486,7 +11486,7 @@ Low-Noise, Very Low Drift, Precision</description>
 <gate name="G$1" symbol="TPS54233" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BOOT" pad="1"/>
 <connect gate="G$1" pin="COMP" pad="6"/>
@@ -11582,7 +11582,7 @@ SWIFT, 1.5-A, 60-V, Step-Down</description>
 <gate name="G$1" symbol="TPS2492" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!FLT!" pad="9"/>
 <connect gate="G$1" pin="!PG!" pad="8"/>
@@ -11675,7 +11675,7 @@ WITH OPTIONAL SERIAL EEPROM INTERFACE</description>
 <gate name="G$1" symbol="TUSB2046B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="VF" package="LQFP-80P-700W-700L-160H-32">
+<device name="VF" package="LQFP-32-80P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!EXTMEM!" pad="26"/>
 <connect gate="G$1" pin="!OVRCUR1!" pad="10"/>
@@ -11761,7 +11761,7 @@ WITH OPTIONAL SERIAL EEPROM INTERFACE</description>
 <gate name="G$1" symbol="SN75240" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-300L-120H-100F-8">
+<device name="PW" package="SSOP-8-65P-440W-300L-120H-100F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="6"/>
@@ -11866,7 +11866,7 @@ LOW-VOLTAGE WITH ±15-kV IEC ESD PROTECTION</description>
 <gate name="G$1" symbol="AM26LV31E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!G!" pad="12"/>
 <connect gate="G$1" pin="1A" pad="1"/>
@@ -11889,7 +11889,7 @@ LOW-VOLTAGE WITH ±15-kV IEC ESD PROTECTION</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!G!" pad="12"/>
 <connect gate="G$1" pin="1A" pad="1"/>
@@ -11920,7 +11920,7 @@ LOW-VOLTAGE WITH ±15-kV IEC ESD PROTECTION</description>
 <gate name="G$1" symbol="AM26LV32E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!G!" pad="12"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -11943,7 +11943,7 @@ LOW-VOLTAGE WITH ±15-kV IEC ESD PROTECTION</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!G!" pad="12"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -11975,7 +11975,7 @@ SIMPLE SWITCHER Power Converter 150 kHz 0.5A</description>
 <gate name="G$1" symbol="LM2594" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!ON!/OFF" pad="5"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -11987,7 +11987,7 @@ SIMPLE SWITCHER Power Converter 150 kHz 0.5A</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!ON!/OFF" pad="5"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -12083,7 +12083,7 @@ RS-422/485</description>
 <gate name="G$1" symbol="SN75176B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -12098,7 +12098,7 @@ RS-422/485</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -12121,7 +12121,7 @@ RS-422/485</description>
 <gate name="G$1" symbol="SN65HVD232" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CANH" pad="7"/>
 <connect gate="G$1" pin="CANL" pad="6"/>
@@ -12142,7 +12142,7 @@ RS-422/485</description>
 <gate name="G$1" symbol="SN65HVD230" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CANH" pad="7"/>
 <connect gate="G$1" pin="CANL" pad="6"/>
@@ -12187,7 +12187,7 @@ RS-422/485</description>
 <gate name="G$1" symbol="SN65HVD71" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -12202,7 +12202,7 @@ RS-422/485</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DGK" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="DGK" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -12226,7 +12226,7 @@ RS-422/485</description>
 <gate name="G$1" symbol="SN65HVD76" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="3"/>
 <connect gate="G$1" pin="A" pad="12"/>
@@ -12293,7 +12293,7 @@ RS-422/485</description>
 <gate name="G$1" symbol="LM2907" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="-VIN" pad="11"/>
 <connect gate="G$1" pin="C1" pad="2"/>
@@ -12322,7 +12322,7 @@ RS-422/485</description>
 <gate name="G$1" symbol="DIT4192_SW" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-970L-120H-100F-28">
+<device name="" package="SSOP-28-65P-440W-970L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="5"/>
 <connect gate="G$1" pin="!INT!" pad="22"/>
@@ -12586,7 +12586,7 @@ Wide Input Range, 4.5 V to 75 V.</description>
 <gate name="G$1" symbol="LM5574" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="9"/>
 <connect gate="G$1" pin="BST" pad="16"/>
@@ -12665,7 +12665,7 @@ Wide Input Range, 4.5 V to 75 V.</description>
 <gate name="G$1" symbol="ADS1222" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-440W-500L-120H-100F-14">
+<device name="" package="SSOP-14-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!DRDY!/DOUT" pad="4"/>
 <connect gate="G$1" pin="AINN1" pad="11"/>
@@ -12966,7 +12966,7 @@ Ultra Low-Noise, 250-mA Linear Regulator for RF and Analog Circuits</description
 <gate name="G$1" symbol="SN65HVD1473" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="3"/>
 <connect gate="G$1" pin="A" pad="12"/>
@@ -12983,7 +12983,7 @@ Ultra Low-Noise, 250-mA Linear Regulator for RF and Analog Circuits</description
 <technology name=""/>
 </technologies>
 </device>
-<device name="DGS" package="SSOP-50P-300W-300L-110H-95F-10">
+<device name="DGS" package="SSOP-10-50P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A" pad="9"/>
@@ -13088,7 +13088,7 @@ Low-Noise, Very Low Drift, Precision</description>
 <gate name="G$1" symbol="TPS40200" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COMP" pad="3"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -13143,7 +13143,7 @@ Low-Noise, Very Low Drift, Precision</description>
 <gate name="G$1" symbol="INA219" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="1"/>
@@ -13243,7 +13243,7 @@ BUCK SYNC ADJ 1A</description>
 <gate name="P" symbol="VCCGND" x="27.94" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="G$1" pin="!EN!" pad="1"/>
 <connect gate="G$1" pin="!FORCEOFF!" pad="16"/>

--- a/that-corp.lbr
+++ b/that-corp.lbr
@@ -257,7 +257,7 @@ wide body 7.5 mm x 15.4 mm, 1MM pitch leads</description>
 <text x="-4.826" y="-1.905" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.551" y="-1.905" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -277,7 +277,7 @@ wide body 7.5 mm x 15.4 mm, 1MM pitch leads</description>
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -303,7 +303,7 @@ wide body 7.5 mm x 15.4 mm, 1MM pitch leads</description>
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-20">
+<package name="DIP-20-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="12.7" y1="1.905" x2="-12.7" y2="1.905" width="0.2032" layer="21"/>
@@ -335,7 +335,7 @@ wide body 7.5 mm x 15.4 mm, 1MM pitch leads</description>
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -369,7 +369,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -415,7 +415,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1030L-265H-140F-16">
+<package name="SOP-16-127P-750W-1030L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
@@ -1017,7 +1017,7 @@ Low Noise, High Performance</description>
 <gate name="G$1" symbol="THAT1512" x="-2.54" y="2.54"/>
 </gates>
 <devices>
-<device name="SO8-U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SO8-U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="3"/>
 <connect gate="G$1" pin="IN-" pad="2"/>
@@ -1032,7 +1032,7 @@ Low Noise, High Performance</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P08-U" package="DIP-300-8">
+<device name="P08-U" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="IN+" pad="3"/>
 <connect gate="G$1" pin="IN-" pad="2"/>
@@ -1047,7 +1047,7 @@ Low Noise, High Performance</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="W16-U" package="SOP-127P-750W-1030L-265H-140F-16">
+<device name="W16-U" package="SOP-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="5"/>
 <connect gate="G$1" pin="IN-" pad="4"/>
@@ -1062,7 +1062,7 @@ Low Noise, High Performance</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S14-U" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="S14-U" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="5"/>
 <connect gate="G$1" pin="IN-" pad="4"/>
@@ -1085,7 +1085,7 @@ Low Noise, High Performance</description>
 <gate name="G$1" symbol="THAT2181" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EC+" pad="2"/>
 <connect gate="G$1" pin="EC-" pad="3"/>
@@ -1176,7 +1176,7 @@ IC Dynamics Processor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P20-I" package="DIP-300-20">
+<device name="P20-I" package="DIP-20-254P-762W">
 <connects>
 <connect gate="-OA1" pin="+IN" pad="20"/>
 <connect gate="-OA1" pin="-IN" pad="19"/>
@@ -1334,7 +1334,7 @@ Pre-trimmed Low-voltage Low-power</description>
 <gate name="D" symbol="NPN" x="7.62" y="-20.32"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="S" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -1353,7 +1353,7 @@ Pre-trimmed Low-voltage Low-power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -1383,7 +1383,7 @@ Pre-trimmed Low-voltage Low-power</description>
 <gate name="D" symbol="PNP" x="7.62" y="-20.32"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="S" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -1402,7 +1402,7 @@ Pre-trimmed Low-voltage Low-power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -1433,7 +1433,7 @@ Pre-trimmed Low-voltage Low-power</description>
 <gate name="-SUB" symbol="SUBPINS" x="22.86" y="-17.78" addlevel="request"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="S" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="-SUB" pin="GND@11" pad="11"/>
 <connect gate="-SUB" pin="GND@4" pad="4"/>
@@ -1454,7 +1454,7 @@ Pre-trimmed Low-voltage Low-power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-14">
+<device name="P" package="DIP-14-254P-762W">
 <connects>
 <connect gate="-SUB" pin="GND@11" pad="11"/>
 <connect gate="-SUB" pin="GND@4" pad="4"/>
@@ -1484,7 +1484,7 @@ InGenius High-CMRR</description>
 <gate name="G$1" symbol="THAT1200" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CM_IN" pad="5"/>
 <connect gate="G$1" pin="CM_OUT" pad="8"/>
@@ -1499,7 +1499,7 @@ InGenius High-CMRR</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P" package="DIP-300-8">
+<device name="P" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CM_IN" pad="5"/>
 <connect gate="G$1" pin="CM_OUT" pad="8"/>
@@ -1523,7 +1523,7 @@ THAT1240, THAT1243, THAT1246</description>
 <gate name="G$1" symbol="THAT1240" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO8-U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SO8-U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="3"/>
 <connect gate="G$1" pin="IN-" pad="2"/>
@@ -1537,7 +1537,7 @@ THAT1240, THAT1243, THAT1246</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P08-U" package="DIP-300-8">
+<device name="P08-U" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="IN+" pad="3"/>
 <connect gate="G$1" pin="IN-" pad="2"/>
@@ -1560,7 +1560,7 @@ THAT1250, THAT1253, THAT1256</description>
 <gate name="G$1" symbol="THAT1250" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO8-U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SO8-U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="3"/>
 <connect gate="G$1" pin="IN-" pad="2"/>
@@ -1574,7 +1574,7 @@ THAT1250, THAT1253, THAT1256</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P08-U" package="DIP-300-8">
+<device name="P08-U" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="IN+" pad="3"/>
 <connect gate="G$1" pin="IN-" pad="2"/>
@@ -1596,7 +1596,7 @@ THAT1250, THAT1253, THAT1256</description>
 <gate name="G$1" symbol="THAT1646" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO8-U" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SO8-U" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="IN" pad="4"/>
@@ -1611,7 +1611,7 @@ THAT1250, THAT1253, THAT1256</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="P08-U" package="DIP-300-8">
+<device name="P08-U" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="IN" pad="4"/>

--- a/ti-dsp.lbr
+++ b/ti-dsp.lbr
@@ -72,7 +72,7 @@
 </layers>
 <library>
 <packages>
-<package name="LQFP-50P-2000W-2000L-160H-144">
+<package name="LQFP-144-50P-2000W-2000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
@@ -537,7 +537,7 @@ Fixed Point</description>
 <gate name="G$1" symbol="TMS320VC5402" x="0" y="0"/>
 </gates>
 <devices>
-<device name="PGE" package="LQFP-50P-2000W-2000L-160H-144">
+<device name="PGE" package="LQFP-144-50P-2000W-2000L-160H">
 <connects>
 <connect gate="G$1" pin="!BIO!" pad="31"/>
 <connect gate="G$1" pin="!DS!" pad="21"/>

--- a/ti-tiva.lbr
+++ b/ti-tiva.lbr
@@ -106,7 +106,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2013, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;&lt;p&gt;</description>
 <packages>
-<package name="LQFP-50P-1400W-1400L-160H-100">
+<package name="LQFP-100-50P-1400W-1400L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BED, L-PQFP-G.
@@ -320,7 +320,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-1000W-1000L-160H-64">
+<package name="LQFP-64-50P-1000W-1000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
@@ -462,7 +462,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="LQFP-50P-2000W-2000L-160H-144">
+<package name="LQFP-144-50P-2000W-2000L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
@@ -1532,7 +1532,7 @@ FCI MiniTek 10-PIN, 0.05" PITCH</description>
 <gate name="G$1" symbol="TM4C123BE6PZ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="G$1" pin="!HIB!" pad="51"/>
 <connect gate="G$1" pin="!RST!" pad="63"/>
@@ -1647,7 +1647,7 @@ FCI MiniTek 10-PIN, 0.05" PITCH</description>
 <gate name="G$1" symbol="TM4C123AH6PM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1000W-1000L-160H-64">
+<device name="" package="LQFP-64-50P-1000W-1000L-160H">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="38"/>
 <connect gate="G$1" pin="GND@0" pad="12"/>
@@ -1949,7 +1949,7 @@ Tiva C Series, ARM Cortex M4F</description>
 <gate name="-PWR" symbol="TM4C123GH6PZ-PWR" x="68.58" y="10.16" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-1400W-1400L-160H-100">
+<device name="" package="LQFP-100-50P-1400W-1400L-160H">
 <connects>
 <connect gate="-IO" pin="I2C0SCL/PB2" pad="72"/>
 <connect gate="-IO" pin="I2C0SDA/PB3" pad="73"/>

--- a/transistor-fet.lbr
+++ b/transistor-fet.lbr
@@ -974,7 +974,7 @@ Also known as SOT78.</description>
 <wire x1="4.699" y1="-4.318" x2="-4.699" y2="-4.318" width="0.2032" layer="21"/>
 <wire x1="5.08" y1="-1.143" x2="4.953" y2="-4.064" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-4">
+<package name="DIP-4-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="2.54" y1="1.905" x2="-2.54" y2="1.905" width="0.2032" layer="21"/>
@@ -1105,7 +1105,7 @@ PLD-1.5</description>
 <rectangle x1="-0.6" y1="2.7" x2="0.6" y2="3.2" layer="51"/>
 <rectangle x1="-0.6" y1="-3.2" x2="0.6" y2="-2.7" layer="51"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -4069,7 +4069,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EP-G2DS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-4">
+<device name="" package="DIP-4-254P-762W">
 <connects>
 <connect gate="G$1" pin="D" pad="4"/>
 <connect gate="G$1" pin="D1" pad="3"/>
@@ -4462,7 +4462,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EN-G4D3S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="D1" pad="5"/>
 <connect gate="G$1" pin="D2" pad="6"/>
@@ -4769,7 +4769,7 @@ Vgs=12V</description>
 <gate name="G$1" symbol="MFNS-D4S3" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="D1" pad="5"/>
 <connect gate="G$1" pin="D2" pad="6"/>
@@ -5295,7 +5295,7 @@ Monolithic Dual, Ultra Low Noise</description>
 <gate name="B" symbol="JFET-N" x="12.7" y="0"/>
 </gates>
 <devices>
-<device name="SOIC-8" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="SOIC-8" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="G" pad="4"/>
@@ -5861,7 +5861,7 @@ Dual N &amp; P Channel Power HEXFET</description>
 <gate name="B" symbol="MFPS-D2" x="0" y="-20.32"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="8"/>
 <connect gate="A" pin="D2" pad="7"/>
@@ -6890,7 +6890,7 @@ Logic Level PowerTrench</description>
 <gate name="B" symbol="EMOS_ND2" x="10.16" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="5"/>
 <connect gate="A" pin="D2" pad="6"/>
@@ -7932,7 +7932,7 @@ MOSFET P-CH 55V 18A DPAK</description>
 <gate name="B" symbol="EMOS-PD" x="20.32" y="0" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="7 8"/>
 <connect gate="A" pin="G" pad="2"/>
@@ -7991,7 +7991,7 @@ Logic Level, PowerTrench</description>
 <gate name="B" symbol="EMOS-PD" x="17.78" y="0" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="7 8"/>
 <connect gate="A" pin="G" pad="2"/>

--- a/transistor-npn.lbr
+++ b/transistor-npn.lbr
@@ -961,7 +961,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <wire x1="3.25" y1="-1.75" x2="-3.25" y2="-1.75" width="0.2032" layer="21"/>
 <wire x1="3.25" y1="1.75" x2="3.25" y2="-1.75" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -981,7 +981,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -1009,7 +1009,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -1078,7 +1078,7 @@ JEDEC TO-78.
 <wire x1="-5.334" y1="-0.508" x2="-4.572" y2="-0.508" width="0.2032" layer="21"/>
 <wire x1="-4.572" y1="0.508" x2="-5.334" y2="0.508" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-14">
+<package name="DIP-14-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="8.5725" y1="1.905" x2="-8.5725" y2="1.905" width="0.2032" layer="21"/>
@@ -1104,7 +1104,7 @@ JEDEC TO-78.
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-865L-175H-140F-14">
+<package name="SOP-14-127P-390W-865L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
@@ -3705,7 +3705,7 @@ common collector</description>
 <gate name="A" symbol="NPN-PAD" x="-27.94" y="5.08" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="B" pad="16"/>
 <connect gate="A" pin="C" pad="15"/>
@@ -3727,7 +3727,7 @@ common collector</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="16"/>
 <connect gate="A" pin="C" pad="15"/>
@@ -3765,7 +3765,7 @@ common emitter</description>
 <gate name="G" symbol="NPN-C" x="27.94" y="0" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="B" pad="16"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -3787,7 +3787,7 @@ common emitter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="16"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -5004,7 +5004,7 @@ common emitter</description>
 <gate name="B" symbol="NPN" x="7.62" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -5427,7 +5427,7 @@ complimentary to CMPTA56</description>
 <gate name="D" symbol="NPN-R" x="7.62" y="-10.16" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="Y" package="DIP-300-14">
+<device name="Y" package="DIP-14-254P-762W">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -5446,7 +5446,7 @@ complimentary to CMPTA56</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-865L-175H-140F-14">
+<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="1"/>

--- a/transistor-power.lbr
+++ b/transistor-power.lbr
@@ -1691,7 +1691,7 @@ JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
 <wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
 <wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -3357,7 +3357,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <gate name="B" symbol="PNP2" x="7.62" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="7"/>

--- a/transistor.lbr
+++ b/transistor.lbr
@@ -1093,7 +1093,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <wire x1="3.25" y1="-1.75" x2="-3.25" y2="-1.75" width="0.2032" layer="21"/>
 <wire x1="3.25" y1="1.75" x2="3.25" y2="-1.75" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -1121,7 +1121,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -3702,7 +3702,7 @@ common collector</description>
 <gate name="A" symbol="NPN-PAD" x="-27.94" y="5.08" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="B" pad="16"/>
 <connect gate="A" pin="C" pad="15"/>
@@ -3724,7 +3724,7 @@ common collector</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="16"/>
 <connect gate="A" pin="C" pad="15"/>
@@ -3762,7 +3762,7 @@ common emitter</description>
 <gate name="G" symbol="NPN-C" x="27.94" y="0" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-16">
+<device name="" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="B" pad="16"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -3784,7 +3784,7 @@ common emitter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="16"/>
 <connect gate="A" pin="C" pad="1"/>

--- a/uln-udn.lbr
+++ b/uln-udn.lbr
@@ -75,7 +75,7 @@
 ULN and UDN Series&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="SSOP-65P-440W-500L-120H-100F-16">
+<package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
@@ -120,7 +120,7 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="-2.1" x2="2.4" y2="2.1" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-16">
+<package name="DIP-16-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="10.16" y1="1.905" x2="-10.16" y2="1.905" width="0.2032" layer="21"/>
@@ -148,7 +148,7 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -178,7 +178,7 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -235,7 +235,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1155L-265H-140F-18">
+<package name="SOP-18-127P-750W-1155L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
@@ -288,7 +288,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -620,7 +620,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2801A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="CD+" pad="10"/>
 <connect gate="A" pin="GND" pad="9"/>
@@ -653,7 +653,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2001A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -676,7 +676,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -707,7 +707,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2001A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -730,7 +730,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -753,7 +753,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -784,7 +784,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2001A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -807,7 +807,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -830,7 +830,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -861,7 +861,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2001A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -884,7 +884,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -907,7 +907,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="PW" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="PW" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -938,7 +938,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2064B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -959,7 +959,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -988,7 +988,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2064B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1009,7 +1009,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1038,7 +1038,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2064B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1059,7 +1059,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1088,7 +1088,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2064B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1109,7 +1109,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1138,7 +1138,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2068B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1160,7 +1160,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1190,7 +1190,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2068B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1212,7 +1212,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1242,7 +1242,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2068B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1264,7 +1264,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1294,7 +1294,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2068B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1316,7 +1316,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1346,7 +1346,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2074B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="C1" pad="1"/>
 <connect gate="A" pin="C2" pad="8"/>
@@ -1369,7 +1369,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="C1" pad="1"/>
 <connect gate="A" pin="C2" pad="8"/>
@@ -1400,7 +1400,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2074B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="C1" pad="1"/>
 <connect gate="A" pin="C2" pad="8"/>
@@ -1423,7 +1423,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="C1" pad="1"/>
 <connect gate="A" pin="C2" pad="8"/>
@@ -1454,7 +1454,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2074B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="C1" pad="1"/>
 <connect gate="A" pin="C2" pad="8"/>
@@ -1477,7 +1477,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="C1" pad="1"/>
 <connect gate="A" pin="C2" pad="8"/>
@@ -1508,7 +1508,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="A" symbol="2074B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="C1" pad="1"/>
 <connect gate="A" pin="C2" pad="8"/>
@@ -1531,7 +1531,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="C1" pad="1"/>
 <connect gate="A" pin="C2" pad="8"/>
@@ -1562,7 +1562,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="1" symbol="UDN6118A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="1" pin="GND" pad="9"/>
 <connect gate="1" pin="I1" pad="1"/>
@@ -1595,7 +1595,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="1" symbol="UDN6116A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="1" pin="GND" pad="8"/>
 <connect gate="1" pin="I1" pad="1"/>
@@ -1616,7 +1616,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="1" pin="GND" pad="8"/>
 <connect gate="1" pin="I1" pad="1"/>
@@ -1645,7 +1645,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="1" symbol="UDN2981A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-18">
+<device name="N" package="DIP-18-254P-762W">
 <connects>
 <connect gate="1" pin="GND" pad="10"/>
 <connect gate="1" pin="I1" pad="1"/>
@@ -1670,7 +1670,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="1" pin="GND" pad="10"/>
 <connect gate="1" pin="I1" pad="1"/>
@@ -1703,7 +1703,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="2801A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="CD+" pad="10"/>
 <connect gate="G$1" pin="GND" pad="9"/>
@@ -1736,7 +1736,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="2801A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-18">
+<device name="P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="CD+" pad="10"/>
 <connect gate="G$1" pin="GND" pad="9"/>
@@ -1761,7 +1761,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="FW" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="FW" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CD+" pad="10"/>
 <connect gate="G$1" pin="GND" pad="9"/>
@@ -1794,7 +1794,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="2801A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="P" package="DIP-300-18">
+<device name="P" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="CD+" pad="10"/>
 <connect gate="G$1" pin="GND" pad="9"/>
@@ -1819,7 +1819,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="FW" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="FW" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CD+" pad="10"/>
 <connect gate="G$1" pin="GND" pad="9"/>
@@ -1852,7 +1852,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="2801A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-300-18">
+<device name="" package="DIP-18-254P-762W">
 <connects>
 <connect gate="G$1" pin="CD+" pad="10"/>
 <connect gate="G$1" pin="GND" pad="9"/>
@@ -1886,7 +1886,7 @@ DS2003 National Semiconductor</description>
 <gate name="A" symbol="DS2003" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="A" pin="COM" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -1909,7 +1909,7 @@ DS2003 National Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TMT" package="SSOP-65P-440W-500L-120H-100F-16">
+<device name="TMT" package="SSOP-16-65P-440W-500L-120H-100F">
 <connects>
 <connect gate="A" pin="COM" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -1932,7 +1932,7 @@ DS2003 National Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="COM" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -1964,7 +1964,7 @@ Darlington, High Voltage, High Current</description>
 <gate name="G$1" symbol="MC1413" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="8"/>
 <connect gate="G$1" pin="I1" pad="1"/>
@@ -1996,7 +1996,7 @@ Darlington, High Voltage, High Current</description>
 <gate name="G$1" symbol="SN75468" x="5.08" y="2.54"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1B" pad="1"/>
 <connect gate="G$1" pin="1C" pad="16"/>
@@ -2019,7 +2019,7 @@ Darlington, High Voltage, High Current</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-16">
+<device name="N" package="DIP-16-254P-762W">
 <connects>
 <connect gate="G$1" pin="1B" pad="1"/>
 <connect gate="G$1" pin="1C" pad="16"/>

--- a/v-reg.lbr
+++ b/v-reg.lbr
@@ -810,7 +810,7 @@ JEDEC TO-263E, variation AA, R-PSFM.
 <wire x1="5.3975" y1="-4.7625" x2="-5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 <wire x1="5.3975" y1="4.445" x2="5.3975" y2="-4.7625" width="0.2032" layer="21"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -1096,7 +1096,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <wire x1="3.25" y1="-1.75" x2="-3.25" y2="-1.75" width="0.2032" layer="21"/>
 <wire x1="3.25" y1="1.75" x2="3.25" y2="-1.75" width="0.2032" layer="21"/>
 </package>
-<package name="DIP-300-8">
+<package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="5.08" y1="1.905" x2="-5.08" y2="1.905" width="0.2032" layer="21"/>
@@ -1116,7 +1116,7 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -3296,7 +3296,7 @@ horizontal, no mount hole.</description>
 <gate name="G$1" symbol="L78XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="2 3 6 7"/>
 <connect gate="G$1" pin="IN" pad="8"/>
@@ -3409,7 +3409,7 @@ National Semiconductor</description>
 <gate name="A" symbol="LM2674" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="CB" pad="1"/>
 <connect gate="A" pin="FB" pad="4"/>
@@ -3422,7 +3422,7 @@ National Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="A" pin="CB" pad="1"/>
 <connect gate="A" pin="FB" pad="4"/>
@@ -3466,7 +3466,7 @@ National Semiconductor</description>
 <gate name="G$1" symbol="MIC5219A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="4"/>
 <connect gate="G$1" pin="EN" pad="1"/>
@@ -3492,7 +3492,7 @@ National Semiconductor</description>
 <gate name="G3" symbol="GND-1" x="17.78" y="-15.24"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="BYP" pad="4"/>
 <connect gate="G$1" pin="EN" pad="1"/>
@@ -3557,7 +3557,7 @@ Sharp PQ20WZ51 / PQ20WZ11</description>
 <gate name="G$1" symbol="LM2936BM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND@1" pad="2"/>
 <connect gate="G$1" pin="GND@2" pad="3"/>
@@ -3617,7 +3617,7 @@ Texas Instruments</description>
 <gate name="G$1" symbol="LM2671" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CB" pad="1"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -3632,7 +3632,7 @@ Texas Instruments</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="CB" pad="1"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -3716,7 +3716,7 @@ Texas Instruments</description>
 <gate name="G$1" symbol="78LXXACM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="GND1" pad="3"/>
@@ -3837,7 +3837,7 @@ National Semiconductor</description>
 <gate name="G$1" symbol="78XX" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="XXS8-5" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="XXS8-5" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="IN" pad="2"/>
@@ -3847,7 +3847,7 @@ National Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="XXMS8-5" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="XXMS8-5" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="IN" pad="2"/>
@@ -3997,7 +3997,7 @@ SO-8, fixed voltage</description>
 <gate name="G$1" symbol="LM2931D" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND@2" pad="2"/>
 <connect gate="G$1" pin="GND@3" pad="3"/>
@@ -4021,7 +4021,7 @@ SO-8, adjustable voltage</description>
 <gate name="G$1" symbol="LM2931D-ADJ" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="4"/>
 <connect gate="G$1" pin="GND@2" pad="2"/>
@@ -4063,7 +4063,7 @@ Burr-Brown</description>
 <gate name="G$1" symbol="TDA3673" x="0" y="0"/>
 </gates>
 <devices>
-<device name="AT" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="AT" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EN" pad="5"/>
 <connect gate="G$1" pin="GND" pad="2"/>
@@ -4364,7 +4364,7 @@ Adjustable</description>
 <gate name="G$1" symbol="MIC5201-X.XYM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EN" pad="5"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -4437,7 +4437,7 @@ CMOS Micropower, Ultra Low-Dropout, Low-Noise, 300mA</description>
 <gate name="G$1" symbol="LP3982IMM-ADJ" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!FAULT!" pad="8"/>
 <connect gate="G$1" pin="!SHDN!" pad="7"/>
@@ -4627,7 +4627,7 @@ ULTRALOW-NOISE, HIGH PSRR, FAST RF 250-mA</description>
 <gate name="G$1" symbol="TPS794XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="NR" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="NR" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="BYP" pad="4"/>
 <connect gate="G$1" pin="EN" pad="6"/>
@@ -4726,7 +4726,7 @@ Adjustable Micropower, 100mA</description>
 <gate name="G$1" symbol="LP2951" x="0" y="0"/>
 </gates>
 <devices>
-<device name="MM" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="MM" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="!ERR" pad="5"/>
 <connect gate="G$1" pin="FB" pad="7"/>
@@ -4741,7 +4741,7 @@ Adjustable Micropower, 100mA</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="DIP-300-8">
+<device name="N" package="DIP-8-254P-762W">
 <connects>
 <connect gate="G$1" pin="!ERR" pad="5"/>
 <connect gate="G$1" pin="FB" pad="7"/>
@@ -4756,7 +4756,7 @@ Adjustable Micropower, 100mA</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!ERR" pad="5"/>
 <connect gate="G$1" pin="FB" pad="7"/>
@@ -5537,7 +5537,7 @@ Fixed 150mA Low-Noise</description>
 <technology name="AC"/>
 </technologies>
 </device>
-<device name="D13TR" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="D13TR" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="5"/>
 <connect gate="G$1" pin="IN" pad="2 3 6 7" route="any"/>

--- a/vishay.lbr
+++ b/vishay.lbr
@@ -79,7 +79,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2014, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -269,7 +269,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="-PWR" symbol="DG41XL-PWR" x="-2.54" y="27.94" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="-PWR" pin="GND" pad="5"/>
 <connect gate="-PWR" pin="V+" pad="13"/>
@@ -304,7 +304,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="D" symbol="DG41XL-NC-GATE" x="38.1" y="-25.4" swaplevel="1"/>
 </gates>
 <devices>
-<device name="D" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="-PWR" pin="GND" pad="5"/>
 <connect gate="-PWR" pin="V+" pad="13"/>

--- a/vlsi-solution.lbr
+++ b/vlsi-solution.lbr
@@ -77,7 +77,7 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2010, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="LQFP-50P-700W-700L-160H-48">
+<package name="LQFP-48-50P-700W-700L-160H">
 <description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
 &lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
@@ -254,7 +254,7 @@ Ogg Vorbis/MP3/AAC/WMA/FLAC/MIDI AUDIO CODEC</description>
 <gate name="G$1" symbol="VS1053B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="LQFP-50P-700W-700L-160H-48">
+<device name="" package="LQFP-48-50P-700W-700L-160H">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="23"/>
 <connect gate="G$1" pin="!DCS!/BSYNC" pad="13"/>

--- a/wafer-scale-psd.lbr
+++ b/wafer-scale-psd.lbr
@@ -370,7 +370,7 @@ square</description>
 <text x="-8.89" y="10.541" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2.54" y="10.541" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="QFP-100P-1400W-1400L-245H-160F-52">
+<package name="QFP-52-100P-1400W-1400L-245H-160F">
 <description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 52 leads.
 &lt;p/&gt;JEDEC MS-022B, variation BA, PQFP-G.
@@ -1351,7 +1351,7 @@ square</description>
 <rectangle x1="8.51" y1="-12.57" x2="9.27" y2="-12.1" layer="51"/>
 <rectangle x1="9.78" y1="-12.57" x2="10.54" y2="-12.1" layer="51"/>
 </package>
-<package name="TQFP-50P-1200W-1200L-120H-80">
+<package name="TQFP-80-50P-1200W-1200L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 80 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ADD, T-PQFP-G.
@@ -1525,7 +1525,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="-5.9" x2="5.9" y2="5.9" width="0.2032" layer="21"/>
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
-<package name="PLCC-SOCKET-TH-13X13-52">
+<package name="PLCC-SOCKET-TH-52-13X13">
 <description>&lt;b&gt;PLCC socket (2.54mm pitch, 52 leads, through-hole)&lt;/b&gt;&lt;p&gt;
 Plastic leaded chip carrier socket. 2.54mm lead pitch, 52 leads.
 &lt;/p&gt;</description>
@@ -1816,7 +1816,7 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 52 leads.
 <wire x1="12.7" y1="-12.7" x2="12.7" y2="12.7" width="0.2032" layer="21"/>
 <wire x1="12.7" y1="12.7" x2="-11.43" y2="12.7" width="0.2032" layer="21"/>
 </package>
-<package name="TQFP-80P-1000W-1000L-120H-44">
+<package name="TQFP-44-80P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
 &lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
@@ -3102,7 +3102,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-100P-1400W-1400L-245H-160F-52">
+<device name="" package="QFP-52-100P-1400W-1400L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="46"/>
 <connect gate="G$1" pin="!RD!/E" pad="19"/>
@@ -3170,7 +3170,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E" pad="16"/>
@@ -3290,7 +3290,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E" pad="16"/>
@@ -3350,7 +3350,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-27.94" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-100P-1400W-1400L-245H-160F-52">
+<device name="" package="QFP-52-100P-1400W-1400L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="46"/>
 <connect gate="G$1" pin="!RD!/E" pad="19"/>
@@ -3478,7 +3478,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -3598,7 +3598,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-27.94" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-100P-1400W-1400L-245H-160F-52">
+<device name="" package="QFP-52-100P-1400W-1400L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="46"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="19"/>
@@ -3726,7 +3726,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -3786,7 +3786,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-33.02" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-100P-1400W-1400L-245H-160F-52">
+<device name="" package="QFP-52-100P-1400W-1400L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="46"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="19"/>
@@ -3914,7 +3914,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -4094,7 +4094,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -4154,7 +4154,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-100P-1400W-1400L-245H-160F-52">
+<device name="" package="QFP-52-100P-1400W-1400L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="46"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="19"/>
@@ -4282,7 +4282,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -4462,7 +4462,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-22.86" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -4522,7 +4522,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-27.94" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="QFP-100P-1400W-1400L-245H-160F-52">
+<device name="" package="QFP-52-100P-1400W-1400L-245H-160F">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="46"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="19"/>
@@ -4710,7 +4710,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E" pad="16"/>
@@ -4890,7 +4890,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-22.86" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E" pad="16"/>
@@ -5070,7 +5070,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -5250,7 +5250,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="G$1" symbol="PSD312L" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -5430,7 +5430,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -5730,7 +5730,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -5790,7 +5790,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -6090,7 +6090,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E" pad="16"/>
@@ -6150,7 +6150,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="G$1" symbol="PSD311" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E" pad="16"/>
@@ -6510,7 +6510,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -7590,7 +7590,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -7650,7 +7650,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-25.4" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!BHE!/!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -7710,7 +7710,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -7770,7 +7770,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="1VCC2GND" x="-20.32" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-80P-1000W-1000L-120H-44">
+<device name="" package="TQFP-44-80P-1000W-1000L-120H">
 <connects>
 <connect gate="G$1" pin="!PSEN!" pad="39"/>
 <connect gate="G$1" pin="!RD!/E/!DS!" pad="16"/>
@@ -7998,7 +7998,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="4VCC8GND" x="-38.1" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1200W-1200L-120H-80">
+<device name="" package="TQFP-80-50P-1200W-1200L-120H">
 <connects>
 <connect gate="G$1" pin="AD0" pad="79"/>
 <connect gate="G$1" pin="AD1" pad="78"/>
@@ -8101,7 +8101,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="V3" symbol="VCC" x="33.02" y="22.86" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="TQFP-50P-1200W-1200L-120H-80">
+<device name="" package="TQFP-80-50P-1200W-1200L-120H">
 <connects>
 <connect gate="G$1" pin="AD0" pad="3"/>
 <connect gate="G$1" pin="AD1" pad="4"/>
@@ -8197,7 +8197,7 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <gate name="P" symbol="2VCC3GND" x="-38.1" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="PLCC-SOCKET-TH-13X13-52">
+<device name="" package="PLCC-SOCKET-TH-52-13X13">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="48"/>
 <connect gate="G$1" pin="AD0" pad="30"/>

--- a/winbond.lbr
+++ b/winbond.lbr
@@ -71,7 +71,7 @@
 </layers>
 <library>
 <packages>
-<package name="SSOP-50P-1840W-1400L-120H-80F-56">
+<package name="SSOP-56-50P-1840W-1400L-120H-80F">
 <description>&lt;b&gt;TSOP (0.50mm pitch, 0.8mm lead length, 14.0mm length, 18.4mm width, 1.20mm max height, 56 leads)&lt;/b&gt;&lt;p&gt;
 Thin small outline package. 0.50mm pitch, 0.8mm lead length 14.0mm length, 18.4mm width, 1.20mm max height, 56 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-142D, variation EC, R-PDSO-G.&lt;/p&gt;
@@ -240,7 +240,7 @@ JEDEC MO-142D, variation EC, R-PDSO-G.&lt;/p&gt;
 <gate name="G$1" symbol="WTS701" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-50P-1840W-1400L-120H-80F-56">
+<device name="" package="SSOP-56-50P-1840W-1400L-120H-80F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="25"/>
 <connect gate="G$1" pin="!INT!" pad="13"/>

--- a/zarlink.lbr
+++ b/zarlink.lbr
@@ -72,7 +72,7 @@
 </layers>
 <library>
 <packages>
-<package name="DIP-300-18">
+<package name="DIP-18-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 300 mil row spacing, JEDEC MS-001D</description>
 <wire x1="11.43" y1="1.905" x2="-11.43" y2="1.905" width="0.2032" layer="21"/>
@@ -102,7 +102,7 @@
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-127P-750W-1155L-265H-140F-18">
+<package name="SOP-18-127P-750W-1155L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
@@ -155,7 +155,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SSOP-065-530-20">
+<package name="SSOP-20-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 20 leads)&lt;/b&gt;&lt;p&gt;
 Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JEDEC MO-150B. Variation AE.</description>
 <circle x="-2.885" y="-1.7988" radius="0.3175" width="0" layer="21"/>
@@ -249,7 +249,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="VDDVSS" x="-27.94" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="E" package="DIP-300-18">
+<device name="E" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="EST" pad="16"/>
 <connect gate="A" pin="GS" pad="3"/>
@@ -274,7 +274,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="S" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="A" pin="EST" pad="16"/>
 <connect gate="A" pin="GS" pad="3"/>
@@ -299,7 +299,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="SSOP-065-530-20">
+<device name="N" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="A" pin="EST" pad="18"/>
 <connect gate="A" pin="GS" pad="3"/>
@@ -334,7 +334,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="VDDVSS" x="-27.94" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="E" package="DIP-300-18">
+<device name="E" package="DIP-18-254P-762W">
 <connects>
 <connect gate="A" pin="EST" pad="16"/>
 <connect gate="A" pin="GS" pad="3"/>
@@ -359,7 +359,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-127P-750W-1155L-265H-140F-18">
+<device name="S" package="SOP-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="A" pin="EST" pad="16"/>
 <connect gate="A" pin="GS" pad="3"/>
@@ -384,7 +384,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="SSOP-065-530-20">
+<device name="N" package="SSOP-20-65P-530W">
 <connects>
 <connect gate="A" pin="EST" pad="18"/>
 <connect gate="A" pin="GS" pad="3"/>

--- a/zetex.lbr
+++ b/zetex.lbr
@@ -311,7 +311,7 @@ Source : Analog and Discrete Components Databook ST306 April 2001</description>
 <rectangle x1="1.25" y1="-2.15" x2="1.75" y2="-1.15" layer="51"/>
 <rectangle x1="-0.85" y1="1.65" x2="0.85" y2="2.2" layer="51"/>
 </package>
-<package name="SSOP-65P-300W-300L-110H-95F-8">
+<package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
 JEDEC MO-187F, variation AA, TSR-PDSO.&lt;/p&gt;
@@ -394,7 +394,7 @@ Thin shrink small outline transistor package (also known as SOT323). 0.65mm pitc
 <rectangle x1="0.9" y1="-0.2" x2="1.35" y2="0.2" layer="51"/>
 <rectangle x1="-0.45" y1="-0.575" x2="-0.075" y2="0.575" layer="21"/>
 </package>
-<package name="SOP-127P-390W-490L-175H-140F-8">
+<package name="SOP-8-127P-390W-490L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
@@ -428,7 +428,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-750W-1280L-265H-140F-20">
+<package name="SOP-20-127P-750W-1280L-265H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
@@ -485,7 +485,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-127P-390W-990L-175H-140F-16">
+<package name="SOP-16-127P-390W-990L-175H-140F">
 <description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
@@ -2705,7 +2705,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="B" symbol="N_MOS2D" x="2.54" y="-7.62" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="D" pad="3"/>
 <connect gate="A" pin="D2" pad="4"/>
@@ -2765,7 +2765,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="B" symbol="P_MOS2D" x="2.54" y="-5.08" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="D" pad="7"/>
 <connect gate="A" pin="D2" pad="8"/>
@@ -2790,7 +2790,7 @@ source ZXMD63C02.pdf from http://www.zetex.com/</description>
 <gate name="B" symbol="N_MOS2D" x="2.54" y="-7.62"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="D" pad="7"/>
 <connect gate="A" pin="D2" pad="8"/>
@@ -2966,7 +2966,7 @@ source ZXMD63C02.pdf from http://www.zetex.com/</description>
 <gate name="A" symbol="SDA12" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-490L-175H-140F-8">
+<device name="" package="SOP-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D01" pad="2"/>
 <connect gate="A" pin="D02" pad="3"/>
@@ -2989,7 +2989,7 @@ source ZXMD63C02.pdf from http://www.zetex.com/</description>
 <gate name="A" symbol="SDA24" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-390W-990L-175H-140F-16">
+<device name="" package="SOP-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D01" pad="2"/>
 <connect gate="A" pin="D02" pad="3"/>
@@ -3020,7 +3020,7 @@ source ZXMD63C02.pdf from http://www.zetex.com/</description>
 <gate name="A" symbol="SDA32" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-127P-750W-1280L-265H-140F-20">
+<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="D01" pad="2"/>
 <connect gate="A" pin="D02" pad="3"/>
@@ -3081,7 +3081,7 @@ source ZXMD63C02.pdf from http://www.zetex.com/</description>
 <gate name="G$1" symbol="NMOS4D3S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="D" pad="1"/>
 <connect gate="G$1" pin="D1" pad="2"/>
@@ -3104,7 +3104,7 @@ source ZXMD63C02.pdf from http://www.zetex.com/</description>
 <gate name="G$1" symbol="PMOS4D3S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="G$1" pin="D" pad="5"/>
 <connect gate="G$1" pin="D1" pad="6"/>
@@ -3280,7 +3280,7 @@ Source: www.zetex.com/ .. zxtd1m832.pdf</description>
 <gate name="A" symbol="NPN4C3E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="B" pad="4"/>
 <connect gate="A" pin="C1" pad="5"/>
@@ -3303,7 +3303,7 @@ Source: www.zetex.com/ .. zxtd1m832.pdf</description>
 <gate name="A" symbol="PNP4C3E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SSOP-65P-300W-300L-110H-95F-8">
+<device name="" package="SSOP-8-65P-300W-300L-110H-95F">
 <connects>
 <connect gate="A" pin="B" pad="4"/>
 <connect gate="A" pin="C" pad="5"/>

--- a/zilog.lbr
+++ b/zilog.lbr
@@ -72,7 +72,7 @@
 <description>&lt;b&gt;Zilog Z80 Microprocessor Devices&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="DIP-600-28">
+<package name="DIP-28-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="17.78" y1="5.715" x2="-17.78" y2="5.715" width="0.2032" layer="21"/>
@@ -112,7 +112,7 @@
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="DIP-600-40">
+<package name="DIP-40-254P-1524W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
 600 mil row spacing, JEDEC MS-011B</description>
 <wire x1="25.4" y1="5.715" x2="-25.4" y2="5.715" width="0.2032" layer="21"/>
@@ -521,7 +521,7 @@
 <gate name="1" symbol="Z8038FIO" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="1" pin="GND" pad="20"/>
 <connect gate="1" pin="M0" pad="21"/>
@@ -576,7 +576,7 @@
 <gate name="1" symbol="Z80CTC" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-28">
+<device name="" package="DIP-28-254P-1524W">
 <connects>
 <connect gate="1" pin="CE" pad="16"/>
 <connect gate="1" pin="CLK" pad="15"/>
@@ -619,7 +619,7 @@
 <gate name="1" symbol="Z80SIO" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="1" pin="B/A" pad="34"/>
 <connect gate="1" pin="C/D" pad="33"/>
@@ -674,7 +674,7 @@
 <gate name="1" symbol="Z80PIO" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="1" pin="A0" pad="15"/>
 <connect gate="1" pin="A1" pad="14"/>
@@ -729,7 +729,7 @@
 <gate name="1" symbol="Z80CPU" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="1" pin="A0" pad="30"/>
 <connect gate="1" pin="A1" pad="31"/>
@@ -784,7 +784,7 @@
 <gate name="G$1" symbol="Z80DMA" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="A0" pad="6"/>
 <connect gate="G$1" pin="A1" pad="5"/>
@@ -839,7 +839,7 @@
 <gate name="G$1" symbol="Z80DART" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="DIP-600-40">
+<device name="" package="DIP-40-254P-1524W">
 <connects>
 <connect gate="G$1" pin="B/!A" pad="34"/>
 <connect gate="G$1" pin="C/!D" pad="33"/>


### PR DESCRIPTION
The names of packages include a lot of information in order to be unique and are thus very long. The pin number at the moment is at the end of the package name and is often not visible, which is inconvenient. This PR moves the number of pins in the package to the front of the package name.

For example: SSOP-65P-440W-500L-120H-100F-16 => SSOP-16-65P-440W-500L-120H-100F.