### PR TITLE
Improve exposed pad stencil pattern for QFP packages

### DIFF
--- a/akm.lbr
+++ b/akm.lbr
@@ -79,10 +79,10 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
 <package name="LQFP-48-50P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -434,10 +434,10 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <rectangle x1="-4.7" y1="2.75" x2="-4.4" y2="3.95" layer="51"/>
 </package>
 <package name="LQFP-64-50P-1000W-1000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>

--- a/altera.lbr
+++ b/altera.lbr
@@ -1466,10 +1466,10 @@ Based on the following sources:
 <rectangle x1="-12.8763" y1="14.097" x2="-12.6223" y2="14.732" layer="21"/>
 </package>
 <package name="QFP-160-65P-2800W-2800L-385H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 160 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 160 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DD-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DD-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-12.86" x2="-14" y2="-12.49" layer="51"/>
 <rectangle x1="-15.6" y1="-12.21" x2="-14" y2="-11.84" layer="51"/>
@@ -1800,10 +1800,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-100-65P-1400W-2000L-340H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.40mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-022B, variation GC-1, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation GC-1, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-6.36" x2="-10" y2="-5.99" layer="51"/>
 <rectangle x1="-11.6" y1="-5.71" x2="-10" y2="-5.34" layer="51"/>
@@ -9913,10 +9913,10 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <wire x1="11.43" y1="11.43" x2="-10.16" y2="11.43" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-44-80P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -10015,10 +10015,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>

--- a/amd-mach.lbr
+++ b/amd-mach.lbr
@@ -266,10 +266,10 @@ JEDEC MS-018A, variation AF.&lt;/p&gt;
 <wire x1="14.6558" y1="14.6558" x2="13.365" y2="14.6558" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-100-65P-1400W-2000L-315H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-022B, variation GC-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation GC-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-6.36" x2="-10" y2="-5.99" layer="51"/>
 <rectangle x1="-11.6" y1="-5.71" x2="-10" y2="-5.34" layer="51"/>
@@ -480,10 +480,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-144-50P-2000W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -784,8 +784,8 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <package name="QFP-208-50P-2800W-2800L-385H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation FA-2, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation FA-2, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.3" y1="-12.875" x2="-14" y2="-12.625" layer="51"/>
 <rectangle x1="-15.3" y1="-12.375" x2="-14" y2="-12.125" layer="51"/>
@@ -1895,10 +1895,10 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <wire x1="8.2931" y1="8.2931" x2="7.015" y2="8.2931" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-48-50P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -2005,10 +2005,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-144-65P-2800W-2800L-385H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DC-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DC-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-11.56" x2="-14" y2="-11.19" layer="51"/>
 <rectangle x1="-15.6" y1="-10.91" x2="-14" y2="-10.54" layer="51"/>
@@ -2307,10 +2307,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-160-65P-2800W-2800L-385H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 160 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 160 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DD-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DD-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-12.86" x2="-14" y2="-12.49" layer="51"/>
 <rectangle x1="-15.6" y1="-12.21" x2="-14" y2="-11.84" layer="51"/>
@@ -2643,8 +2643,8 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <package name="QFP-240-50P-3200W-3200L-410H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 32mm length, 32mm width, 4.10mm max height, 240 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 32mm length, 32mm width, 4.10mm max height, 240 leads, high standoff.
-&lt;p/&gt;JEDEC MS-029A, variation GA, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation GA, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-15.1" y="-15.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-17.3" y1="-14.875" x2="-16" y2="-14.625" layer="51"/>
 <rectangle x1="-17.3" y1="-14.375" x2="-16" y2="-14.125" layer="51"/>
@@ -4099,10 +4099,10 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <wire x1="12.1158" y1="12.1158" x2="10.825" y2="12.1158" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-44-80P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -4201,10 +4201,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>

--- a/analog-devices.lbr
+++ b/analog-devices.lbr
@@ -815,8 +815,8 @@
 <package name="QFP-208-50P-2800W-2800L-385H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation FA-2, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation FA-2, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.3" y1="-12.875" x2="-14" y2="-12.625" layer="51"/>
 <rectangle x1="-15.3" y1="-12.375" x2="-14" y2="-12.125" layer="51"/>
@@ -1269,10 +1269,10 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm lengt
 <rectangle x1="1.7272" y1="1.8542" x2="2.0828" y2="2.8702" layer="51"/>
 </package>
 <package name="QFP-52-65P-1000W-1000L-245H-195F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation AC-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation AC-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.95" y1="-4.075" x2="-5" y2="-3.725" layer="51"/>
 <rectangle x1="-6.95" y1="-3.425" x2="-5" y2="-3.075" layer="51"/>
@@ -1788,10 +1788,10 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <smd name="R15" x="7" y="-7" dx="0.6" dy="0.6" layer="1" roundness="100"/>
 </package>
 <package name="TQFP-80-65P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.35" x2="-7" y2="-6" layer="51"/>
 <rectangle x1="-8" y1="-5.7" x2="-7" y2="-5.35" layer="51"/>
@@ -2024,10 +2024,10 @@ JEDEC MS-018A, variation AA.&lt;/p&gt;
 <wire x1="4.4831" y1="4.4831" x2="3.205" y2="4.4831" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -2238,10 +2238,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-100-50P-1400W-1400L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BED, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BED, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -3966,10 +3966,10 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <rectangle x1="-2.2" y1="1.6" x2="-1.6" y2="2.2" layer="21"/>
 </package>
 <package name="LQFP-48-50P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -4097,10 +4097,10 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <wire x1="1" y1="0.625" x2="1" y2="-0.625" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-32-80P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3" x2="-3.5" y2="-2.6" layer="51"/>
 <rectangle x1="-4.5" y1="-2.2" x2="-3.5" y2="-1.8" layer="51"/>

--- a/atmel-arm.lbr
+++ b/atmel-arm.lbr
@@ -109,10 +109,10 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <text x="-12.7" y="-3.81" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="LQFP-64-50P-1000W-1000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>
@@ -251,10 +251,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-48-50P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -361,10 +361,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-100-50P-1400W-1400L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BED, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BED, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -575,10 +575,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -1946,10 +1946,10 @@ pitch 0.80, outline 15x15 mm</description>
 <rectangle x1="6.096" y1="-1.524" x2="6.604" y2="-1.016" layer="51"/>
 </package>
 <package name="LQFP-144-50P-2000W-2000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -2248,10 +2248,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-144-50P-2000W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>

--- a/atmel-avr.lbr
+++ b/atmel-avr.lbr
@@ -79,10 +79,10 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
 <package name="TQFP-32-80P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3" x2="-3.5" y2="-2.6" layer="51"/>
 <rectangle x1="-4.5" y1="-2.2" x2="-3.5" y2="-1.8" layer="51"/>
@@ -157,10 +157,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-44-80P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -259,10 +259,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-48-50P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -369,10 +369,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-80P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -511,10 +511,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -2535,10 +2535,10 @@ EIAJ EDR-7320.&lt;/p&gt;
 <rectangle x1="0.5" y1="-2" x2="2" y2="-0.5" layer="31"/>
 </package>
 <package name="TQFP-144-50P-2000W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>

--- a/atmel-avr32.lbr
+++ b/atmel-avr32.lbr
@@ -77,10 +77,10 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
 <package name="LQFP-144-50P-2000W-2000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -379,10 +379,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>

--- a/atmel-xmega.lbr
+++ b/atmel-xmega.lbr
@@ -79,10 +79,10 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 20132, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -293,10 +293,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-32-80P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3" x2="-3.5" y2="-2.6" layer="51"/>
 <rectangle x1="-4.5" y1="-2.2" x2="-3.5" y2="-1.8" layer="51"/>
@@ -371,10 +371,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-44-80P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -473,10 +473,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-48-50P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -583,10 +583,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-80P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8" y1="-5.4" x2="-7" y2="-5" layer="51"/>

--- a/atmel.lbr
+++ b/atmel.lbr
@@ -900,10 +900,10 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <rectangle x1="-2.921" y1="-2.159" x2="-2.159" y2="-0.381" layer="51" rot="R180"/>
 </package>
 <package name="TQFP-32-80P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3" x2="-3.5" y2="-2.6" layer="51"/>
 <rectangle x1="-4.5" y1="-2.2" x2="-3.5" y2="-1.8" layer="51"/>
@@ -978,10 +978,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-48-50P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -1088,10 +1088,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-144-50P-2000W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -1390,10 +1390,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-80P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -1783,10 +1783,10 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <wire x1="11.43" y1="11.43" x2="-10.16" y2="11.43" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-48-50P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -1893,10 +1893,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-64-50P-1000W-1000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>
@@ -2177,10 +2177,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <rectangle x1="-3.875" y1="4" x2="-3.625" y2="4.5" layer="51"/>
 </package>
 <package name="TQFP-44-80P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -2279,10 +2279,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>

--- a/cirrus-arm.lbr
+++ b/cirrus-arm.lbr
@@ -484,10 +484,10 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <text x="-12.065" y="-3.81" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="LQFP-208-50P-2800W-2800L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 208 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 208 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BJB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BJB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15" y1="-12.875" x2="-14" y2="-12.625" layer="51"/>
 <rectangle x1="-15" y1="-12.375" x2="-14" y2="-12.125" layer="51"/>

--- a/cirrus.lbr
+++ b/cirrus.lbr
@@ -133,10 +133,10 @@ body 5x5mm/JEDEC MO-220</description>
 <rectangle x1="-2.5" y1="2.1" x2="-2.1" y2="2.5" layer="21"/>
 </package>
 <package name="LQFP-48-50P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -304,10 +304,10 @@ JEDEC MO-153F, variation AD, R-PDSO-G.&lt;/p&gt;
 <wire x1="3.8" y1="2.1" x2="-3.8" y2="2.1" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -1048,10 +1048,10 @@ JEDEC MO-187F, variation BA, TSR-PDSO.&lt;/p&gt;
 <rectangle x1="-3.5" y1="-3.5" x2="-2.5" y2="-2.5" layer="31"/>
 </package>
 <package name="LQFP-64-50P-1000W-1000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>

--- a/cypressmicro.lbr
+++ b/cypressmicro.lbr
@@ -853,10 +853,10 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <wire x1="3.8" y1="2.6" x2="-3.75" y2="2.6" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-44-80P-1000W-1000L-245H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-022B, variation AB, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation AB, PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6.6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -955,10 +955,10 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-48-50P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -2001,10 +2001,10 @@ from micro-philips.lbr</description>
 </polygon>
 </package>
 <package name="TQFP-44-80P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>

--- a/dvs-inc.lbr
+++ b/dvs-inc.lbr
@@ -73,10 +73,10 @@
 <library>
 <packages>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>

--- a/freescale-semi.lbr
+++ b/freescale-semi.lbr
@@ -118,10 +118,10 @@ JEDEC MO-153F, variation AB, R-PDSO-G.&lt;/p&gt;
 <wire x1="2.4" y1="2.1" x2="-2.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-44-80P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>

--- a/ftdi-chip.lbr
+++ b/ftdi-chip.lbr
@@ -90,10 +90,10 @@ Based on the following sources:
 &lt;/p&gt;</description>
 <packages>
 <package name="LQFP-32-80P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3" x2="-3.5" y2="-2.6" layer="51"/>
 <rectangle x1="-4.5" y1="-2.2" x2="-3.5" y2="-1.8" layer="51"/>
@@ -296,10 +296,10 @@ pitch 0.5 mm, body 5x5 mm</description>
 <rectangle x1="-1.25" y1="-1.25" x2="-0.75" y2="-0.75" layer="31"/>
 </package>
 <package name="TQFP-64-50P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>

--- a/isd.lbr
+++ b/isd.lbr
@@ -263,10 +263,10 @@ body 8 X 13.4mm, pitch 0.55mm</description>
 <rectangle x1="2.925" y1="6.275" x2="3.675" y2="6.575" layer="51" rot="R90"/>
 </package>
 <package name="LQFP-48-50P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>

--- a/lattice.lbr
+++ b/lattice.lbr
@@ -644,10 +644,10 @@ JEDEC MS-018A, variation AC.&lt;/p&gt;
 <rectangle x1="-6.31" y1="6.98" x2="-6.09" y2="8" layer="51"/>
 </package>
 <package name="TQFP-44-80P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -746,10 +746,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -960,10 +960,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-144-50P-2000W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>

--- a/luminary-arm.lbr
+++ b/luminary-arm.lbr
@@ -84,10 +84,10 @@ THIS LIBRARY IS PROVIDED AS IS WITHOUT WARRANTY OF ANY KIND, EXPRESSED OR IMPLIE
 http://www.bobstarr.net&lt;/author&gt;</description>
 <packages>
 <package name="LQFP-48-50P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -250,10 +250,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <text x="-5.715" y="-3.81" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="LQFP-100-50P-1400W-1400L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BED, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BED, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>

--- a/maxim.lbr
+++ b/maxim.lbr
@@ -649,10 +649,10 @@ body 5 x 5 mm, pitch 0.8 mm</description>
 <rectangle x1="-0.6" y1="-0.6" x2="-0.1" y2="-0.1" layer="31"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -1289,10 +1289,10 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="TQFP-32-50P-500W-500L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.20mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AAA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AAA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.6" y="-1.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3.5" y1="-1.875" x2="-2.5" y2="-1.625" layer="51"/>
 <rectangle x1="-3.5" y1="-1.375" x2="-2.5" y2="-1.125" layer="51"/>

--- a/micrel.lbr
+++ b/micrel.lbr
@@ -186,10 +186,10 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <wire x1="1.45" y1="0.8" x2="1.45" y2="-0.8" width="0.2032" layer="51"/>
 </package>
 <package name="TQFP-48-50P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -1017,10 +1017,10 @@ body 7.6 x 10.5 mm</description>
 <rectangle x1="-2.25" y1="-3.5" x2="-0.5" y2="-0.5" layer="31"/>
 </package>
 <package name="LQFP-48-50P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>

--- a/micro-fujitsu.lbr
+++ b/micro-fujitsu.lbr
@@ -1716,10 +1716,10 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body 
 <rectangle x1="-9.25" y1="-9.6" x2="-8.75" y2="-7.55" layer="51"/>
 </package>
 <package name="QFP-100-65P-1400W-2000L-315H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-022B, variation GC-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation GC-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-6.36" x2="-10" y2="-5.99" layer="51"/>
 <rectangle x1="-11.6" y1="-5.71" x2="-10" y2="-5.34" layer="51"/>
@@ -2186,10 +2186,10 @@ http://www.fme.gsdc.de</description>
 <rectangle x1="-9" y1="-7.35" x2="-8" y2="-7.15" layer="51"/>
 </package>
 <package name="LQFP-48-50P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>

--- a/micro-motorola.lbr
+++ b/micro-motorola.lbr
@@ -76,10 +76,10 @@ Motorola DRAMs&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
 <package name="QFP-80-65P-1400W-1400L-245H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-022B, variation BC, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation BC, PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.6" y1="-6.36" x2="-7" y2="-5.99" layer="51"/>
 <rectangle x1="-8.6" y1="-5.71" x2="-7" y2="-5.34" layer="51"/>
@@ -826,10 +826,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm widt
 </polygon>
 </package>
 <package name="TQFP-112-65P-2000W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 112 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 112 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.95" x2="-10" y2="-8.6" layer="51"/>
 <rectangle x1="-11" y1="-8.3" x2="-10" y2="-7.95" layer="51"/>
@@ -1064,10 +1064,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-80-65P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.35" x2="-7" y2="-6" layer="51"/>
 <rectangle x1="-8" y1="-5.7" x2="-7" y2="-5.35" layer="51"/>
@@ -2527,10 +2527,10 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 44 leads.
 <wire x1="11.43" y1="11.43" x2="-10.16" y2="11.43" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-64-80P-1400W-1400L-245H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-022B, variation BB, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation BB, PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.6" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8.6" y1="-5.4" x2="-7" y2="-5" layer="51"/>

--- a/micro-philips.lbr
+++ b/micro-philips.lbr
@@ -410,10 +410,10 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <wire x1="12.1158" y1="12.1158" x2="10.825" y2="12.1158" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-100-65P-1400W-2000L-315H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-022B, variation GC-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation GC-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-6.36" x2="-10" y2="-5.99" layer="51"/>
 <rectangle x1="-11.6" y1="-5.71" x2="-10" y2="-5.34" layer="51"/>
@@ -1480,10 +1480,10 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <rectangle x1="-10.1001" y1="-6.51" x2="-7.5999" y2="-6.19" layer="51"/>
 </package>
 <package name="QFP-44-80P-1000W-1000L-245H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-022B, variation AB, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation AB, PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6.6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -1682,10 +1682,10 @@ LQFP-MSQFP-QFP-SQFP-TQFP-REFLOW.pdf</description>
 <rectangle x1="-9.2" y1="-5.25" x2="-7.35" y2="-4.75" layer="51"/>
 </package>
 <package name="QFP-52-65P-1000W-1000L-245H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-022B, variation AC, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation AC, PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.6" y1="-4.085" x2="-5" y2="-3.715" layer="51"/>
 <rectangle x1="-6.6" y1="-3.435" x2="-5" y2="-3.065" layer="51"/>
@@ -1800,10 +1800,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-64-100P-1400W-2000L-345H-195F">
-<description>&lt;b&gt;QFP (1.00mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (1.00mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.45mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.45mm max height, 64 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation CA-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation CA-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.95" y1="-6.225" x2="-10" y2="-5.775" layer="21"/>
 <rectangle x1="-11.95" y1="-5.225" x2="-10" y2="-4.775" layer="21"/>
@@ -1942,10 +1942,10 @@ Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 20mm length, 14mm wi
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-64-80P-1400W-1400L-315H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm width, 3.15mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-022B, variation BE, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation BE, PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.6" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8.6" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -2428,10 +2428,10 @@ LQFP-MSQFP-QFP-SQFP-TQFP-REFLOW.pdf</description>
 <rectangle x1="-11.65" y1="-6.15" x2="-10.05" y2="-5.85" layer="51"/>
 </package>
 <package name="QFP-80-65P-1400W-1400L-315H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm width, 3.15mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-022B, variation BF, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation BF, PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.6" y1="-6.36" x2="-7" y2="-5.99" layer="51"/>
 <rectangle x1="-8.6" y1="-5.71" x2="-7" y2="-5.34" layer="51"/>
@@ -2602,10 +2602,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-100-65P-1400W-2000L-340H-195F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation CC-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation CC-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.95" y1="-6.35" x2="-10" y2="-6" layer="51"/>
 <rectangle x1="-11.95" y1="-5.7" x2="-10" y2="-5.35" layer="51"/>
@@ -2816,10 +2816,10 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 20mm length, 14mm wi
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-128-80P-2800W-2800L-385H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 128 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 128 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DB-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DB-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-12.6" x2="-14" y2="-12.2" layer="51"/>
 <rectangle x1="-15.6" y1="-11.8" x2="-14" y2="-11.4" layer="51"/>
@@ -4464,10 +4464,10 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <wire x1="4.45" y1="2.6" x2="-4.4" y2="2.6" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-144-50P-2000W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>

--- a/micro-siemens.lbr
+++ b/micro-siemens.lbr
@@ -77,10 +77,10 @@ www.siemens.de&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
 <package name="QFP-100-65P-1400W-2000L-315H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-022B, variation GC-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation GC-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-6.36" x2="-10" y2="-5.99" layer="51"/>
 <rectangle x1="-11.6" y1="-5.71" x2="-10" y2="-5.34" layer="51"/>
@@ -465,10 +465,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <rectangle x1="-11.473" y1="-6.2" x2="-9.873" y2="-5.8" layer="51"/>
 </package>
 <package name="QFP-80-65P-1400W-1400L-245H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-022B, variation BC, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation BC, PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.6" y1="-6.36" x2="-7" y2="-5.99" layer="51"/>
 <rectangle x1="-8.6" y1="-5.71" x2="-7" y2="-5.34" layer="51"/>
@@ -639,10 +639,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-64-80P-1400W-1400L-245H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-022B, variation BB, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation BB, PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.6" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8.6" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -781,10 +781,10 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-44-80P-1000W-1000L-245H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-022B, variation AB, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation AB, PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6.6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -883,10 +883,10 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-144-65P-2800W-2800L-385H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DC-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DC-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-11.56" x2="-14" y2="-11.19" layer="51"/>
 <rectangle x1="-15.6" y1="-10.91" x2="-14" y2="-10.54" layer="51"/>
@@ -1185,10 +1185,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-160-65P-2800W-2800L-385H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 160 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 160 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DD-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DD-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-12.86" x2="-14" y2="-12.49" layer="51"/>
 <rectangle x1="-15.6" y1="-12.21" x2="-14" y2="-11.84" layer="51"/>
@@ -1519,10 +1519,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-48-50P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -1896,10 +1896,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <rectangle x1="7.61" y1="-10.873" x2="7.885" y2="-9.868" layer="51"/>
 </package>
 <package name="TQFP-144-50P-2000W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -2198,10 +2198,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-176-40P-2000W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 176 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.7" x2="-10" y2="-8.5" layer="51"/>
 <rectangle x1="-11" y1="-8.3" x2="-10" y2="-8.1" layer="51"/>
@@ -2945,8 +2945,8 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20m
 <package name="QFP-208-50P-2800W-2800L-385H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation FA-2, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation FA-2, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.3" y1="-12.875" x2="-14" y2="-12.625" layer="51"/>
 <rectangle x1="-15.3" y1="-12.375" x2="-14" y2="-12.125" layer="51"/>
@@ -6794,10 +6794,10 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 68 leads.
 <rectangle x1="-16.5001" y1="-12.86" x2="-14" y2="-12.54" layer="51"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -7049,10 +7049,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 </polygon>
 </package>
 <package name="TQFP-64-50P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>

--- a/microchip.lbr
+++ b/microchip.lbr
@@ -481,10 +481,10 @@ Source: http://www.microchip.com .. 39637a.pdf</description>
 <rectangle x1="-1.7355" y1="-1.7355" x2="1.7355" y2="1.7355" layer="31"/>
 </package>
 <package name="TQFP-80-50P-1200W-1200L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ADD, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ADD, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-4.875" x2="-6" y2="-4.625" layer="51"/>
 <rectangle x1="-7" y1="-4.375" x2="-6" y2="-4.125" layer="51"/>
@@ -1815,10 +1815,10 @@ JEDEC MS-018A, variation AA.&lt;/p&gt;
 <wire x1="4.4831" y1="4.4831" x2="3.205" y2="4.4831" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-80P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -1986,10 +1986,10 @@ JEDEC MO-153F, variation AA, R-PDSO-G.&lt;/p&gt;
 <wire x1="1.4" y1="2.1" x2="-1.4" y2="2.1" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -2905,10 +2905,10 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <wire x1="5.1" y1="2.6" x2="-5.05" y2="2.6" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-44-80P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -3007,10 +3007,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-50P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>
@@ -3283,10 +3283,10 @@ type I, package type TS</description>
 <rectangle x1="-0.425" y1="-6.75" x2="-0.125" y2="-5.55" layer="51"/>
 </package>
 <package name="QFP-44-80P-1000W-1000L-245H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-022B, variation AB, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation AB, PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6.6" y1="-3.4" x2="-5" y2="-3" layer="51"/>

--- a/micronas.lbr
+++ b/micronas.lbr
@@ -73,10 +73,10 @@
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
 <package name="QFP-44-80P-1000W-1000L-245H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-022B, variation AB, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation AB, PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6.6" y1="-3.4" x2="-5" y2="-3" layer="51"/>

--- a/nxp-arm.lbr
+++ b/nxp-arm.lbr
@@ -1649,10 +1649,10 @@ Samtech</description>
 <rectangle x1="11.176" y1="-1.524" x2="11.684" y2="-1.016" layer="51"/>
 </package>
 <package name="LQFP-80-50P-1200W-1200L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BDD, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BDD, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-4.875" x2="-6" y2="-4.625" layer="51"/>
 <rectangle x1="-7" y1="-4.375" x2="-6" y2="-4.125" layer="51"/>
@@ -2093,10 +2093,10 @@ Samtec FTSH-105-01-L-DV-K</description>
 <text x="-4.445" y="-3.81" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="LQFP-64-50P-1000W-1000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>
@@ -2235,10 +2235,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-100-50P-1400W-1400L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BED, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BED, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -2449,10 +2449,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-144-50P-2000W-2000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -2967,10 +2967,10 @@ outline SOT926-1</description>
 </polygon>
 </package>
 <package name="LQFP-48-50P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>

--- a/oxford-semi.lbr
+++ b/oxford-semi.lbr
@@ -77,10 +77,10 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>

--- a/philips-6.lbr
+++ b/philips-6.lbr
@@ -404,10 +404,10 @@ JEDEC MS-018A, variation AE.&lt;/p&gt;
 <wire x1="12.1158" y1="12.1158" x2="10.825" y2="12.1158" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-100-65P-1400W-2000L-315H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-022B, variation GC-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation GC-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-6.36" x2="-10" y2="-5.99" layer="51"/>
 <rectangle x1="-11.6" y1="-5.71" x2="-10" y2="-5.34" layer="51"/>
@@ -864,10 +864,10 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
 <package name="TQFP-144-50P-2000W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -1200,10 +1200,10 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
 </package>
 <package name="TQFP-64-50P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>
@@ -1631,10 +1631,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <rectangle x1="-5.207" y1="-2.9718" x2="-4.953" y2="-2.7178" layer="21"/>
 </package>
 <package name="LQFP-64-50P-1000W-1000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>
@@ -1920,10 +1920,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <rectangle x1="-11.557" y1="-2.9718" x2="-11.303" y2="-2.7178" layer="21"/>
 </package>
 <package name="LQFP-48-50P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>

--- a/quickfilter.lbr
+++ b/quickfilter.lbr
@@ -77,10 +77,10 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
 <package name="LQFP-32-80P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3" x2="-3.5" y2="-2.6" layer="51"/>
 <rectangle x1="-4.5" y1="-2.2" x2="-3.5" y2="-1.8" layer="51"/>

--- a/ref-packages-lqfp.lbr
+++ b/ref-packages-lqfp.lbr
@@ -66,10 +66,10 @@
 NOTE: This library is used to globally update common IC packages in all other libraries.&lt;p&gt;</description>
 <packages>
 <package name="LQFP-36-100P-1000W-1000L-160H">
-<description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 36 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 36 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.225" x2="-5" y2="-3.775" layer="51"/>
 <rectangle x1="-6" y1="-3.225" x2="-5" y2="-2.775" layer="51"/>
@@ -152,10 +152,10 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-36-100P-1000W-1000L-160H-EP">
-<description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 36 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 36 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCA-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCA-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.225" x2="-5" y2="-3.775" layer="51"/>
 <rectangle x1="-6" y1="-3.225" x2="-5" y2="-2.775" layer="51"/>
@@ -170,14 +170,24 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm
 <rectangle x1="-4.225" y1="5" x2="-3.775" y2="6" layer="51"/>
 <rectangle x1="-3.225" y1="-6" x2="-2.775" y2="-5" layer="51"/>
 <rectangle x1="-3.225" y1="5" x2="-2.775" y2="6" layer="51"/>
+<rectangle x1="-2.5" y1="-2.5" x2="2.5" y2="2.5" layer="29"/>
+<rectangle x1="-2.3639" y1="-2.3639" x2="-0.9694" y2="-0.9694" layer="31"/>
+<rectangle x1="-2.3639" y1="-0.6972" x2="-0.9694" y2="0.6972" layer="31"/>
+<rectangle x1="-2.3639" y1="0.9694" x2="-0.9694" y2="2.3639" layer="31"/>
 <rectangle x1="-2.225" y1="-6" x2="-1.775" y2="-5" layer="51"/>
 <rectangle x1="-2.225" y1="5" x2="-1.775" y2="6" layer="51"/>
 <rectangle x1="-1.225" y1="-6" x2="-0.775" y2="-5" layer="51"/>
 <rectangle x1="-1.225" y1="5" x2="-0.775" y2="6" layer="51"/>
+<rectangle x1="-0.6972" y1="-2.3639" x2="0.6972" y2="-0.9694" layer="31"/>
+<rectangle x1="-0.6972" y1="-0.6972" x2="0.6972" y2="0.6972" layer="31"/>
+<rectangle x1="-0.6972" y1="0.9694" x2="0.6972" y2="2.3639" layer="31"/>
 <rectangle x1="-0.225" y1="-6" x2="0.225" y2="-5" layer="51"/>
 <rectangle x1="-0.225" y1="5" x2="0.225" y2="6" layer="51"/>
 <rectangle x1="0.775" y1="-6" x2="1.225" y2="-5" layer="51"/>
 <rectangle x1="0.775" y1="5" x2="1.225" y2="6" layer="51"/>
+<rectangle x1="0.9694" y1="-2.3639" x2="2.3639" y2="-0.9694" layer="31"/>
+<rectangle x1="0.9694" y1="-0.6972" x2="2.3639" y2="0.6972" layer="31"/>
+<rectangle x1="0.9694" y1="0.9694" x2="2.3639" y2="2.3639" layer="31"/>
 <rectangle x1="1.775" y1="-6" x2="2.225" y2="-5" layer="51"/>
 <rectangle x1="1.775" y1="5" x2="2.225" y2="6" layer="51"/>
 <rectangle x1="2.775" y1="-6" x2="3.225" y2="-5" layer="51"/>
@@ -229,7 +239,8 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm
 <smd name="34" x="-5.9" y="-2" dx="1.5" dy="0.55" layer="1"/>
 <smd name="35" x="-5.9" y="-3" dx="1.5" dy="0.55" layer="1"/>
 <smd name="36" x="-5.9" y="-4" dx="1.5" dy="0.55" layer="1"/>
-<smd name="EP" x="0" y="0" dx="5" dy="5" layer="1"/><text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="5.2" dy="5.2" layer="1" stop="no" cream="no"/>
+<text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-4.5" y="7" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-4.9" y1="-4.5" x2="-4.5" y2="-4.9" width="0.2032" layer="21"/>
 <wire x1="-4.9" y1="4.9" x2="-4.9" y2="-4.5" width="0.2032" layer="21"/>
@@ -238,10 +249,10 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-44-100P-1200W-1200L-160H">
-<description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BDA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BDA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-5.225" x2="-6" y2="-4.775" layer="51"/>
 <rectangle x1="-7" y1="-4.225" x2="-6" y2="-3.775" layer="51"/>
@@ -340,10 +351,10 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-44-100P-1200W-1200L-160H-EP">
-<description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BDA-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BDA-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-5.225" x2="-6" y2="-4.775" layer="51"/>
 <rectangle x1="-7" y1="-4.225" x2="-6" y2="-3.775" layer="51"/>
@@ -362,14 +373,24 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm
 <rectangle x1="-4.225" y1="6" x2="-3.775" y2="7" layer="51"/>
 <rectangle x1="-3.225" y1="-7" x2="-2.775" y2="-6" layer="51"/>
 <rectangle x1="-3.225" y1="6" x2="-2.775" y2="7" layer="51"/>
+<rectangle x1="-3" y1="-3" x2="3" y2="3" layer="29"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
 <rectangle x1="-2.225" y1="-7" x2="-1.775" y2="-6" layer="51"/>
 <rectangle x1="-2.225" y1="6" x2="-1.775" y2="7" layer="51"/>
 <rectangle x1="-1.225" y1="-7" x2="-0.775" y2="-6" layer="51"/>
 <rectangle x1="-1.225" y1="6" x2="-0.775" y2="7" layer="51"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
 <rectangle x1="-0.225" y1="-7" x2="0.225" y2="-6" layer="51"/>
 <rectangle x1="-0.225" y1="6" x2="0.225" y2="7" layer="51"/>
 <rectangle x1="0.775" y1="-7" x2="1.225" y2="-6" layer="51"/>
 <rectangle x1="0.775" y1="6" x2="1.225" y2="7" layer="51"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
 <rectangle x1="1.775" y1="-7" x2="2.225" y2="-6" layer="51"/>
 <rectangle x1="1.775" y1="6" x2="2.225" y2="7" layer="51"/>
 <rectangle x1="2.775" y1="-7" x2="3.225" y2="-6" layer="51"/>
@@ -433,7 +454,8 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm
 <smd name="42" x="-6.9" y="-3" dx="1.5" dy="0.55" layer="1"/>
 <smd name="43" x="-6.9" y="-4" dx="1.5" dy="0.55" layer="1"/>
 <smd name="44" x="-6.9" y="-5" dx="1.5" dy="0.55" layer="1"/>
-<smd name="EP" x="0" y="0" dx="6" dy="6" layer="1"/><text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="6.2" dy="6.2" layer="1" stop="no" cream="no"/>
+<text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-5.5" y="8" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-5.9" y1="-5.5" x2="-5.5" y2="-5.9" width="0.2032" layer="21"/>
 <wire x1="-5.9" y1="5.9" x2="-5.9" y2="-5.5" width="0.2032" layer="21"/>
@@ -442,10 +464,10 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-52-100P-1400W-1400L-160H">
-<description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BEA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BEA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.225" x2="-7" y2="-5.775" layer="51"/>
 <rectangle x1="-8" y1="-5.225" x2="-7" y2="-4.775" layer="51"/>
@@ -560,10 +582,10 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-52-100P-1400W-1400L-160H-EP">
-<description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (1.00mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BEA-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BEA-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.225" x2="-7" y2="-5.775" layer="51"/>
 <rectangle x1="-8" y1="-5.225" x2="-7" y2="-4.775" layer="51"/>
@@ -584,18 +606,35 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm
 <rectangle x1="-5.225" y1="7" x2="-4.775" y2="8" layer="51"/>
 <rectangle x1="-4.225" y1="-8" x2="-3.775" y2="-7" layer="51"/>
 <rectangle x1="-4.225" y1="7" x2="-3.775" y2="8" layer="51"/>
+<rectangle x1="-3.5" y1="-3.5" x2="3.5" y2="3.5" layer="29"/>
+<rectangle x1="-3.3571" y1="-3.3571" x2="-1.8929" y2="-1.8929" layer="31"/>
+<rectangle x1="-3.3571" y1="-1.6071" x2="-1.8929" y2="-0.1429" layer="31"/>
+<rectangle x1="-3.3571" y1="0.1429" x2="-1.8929" y2="1.6071" layer="31"/>
+<rectangle x1="-3.3571" y1="1.8929" x2="-1.8929" y2="3.3571" layer="31"/>
 <rectangle x1="-3.225" y1="-8" x2="-2.775" y2="-7" layer="51"/>
 <rectangle x1="-3.225" y1="7" x2="-2.775" y2="8" layer="51"/>
 <rectangle x1="-2.225" y1="-8" x2="-1.775" y2="-7" layer="51"/>
 <rectangle x1="-2.225" y1="7" x2="-1.775" y2="8" layer="51"/>
+<rectangle x1="-1.6071" y1="-3.3571" x2="-0.1429" y2="-1.8929" layer="31"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
+<rectangle x1="-1.6071" y1="1.8929" x2="-0.1429" y2="3.3571" layer="31"/>
 <rectangle x1="-1.225" y1="-8" x2="-0.775" y2="-7" layer="51"/>
 <rectangle x1="-1.225" y1="7" x2="-0.775" y2="8" layer="51"/>
 <rectangle x1="-0.225" y1="-8" x2="0.225" y2="-7" layer="51"/>
 <rectangle x1="-0.225" y1="7" x2="0.225" y2="8" layer="51"/>
+<rectangle x1="0.1429" y1="-3.3571" x2="1.6071" y2="-1.8929" layer="31"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
+<rectangle x1="0.1429" y1="1.8929" x2="1.6071" y2="3.3571" layer="31"/>
 <rectangle x1="0.775" y1="-8" x2="1.225" y2="-7" layer="51"/>
 <rectangle x1="0.775" y1="7" x2="1.225" y2="8" layer="51"/>
 <rectangle x1="1.775" y1="-8" x2="2.225" y2="-7" layer="51"/>
 <rectangle x1="1.775" y1="7" x2="2.225" y2="8" layer="51"/>
+<rectangle x1="1.8929" y1="-3.3571" x2="3.3571" y2="-1.8929" layer="31"/>
+<rectangle x1="1.8929" y1="-1.6071" x2="3.3571" y2="-0.1429" layer="31"/>
+<rectangle x1="1.8929" y1="0.1429" x2="3.3571" y2="1.6071" layer="31"/>
+<rectangle x1="1.8929" y1="1.8929" x2="3.3571" y2="3.3571" layer="31"/>
 <rectangle x1="2.775" y1="-8" x2="3.225" y2="-7" layer="51"/>
 <rectangle x1="2.775" y1="7" x2="3.225" y2="8" layer="51"/>
 <rectangle x1="3.775" y1="-8" x2="4.225" y2="-7" layer="51"/>
@@ -669,7 +708,8 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm
 <smd name="50" x="-7.9" y="-4" dx="1.5" dy="0.55" layer="1"/>
 <smd name="51" x="-7.9" y="-5" dx="1.5" dy="0.55" layer="1"/>
 <smd name="52" x="-7.9" y="-6" dx="1.5" dy="0.55" layer="1"/>
-<smd name="EP" x="0" y="0" dx="7" dy="7" layer="1"/><text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="7.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-6.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-6.9" y1="-6.5" x2="-6.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-6.9" y1="6.9" x2="-6.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -678,10 +718,10 @@ Low profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-80-40P-1000W-1000L-160H">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCE, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCE, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.9" x2="-5" y2="-3.7" layer="51"/>
 <rectangle x1="-6" y1="-3.5" x2="-5" y2="-3.3" layer="51"/>
@@ -852,10 +892,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-80-40P-1000W-1000L-160H-EP">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCE-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCE-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.9" x2="-5" y2="-3.7" layer="51"/>
 <rectangle x1="-6" y1="-3.5" x2="-5" y2="-3.3" layer="51"/>
@@ -885,6 +925,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm
 <rectangle x1="-3.1" y1="5" x2="-2.9" y2="6" layer="51"/>
 <rectangle x1="-2.7" y1="-6" x2="-2.5" y2="-5" layer="51"/>
 <rectangle x1="-2.7" y1="5" x2="-2.5" y2="6" layer="51"/>
+<rectangle x1="-2.5" y1="-2.5" x2="2.5" y2="2.5" layer="29"/>
+<rectangle x1="-2.3639" y1="-2.3639" x2="-0.9694" y2="-0.9694" layer="31"/>
+<rectangle x1="-2.3639" y1="-0.6972" x2="-0.9694" y2="0.6972" layer="31"/>
+<rectangle x1="-2.3639" y1="0.9694" x2="-0.9694" y2="2.3639" layer="31"/>
 <rectangle x1="-2.3" y1="-6" x2="-2.1" y2="-5" layer="51"/>
 <rectangle x1="-2.3" y1="5" x2="-2.1" y2="6" layer="51"/>
 <rectangle x1="-1.9" y1="-6" x2="-1.7" y2="-5" layer="51"/>
@@ -895,6 +939,9 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm
 <rectangle x1="-1.1" y1="5" x2="-0.9" y2="6" layer="51"/>
 <rectangle x1="-0.7" y1="-6" x2="-0.5" y2="-5" layer="51"/>
 <rectangle x1="-0.7" y1="5" x2="-0.5" y2="6" layer="51"/>
+<rectangle x1="-0.6972" y1="-2.3639" x2="0.6972" y2="-0.9694" layer="31"/>
+<rectangle x1="-0.6972" y1="-0.6972" x2="0.6972" y2="0.6972" layer="31"/>
+<rectangle x1="-0.6972" y1="0.9694" x2="0.6972" y2="2.3639" layer="31"/>
 <rectangle x1="-0.3" y1="-6" x2="-0.1" y2="-5" layer="51"/>
 <rectangle x1="-0.3" y1="5" x2="-0.1" y2="6" layer="51"/>
 <rectangle x1="0.1" y1="-6" x2="0.3" y2="-5" layer="51"/>
@@ -903,6 +950,9 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm
 <rectangle x1="0.5" y1="5" x2="0.7" y2="6" layer="51"/>
 <rectangle x1="0.9" y1="-6" x2="1.1" y2="-5" layer="51"/>
 <rectangle x1="0.9" y1="5" x2="1.1" y2="6" layer="51"/>
+<rectangle x1="0.9694" y1="-2.3639" x2="2.3639" y2="-0.9694" layer="31"/>
+<rectangle x1="0.9694" y1="-0.6972" x2="2.3639" y2="0.6972" layer="31"/>
+<rectangle x1="0.9694" y1="0.9694" x2="2.3639" y2="2.3639" layer="31"/>
 <rectangle x1="1.3" y1="-6" x2="1.5" y2="-5" layer="51"/>
 <rectangle x1="1.3" y1="5" x2="1.5" y2="6" layer="51"/>
 <rectangle x1="1.7" y1="-6" x2="1.9" y2="-5" layer="51"/>
@@ -1017,7 +1067,8 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm
 <smd name="78" x="-5.8" y="-3" dx="1.2" dy="0.23" layer="1"/>
 <smd name="79" x="-5.8" y="-3.4" dx="1.2" dy="0.23" layer="1"/>
 <smd name="80" x="-5.8" y="-3.8" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="5" dy="5" layer="1"/><text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="5.2" dy="5.2" layer="1" stop="no" cream="no"/>
+<text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-4.5" y="7" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-4.9" y1="-4.5" x2="-4.5" y2="-4.9" width="0.2032" layer="21"/>
 <wire x1="-4.9" y1="4.9" x2="-4.9" y2="-4.5" width="0.2032" layer="21"/>
@@ -1026,10 +1077,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-100-40P-1200W-1200L-160H">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BDE, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BDE, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-4.9" x2="-6" y2="-4.7" layer="51"/>
 <rectangle x1="-7" y1="-4.5" x2="-6" y2="-4.3" layer="51"/>
@@ -1240,10 +1291,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-100-40P-1200W-1200L-160H-EP">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BDE-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BDE-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-4.9" x2="-6" y2="-4.7" layer="51"/>
 <rectangle x1="-7" y1="-4.5" x2="-6" y2="-4.3" layer="51"/>
@@ -1280,8 +1331,12 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm
 <rectangle x1="-3.7" y1="6" x2="-3.5" y2="7" layer="51"/>
 <rectangle x1="-3.3" y1="-7" x2="-3.1" y2="-6" layer="51"/>
 <rectangle x1="-3.3" y1="6" x2="-3.1" y2="7" layer="51"/>
+<rectangle x1="-3" y1="-3" x2="3" y2="3" layer="29"/>
 <rectangle x1="-2.9" y1="-7" x2="-2.7" y2="-6" layer="51"/>
 <rectangle x1="-2.9" y1="6" x2="-2.7" y2="7" layer="51"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
 <rectangle x1="-2.5" y1="-7" x2="-2.3" y2="-6" layer="51"/>
 <rectangle x1="-2.5" y1="6" x2="-2.3" y2="7" layer="51"/>
 <rectangle x1="-2.1" y1="-7" x2="-1.9" y2="-6" layer="51"/>
@@ -1292,6 +1347,9 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm
 <rectangle x1="-1.3" y1="6" x2="-1.1" y2="7" layer="51"/>
 <rectangle x1="-0.9" y1="-7" x2="-0.7" y2="-6" layer="51"/>
 <rectangle x1="-0.9" y1="6" x2="-0.7" y2="7" layer="51"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
 <rectangle x1="-0.5" y1="-7" x2="-0.3" y2="-6" layer="51"/>
 <rectangle x1="-0.5" y1="6" x2="-0.3" y2="7" layer="51"/>
 <rectangle x1="-0.1" y1="-7" x2="0.1" y2="-6" layer="51"/>
@@ -1302,6 +1360,9 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm
 <rectangle x1="0.7" y1="6" x2="0.9" y2="7" layer="51"/>
 <rectangle x1="1.1" y1="-7" x2="1.3" y2="-6" layer="51"/>
 <rectangle x1="1.1" y1="6" x2="1.3" y2="7" layer="51"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
 <rectangle x1="1.5" y1="-7" x2="1.7" y2="-6" layer="51"/>
 <rectangle x1="1.5" y1="6" x2="1.7" y2="7" layer="51"/>
 <rectangle x1="1.9" y1="-7" x2="2.1" y2="-6" layer="51"/>
@@ -1445,7 +1506,8 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm
 <smd name="98" x="-6.8" y="-4" dx="1.2" dy="0.23" layer="1"/>
 <smd name="99" x="-6.8" y="-4.4" dx="1.2" dy="0.23" layer="1"/>
 <smd name="100" x="-6.8" y="-4.8" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="6" dy="6" layer="1"/><text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="6.2" dy="6.2" layer="1" stop="no" cream="no"/>
+<text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-5.5" y="8" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-5.9" y1="-5.5" x2="-5.5" y2="-5.9" width="0.2032" layer="21"/>
 <wire x1="-5.9" y1="5.9" x2="-5.9" y2="-5.5" width="0.2032" layer="21"/>
@@ -1454,10 +1516,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-120-40P-1400W-1400L-160H">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 120 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 120 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BEE, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BEE, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-5.9" x2="-7" y2="-5.7" layer="51"/>
 <rectangle x1="-8" y1="-5.5" x2="-7" y2="-5.3" layer="51"/>
@@ -1708,10 +1770,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-120-40P-1400W-1400L-160H-EP">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 120 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 120 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BEE-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BEE-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-5.9" x2="-7" y2="-5.7" layer="51"/>
 <rectangle x1="-8" y1="-5.5" x2="-7" y2="-5.3" layer="51"/>
@@ -1756,7 +1818,12 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm
 <rectangle x1="-3.9" y1="-8" x2="-3.7" y2="-7" layer="51"/>
 <rectangle x1="-3.9" y1="7" x2="-3.7" y2="8" layer="51"/>
 <rectangle x1="-3.5" y1="-8" x2="-3.3" y2="-7" layer="51"/>
+<rectangle x1="-3.5" y1="-3.5" x2="3.5" y2="3.5" layer="29"/>
 <rectangle x1="-3.5" y1="7" x2="-3.3" y2="8" layer="51"/>
+<rectangle x1="-3.3571" y1="-3.3571" x2="-1.8929" y2="-1.8929" layer="31"/>
+<rectangle x1="-3.3571" y1="-1.6071" x2="-1.8929" y2="-0.1429" layer="31"/>
+<rectangle x1="-3.3571" y1="0.1429" x2="-1.8929" y2="1.6071" layer="31"/>
+<rectangle x1="-3.3571" y1="1.8929" x2="-1.8929" y2="3.3571" layer="31"/>
 <rectangle x1="-3.1" y1="-8" x2="-2.9" y2="-7" layer="51"/>
 <rectangle x1="-3.1" y1="7" x2="-2.9" y2="8" layer="51"/>
 <rectangle x1="-2.7" y1="-8" x2="-2.5" y2="-7" layer="51"/>
@@ -1765,6 +1832,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm
 <rectangle x1="-2.3" y1="7" x2="-2.1" y2="8" layer="51"/>
 <rectangle x1="-1.9" y1="-8" x2="-1.7" y2="-7" layer="51"/>
 <rectangle x1="-1.9" y1="7" x2="-1.7" y2="8" layer="51"/>
+<rectangle x1="-1.6071" y1="-3.3571" x2="-0.1429" y2="-1.8929" layer="31"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
+<rectangle x1="-1.6071" y1="1.8929" x2="-0.1429" y2="3.3571" layer="31"/>
 <rectangle x1="-1.5" y1="-8" x2="-1.3" y2="-7" layer="51"/>
 <rectangle x1="-1.5" y1="7" x2="-1.3" y2="8" layer="51"/>
 <rectangle x1="-1.1" y1="-8" x2="-0.9" y2="-7" layer="51"/>
@@ -1775,6 +1846,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm
 <rectangle x1="-0.3" y1="7" x2="-0.1" y2="8" layer="51"/>
 <rectangle x1="0.1" y1="-8" x2="0.3" y2="-7" layer="51"/>
 <rectangle x1="0.1" y1="7" x2="0.3" y2="8" layer="51"/>
+<rectangle x1="0.1429" y1="-3.3571" x2="1.6071" y2="-1.8929" layer="31"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
+<rectangle x1="0.1429" y1="1.8929" x2="1.6071" y2="3.3571" layer="31"/>
 <rectangle x1="0.5" y1="-8" x2="0.7" y2="-7" layer="51"/>
 <rectangle x1="0.5" y1="7" x2="0.7" y2="8" layer="51"/>
 <rectangle x1="0.9" y1="-8" x2="1.1" y2="-7" layer="51"/>
@@ -1783,6 +1858,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm
 <rectangle x1="1.3" y1="7" x2="1.5" y2="8" layer="51"/>
 <rectangle x1="1.7" y1="-8" x2="1.9" y2="-7" layer="51"/>
 <rectangle x1="1.7" y1="7" x2="1.9" y2="8" layer="51"/>
+<rectangle x1="1.8929" y1="-3.3571" x2="3.3571" y2="-1.8929" layer="31"/>
+<rectangle x1="1.8929" y1="-1.6071" x2="3.3571" y2="-0.1429" layer="31"/>
+<rectangle x1="1.8929" y1="0.1429" x2="3.3571" y2="1.6071" layer="31"/>
+<rectangle x1="1.8929" y1="1.8929" x2="3.3571" y2="3.3571" layer="31"/>
 <rectangle x1="2.1" y1="-8" x2="2.3" y2="-7" layer="51"/>
 <rectangle x1="2.1" y1="7" x2="2.3" y2="8" layer="51"/>
 <rectangle x1="2.5" y1="-8" x2="2.7" y2="-7" layer="51"/>
@@ -1953,7 +2032,8 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm
 <smd name="118" x="-7.8" y="-5" dx="1.2" dy="0.23" layer="1"/>
 <smd name="119" x="-7.8" y="-5.4" dx="1.2" dy="0.23" layer="1"/>
 <smd name="120" x="-7.8" y="-5.8" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="7" dy="7" layer="1"/><text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="7.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-6.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-6.9" y1="-6.5" x2="-6.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-6.9" y1="6.9" x2="-6.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -1962,10 +2042,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-176-40P-2000W-2000L-160H">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 176 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 176 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BFC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BFC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.7" x2="-10" y2="-8.5" layer="51"/>
 <rectangle x1="-11" y1="-8.3" x2="-10" y2="-8.1" layer="51"/>
@@ -2328,10 +2408,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-176-40P-2000W-2000L-160H-EP">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 176 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 176 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BFC-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BFC-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.7" x2="-10" y2="-8.5" layer="51"/>
 <rectangle x1="-11" y1="-8.3" x2="-10" y2="-8.1" layer="51"/>
@@ -2397,6 +2477,12 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm
 <rectangle x1="-5.5" y1="10" x2="-5.3" y2="11" layer="51"/>
 <rectangle x1="-5.1" y1="-11" x2="-4.9" y2="-10" layer="51"/>
 <rectangle x1="-5.1" y1="10" x2="-4.9" y2="11" layer="51"/>
+<rectangle x1="-5" y1="-5" x2="5" y2="5" layer="29"/>
+<rectangle x1="-4.8367" y1="-4.8367" x2="-3.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-2.8367" x2="-3.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-0.8367" x2="-3.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="1.1633" x2="-3.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="3.1633" x2="-3.1633" y2="4.8367" layer="31"/>
 <rectangle x1="-4.7" y1="-11" x2="-4.5" y2="-10" layer="51"/>
 <rectangle x1="-4.7" y1="10" x2="-4.5" y2="11" layer="51"/>
 <rectangle x1="-4.3" y1="-11" x2="-4.1" y2="-10" layer="51"/>
@@ -2407,6 +2493,11 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm
 <rectangle x1="-3.5" y1="10" x2="-3.3" y2="11" layer="51"/>
 <rectangle x1="-3.1" y1="-11" x2="-2.9" y2="-10" layer="51"/>
 <rectangle x1="-3.1" y1="10" x2="-2.9" y2="11" layer="51"/>
+<rectangle x1="-2.8367" y1="-4.8367" x2="-1.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="3.1633" x2="-1.1633" y2="4.8367" layer="31"/>
 <rectangle x1="-2.7" y1="-11" x2="-2.5" y2="-10" layer="51"/>
 <rectangle x1="-2.7" y1="10" x2="-2.5" y2="11" layer="51"/>
 <rectangle x1="-2.3" y1="-11" x2="-2.1" y2="-10" layer="51"/>
@@ -2417,6 +2508,11 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm
 <rectangle x1="-1.5" y1="10" x2="-1.3" y2="11" layer="51"/>
 <rectangle x1="-1.1" y1="-11" x2="-0.9" y2="-10" layer="51"/>
 <rectangle x1="-1.1" y1="10" x2="-0.9" y2="11" layer="51"/>
+<rectangle x1="-0.8367" y1="-4.8367" x2="0.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="3.1633" x2="0.8367" y2="4.8367" layer="31"/>
 <rectangle x1="-0.7" y1="-11" x2="-0.5" y2="-10" layer="51"/>
 <rectangle x1="-0.7" y1="10" x2="-0.5" y2="11" layer="51"/>
 <rectangle x1="-0.3" y1="-11" x2="-0.1" y2="-10" layer="51"/>
@@ -2427,6 +2523,11 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm
 <rectangle x1="0.5" y1="10" x2="0.7" y2="11" layer="51"/>
 <rectangle x1="0.9" y1="-11" x2="1.1" y2="-10" layer="51"/>
 <rectangle x1="0.9" y1="10" x2="1.1" y2="11" layer="51"/>
+<rectangle x1="1.1633" y1="-4.8367" x2="2.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
+<rectangle x1="1.1633" y1="3.1633" x2="2.8367" y2="4.8367" layer="31"/>
 <rectangle x1="1.3" y1="-11" x2="1.5" y2="-10" layer="51"/>
 <rectangle x1="1.3" y1="10" x2="1.5" y2="11" layer="51"/>
 <rectangle x1="1.7" y1="-11" x2="1.9" y2="-10" layer="51"/>
@@ -2437,6 +2538,11 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm
 <rectangle x1="2.5" y1="10" x2="2.7" y2="11" layer="51"/>
 <rectangle x1="2.9" y1="-11" x2="3.1" y2="-10" layer="51"/>
 <rectangle x1="2.9" y1="10" x2="3.1" y2="11" layer="51"/>
+<rectangle x1="3.1633" y1="-4.8367" x2="4.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-2.8367" x2="4.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-0.8367" x2="4.8367" y2="0.8367" layer="31"/>
+<rectangle x1="3.1633" y1="1.1633" x2="4.8367" y2="2.8367" layer="31"/>
+<rectangle x1="3.1633" y1="3.1633" x2="4.8367" y2="4.8367" layer="31"/>
 <rectangle x1="3.3" y1="-11" x2="3.5" y2="-10" layer="51"/>
 <rectangle x1="3.3" y1="10" x2="3.5" y2="11" layer="51"/>
 <rectangle x1="3.7" y1="-11" x2="3.9" y2="-10" layer="51"/>
@@ -2685,7 +2791,8 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm
 <smd name="174" x="-10.8" y="-7.8" dx="1.2" dy="0.23" layer="1"/>
 <smd name="175" x="-10.8" y="-8.2" dx="1.2" dy="0.23" layer="1"/>
 <smd name="176" x="-10.8" y="-8.6" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="10" dy="10" layer="1"/><text x="-9.5" y="-13" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="10.2" dy="10.2" layer="1" stop="no" cream="no"/>
+<text x="-9.5" y="-13" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-9.5" y="12" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-9.9" y1="-9.5" x2="-9.5" y2="-9.9" width="0.2032" layer="21"/>
 <wire x1="-9.9" y1="9.9" x2="-9.9" y2="-9.5" width="0.2032" layer="21"/>
@@ -2694,10 +2801,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-216-40P-2400W-2400L-160H">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.60mm max height, 216 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.60mm max height, 216 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.60mm max height, 216 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BGB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BGB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-11.1" y="-11.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-13" y1="-10.7" x2="-12" y2="-10.5" layer="51"/>
 <rectangle x1="-13" y1="-10.3" x2="-12" y2="-10.1" layer="51"/>
@@ -3140,10 +3247,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-216-40P-2400W-2400L-160H-EP">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.60mm max height, 216 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.60mm max height, 216 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.60mm max height, 216 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BGB-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BGB-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-11.1" y="-11.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-13" y1="-10.7" x2="-12" y2="-10.5" layer="51"/>
 <rectangle x1="-13" y1="-10.3" x2="-12" y2="-10.1" layer="51"/>
@@ -3223,8 +3330,15 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm
 <rectangle x1="-6.7" y1="12" x2="-6.5" y2="13" layer="51"/>
 <rectangle x1="-6.3" y1="-13" x2="-6.1" y2="-12" layer="51"/>
 <rectangle x1="-6.3" y1="12" x2="-6.1" y2="13" layer="51"/>
+<rectangle x1="-6" y1="-6" x2="6" y2="6" layer="29"/>
 <rectangle x1="-5.9" y1="-13" x2="-5.7" y2="-12" layer="51"/>
 <rectangle x1="-5.9" y1="12" x2="-5.7" y2="13" layer="51"/>
+<rectangle x1="-5.8367" y1="-5.8367" x2="-4.1633" y2="-4.1633" layer="31"/>
+<rectangle x1="-5.8367" y1="-3.8367" x2="-4.1633" y2="-2.1633" layer="31"/>
+<rectangle x1="-5.8367" y1="-1.8367" x2="-4.1633" y2="-0.1633" layer="31"/>
+<rectangle x1="-5.8367" y1="0.1633" x2="-4.1633" y2="1.8367" layer="31"/>
+<rectangle x1="-5.8367" y1="2.1633" x2="-4.1633" y2="3.8367" layer="31"/>
+<rectangle x1="-5.8367" y1="4.1633" x2="-4.1633" y2="5.8367" layer="31"/>
 <rectangle x1="-5.5" y1="-13" x2="-5.3" y2="-12" layer="51"/>
 <rectangle x1="-5.5" y1="12" x2="-5.3" y2="13" layer="51"/>
 <rectangle x1="-5.1" y1="-13" x2="-4.9" y2="-12" layer="51"/>
@@ -3235,6 +3349,12 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm
 <rectangle x1="-4.3" y1="12" x2="-4.1" y2="13" layer="51"/>
 <rectangle x1="-3.9" y1="-13" x2="-3.7" y2="-12" layer="51"/>
 <rectangle x1="-3.9" y1="12" x2="-3.7" y2="13" layer="51"/>
+<rectangle x1="-3.8367" y1="-5.8367" x2="-2.1633" y2="-4.1633" layer="31"/>
+<rectangle x1="-3.8367" y1="-3.8367" x2="-2.1633" y2="-2.1633" layer="31"/>
+<rectangle x1="-3.8367" y1="-1.8367" x2="-2.1633" y2="-0.1633" layer="31"/>
+<rectangle x1="-3.8367" y1="0.1633" x2="-2.1633" y2="1.8367" layer="31"/>
+<rectangle x1="-3.8367" y1="2.1633" x2="-2.1633" y2="3.8367" layer="31"/>
+<rectangle x1="-3.8367" y1="4.1633" x2="-2.1633" y2="5.8367" layer="31"/>
 <rectangle x1="-3.5" y1="-13" x2="-3.3" y2="-12" layer="51"/>
 <rectangle x1="-3.5" y1="12" x2="-3.3" y2="13" layer="51"/>
 <rectangle x1="-3.1" y1="-13" x2="-2.9" y2="-12" layer="51"/>
@@ -3245,6 +3365,12 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm
 <rectangle x1="-2.3" y1="12" x2="-2.1" y2="13" layer="51"/>
 <rectangle x1="-1.9" y1="-13" x2="-1.7" y2="-12" layer="51"/>
 <rectangle x1="-1.9" y1="12" x2="-1.7" y2="13" layer="51"/>
+<rectangle x1="-1.8367" y1="-5.8367" x2="-0.1633" y2="-4.1633" layer="31"/>
+<rectangle x1="-1.8367" y1="-3.8367" x2="-0.1633" y2="-2.1633" layer="31"/>
+<rectangle x1="-1.8367" y1="-1.8367" x2="-0.1633" y2="-0.1633" layer="31"/>
+<rectangle x1="-1.8367" y1="0.1633" x2="-0.1633" y2="1.8367" layer="31"/>
+<rectangle x1="-1.8367" y1="2.1633" x2="-0.1633" y2="3.8367" layer="31"/>
+<rectangle x1="-1.8367" y1="4.1633" x2="-0.1633" y2="5.8367" layer="31"/>
 <rectangle x1="-1.5" y1="-13" x2="-1.3" y2="-12" layer="51"/>
 <rectangle x1="-1.5" y1="12" x2="-1.3" y2="13" layer="51"/>
 <rectangle x1="-1.1" y1="-13" x2="-0.9" y2="-12" layer="51"/>
@@ -3255,6 +3381,12 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm
 <rectangle x1="-0.3" y1="12" x2="-0.1" y2="13" layer="51"/>
 <rectangle x1="0.1" y1="-13" x2="0.3" y2="-12" layer="51"/>
 <rectangle x1="0.1" y1="12" x2="0.3" y2="13" layer="51"/>
+<rectangle x1="0.1633" y1="-5.8367" x2="1.8367" y2="-4.1633" layer="31"/>
+<rectangle x1="0.1633" y1="-3.8367" x2="1.8367" y2="-2.1633" layer="31"/>
+<rectangle x1="0.1633" y1="-1.8367" x2="1.8367" y2="-0.1633" layer="31"/>
+<rectangle x1="0.1633" y1="0.1633" x2="1.8367" y2="1.8367" layer="31"/>
+<rectangle x1="0.1633" y1="2.1633" x2="1.8367" y2="3.8367" layer="31"/>
+<rectangle x1="0.1633" y1="4.1633" x2="1.8367" y2="5.8367" layer="31"/>
 <rectangle x1="0.5" y1="-13" x2="0.7" y2="-12" layer="51"/>
 <rectangle x1="0.5" y1="12" x2="0.7" y2="13" layer="51"/>
 <rectangle x1="0.9" y1="-13" x2="1.1" y2="-12" layer="51"/>
@@ -3265,6 +3397,12 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm
 <rectangle x1="1.7" y1="12" x2="1.9" y2="13" layer="51"/>
 <rectangle x1="2.1" y1="-13" x2="2.3" y2="-12" layer="51"/>
 <rectangle x1="2.1" y1="12" x2="2.3" y2="13" layer="51"/>
+<rectangle x1="2.1633" y1="-5.8367" x2="3.8367" y2="-4.1633" layer="31"/>
+<rectangle x1="2.1633" y1="-3.8367" x2="3.8367" y2="-2.1633" layer="31"/>
+<rectangle x1="2.1633" y1="-1.8367" x2="3.8367" y2="-0.1633" layer="31"/>
+<rectangle x1="2.1633" y1="0.1633" x2="3.8367" y2="1.8367" layer="31"/>
+<rectangle x1="2.1633" y1="2.1633" x2="3.8367" y2="3.8367" layer="31"/>
+<rectangle x1="2.1633" y1="4.1633" x2="3.8367" y2="5.8367" layer="31"/>
 <rectangle x1="2.5" y1="-13" x2="2.7" y2="-12" layer="51"/>
 <rectangle x1="2.5" y1="12" x2="2.7" y2="13" layer="51"/>
 <rectangle x1="2.9" y1="-13" x2="3.1" y2="-12" layer="51"/>
@@ -3275,6 +3413,12 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm
 <rectangle x1="3.7" y1="12" x2="3.9" y2="13" layer="51"/>
 <rectangle x1="4.1" y1="-13" x2="4.3" y2="-12" layer="51"/>
 <rectangle x1="4.1" y1="12" x2="4.3" y2="13" layer="51"/>
+<rectangle x1="4.1633" y1="-5.8367" x2="5.8367" y2="-4.1633" layer="31"/>
+<rectangle x1="4.1633" y1="-3.8367" x2="5.8367" y2="-2.1633" layer="31"/>
+<rectangle x1="4.1633" y1="-1.8367" x2="5.8367" y2="-0.1633" layer="31"/>
+<rectangle x1="4.1633" y1="0.1633" x2="5.8367" y2="1.8367" layer="31"/>
+<rectangle x1="4.1633" y1="2.1633" x2="5.8367" y2="3.8367" layer="31"/>
+<rectangle x1="4.1633" y1="4.1633" x2="5.8367" y2="5.8367" layer="31"/>
 <rectangle x1="4.5" y1="-13" x2="4.7" y2="-12" layer="51"/>
 <rectangle x1="4.5" y1="12" x2="4.7" y2="13" layer="51"/>
 <rectangle x1="4.9" y1="-13" x2="5.1" y2="-12" layer="51"/>
@@ -3577,7 +3721,8 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm
 <smd name="214" x="-12.8" y="-9.8" dx="1.2" dy="0.23" layer="1"/>
 <smd name="215" x="-12.8" y="-10.2" dx="1.2" dy="0.23" layer="1"/>
 <smd name="216" x="-12.8" y="-10.6" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="12" dy="12" layer="1"/><text x="-11.5" y="-15" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="12.2" dy="12.2" layer="1" stop="no" cream="no"/>
+<text x="-11.5" y="-15" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-11.5" y="14" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-11.9" y1="-11.5" x2="-11.5" y2="-11.9" width="0.2032" layer="21"/>
 <wire x1="-11.9" y1="11.9" x2="-11.9" y2="-11.5" width="0.2032" layer="21"/>
@@ -3586,10 +3731,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-256-40P-2800W-2800L-160H">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 256 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 256 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 256 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BJC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BJC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15" y1="-12.7" x2="-14" y2="-12.5" layer="51"/>
 <rectangle x1="-15" y1="-12.3" x2="-14" y2="-12.1" layer="51"/>
@@ -4112,10 +4257,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-256-40P-2800W-2800L-160H-EP">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 256 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 256 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 256 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BJC-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BJC-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15" y1="-12.7" x2="-14" y2="-12.5" layer="51"/>
 <rectangle x1="-15" y1="-12.3" x2="-14" y2="-12.1" layer="51"/>
@@ -4211,6 +4356,14 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="-7.5" y1="14" x2="-7.3" y2="15" layer="51"/>
 <rectangle x1="-7.1" y1="-15" x2="-6.9" y2="-14" layer="51"/>
 <rectangle x1="-7.1" y1="14" x2="-6.9" y2="15" layer="51"/>
+<rectangle x1="-7" y1="-7" x2="7" y2="7" layer="29"/>
+<rectangle x1="-6.8367" y1="-6.8367" x2="-5.1633" y2="-5.1633" layer="31"/>
+<rectangle x1="-6.8367" y1="-4.8367" x2="-5.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-6.8367" y1="-2.8367" x2="-5.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-6.8367" y1="-0.8367" x2="-5.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-6.8367" y1="1.1633" x2="-5.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-6.8367" y1="3.1633" x2="-5.1633" y2="4.8367" layer="31"/>
+<rectangle x1="-6.8367" y1="5.1633" x2="-5.1633" y2="6.8367" layer="31"/>
 <rectangle x1="-6.7" y1="-15" x2="-6.5" y2="-14" layer="51"/>
 <rectangle x1="-6.7" y1="14" x2="-6.5" y2="15" layer="51"/>
 <rectangle x1="-6.3" y1="-15" x2="-6.1" y2="-14" layer="51"/>
@@ -4221,6 +4374,13 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="-5.5" y1="14" x2="-5.3" y2="15" layer="51"/>
 <rectangle x1="-5.1" y1="-15" x2="-4.9" y2="-14" layer="51"/>
 <rectangle x1="-5.1" y1="14" x2="-4.9" y2="15" layer="51"/>
+<rectangle x1="-4.8367" y1="-6.8367" x2="-3.1633" y2="-5.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-4.8367" x2="-3.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-2.8367" x2="-3.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-0.8367" x2="-3.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="1.1633" x2="-3.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="3.1633" x2="-3.1633" y2="4.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="5.1633" x2="-3.1633" y2="6.8367" layer="31"/>
 <rectangle x1="-4.7" y1="-15" x2="-4.5" y2="-14" layer="51"/>
 <rectangle x1="-4.7" y1="14" x2="-4.5" y2="15" layer="51"/>
 <rectangle x1="-4.3" y1="-15" x2="-4.1" y2="-14" layer="51"/>
@@ -4231,6 +4391,13 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="-3.5" y1="14" x2="-3.3" y2="15" layer="51"/>
 <rectangle x1="-3.1" y1="-15" x2="-2.9" y2="-14" layer="51"/>
 <rectangle x1="-3.1" y1="14" x2="-2.9" y2="15" layer="51"/>
+<rectangle x1="-2.8367" y1="-6.8367" x2="-1.1633" y2="-5.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-4.8367" x2="-1.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="3.1633" x2="-1.1633" y2="4.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="5.1633" x2="-1.1633" y2="6.8367" layer="31"/>
 <rectangle x1="-2.7" y1="-15" x2="-2.5" y2="-14" layer="51"/>
 <rectangle x1="-2.7" y1="14" x2="-2.5" y2="15" layer="51"/>
 <rectangle x1="-2.3" y1="-15" x2="-2.1" y2="-14" layer="51"/>
@@ -4241,6 +4408,13 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="-1.5" y1="14" x2="-1.3" y2="15" layer="51"/>
 <rectangle x1="-1.1" y1="-15" x2="-0.9" y2="-14" layer="51"/>
 <rectangle x1="-1.1" y1="14" x2="-0.9" y2="15" layer="51"/>
+<rectangle x1="-0.8367" y1="-6.8367" x2="0.8367" y2="-5.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-4.8367" x2="0.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="3.1633" x2="0.8367" y2="4.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="5.1633" x2="0.8367" y2="6.8367" layer="31"/>
 <rectangle x1="-0.7" y1="-15" x2="-0.5" y2="-14" layer="51"/>
 <rectangle x1="-0.7" y1="14" x2="-0.5" y2="15" layer="51"/>
 <rectangle x1="-0.3" y1="-15" x2="-0.1" y2="-14" layer="51"/>
@@ -4251,6 +4425,13 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="0.5" y1="14" x2="0.7" y2="15" layer="51"/>
 <rectangle x1="0.9" y1="-15" x2="1.1" y2="-14" layer="51"/>
 <rectangle x1="0.9" y1="14" x2="1.1" y2="15" layer="51"/>
+<rectangle x1="1.1633" y1="-6.8367" x2="2.8367" y2="-5.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-4.8367" x2="2.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
+<rectangle x1="1.1633" y1="3.1633" x2="2.8367" y2="4.8367" layer="31"/>
+<rectangle x1="1.1633" y1="5.1633" x2="2.8367" y2="6.8367" layer="31"/>
 <rectangle x1="1.3" y1="-15" x2="1.5" y2="-14" layer="51"/>
 <rectangle x1="1.3" y1="14" x2="1.5" y2="15" layer="51"/>
 <rectangle x1="1.7" y1="-15" x2="1.9" y2="-14" layer="51"/>
@@ -4261,6 +4442,13 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="2.5" y1="14" x2="2.7" y2="15" layer="51"/>
 <rectangle x1="2.9" y1="-15" x2="3.1" y2="-14" layer="51"/>
 <rectangle x1="2.9" y1="14" x2="3.1" y2="15" layer="51"/>
+<rectangle x1="3.1633" y1="-6.8367" x2="4.8367" y2="-5.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-4.8367" x2="4.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-2.8367" x2="4.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-0.8367" x2="4.8367" y2="0.8367" layer="31"/>
+<rectangle x1="3.1633" y1="1.1633" x2="4.8367" y2="2.8367" layer="31"/>
+<rectangle x1="3.1633" y1="3.1633" x2="4.8367" y2="4.8367" layer="31"/>
+<rectangle x1="3.1633" y1="5.1633" x2="4.8367" y2="6.8367" layer="31"/>
 <rectangle x1="3.3" y1="-15" x2="3.5" y2="-14" layer="51"/>
 <rectangle x1="3.3" y1="14" x2="3.5" y2="15" layer="51"/>
 <rectangle x1="3.7" y1="-15" x2="3.9" y2="-14" layer="51"/>
@@ -4271,6 +4459,13 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="4.5" y1="14" x2="4.7" y2="15" layer="51"/>
 <rectangle x1="4.9" y1="-15" x2="5.1" y2="-14" layer="51"/>
 <rectangle x1="4.9" y1="14" x2="5.1" y2="15" layer="51"/>
+<rectangle x1="5.1633" y1="-6.8367" x2="6.8367" y2="-5.1633" layer="31"/>
+<rectangle x1="5.1633" y1="-4.8367" x2="6.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="5.1633" y1="-2.8367" x2="6.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="5.1633" y1="-0.8367" x2="6.8367" y2="0.8367" layer="31"/>
+<rectangle x1="5.1633" y1="1.1633" x2="6.8367" y2="2.8367" layer="31"/>
+<rectangle x1="5.1633" y1="3.1633" x2="6.8367" y2="4.8367" layer="31"/>
+<rectangle x1="5.1633" y1="5.1633" x2="6.8367" y2="6.8367" layer="31"/>
 <rectangle x1="5.3" y1="-15" x2="5.5" y2="-14" layer="51"/>
 <rectangle x1="5.3" y1="14" x2="5.5" y2="15" layer="51"/>
 <rectangle x1="5.7" y1="-15" x2="5.9" y2="-14" layer="51"/>
@@ -4629,7 +4824,8 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm
 <smd name="254" x="-14.8" y="-11.8" dx="1.2" dy="0.23" layer="1"/>
 <smd name="255" x="-14.8" y="-12.2" dx="1.2" dy="0.23" layer="1"/>
 <smd name="256" x="-14.8" y="-12.6" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="14" dy="14" layer="1"/><text x="-13.5" y="-17" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="14.2" dy="14.2" layer="1" stop="no" cream="no"/>
+<text x="-13.5" y="-17" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-13.5" y="16" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-13.9" y1="-13.5" x2="-13.5" y2="-13.9" width="0.2032" layer="21"/>
 <wire x1="-13.9" y1="13.9" x2="-13.9" y2="-13.5" width="0.2032" layer="21"/>
@@ -4638,10 +4834,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 28mm length, 28mm
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-32-40P-400W-400L-160H">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.60mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BKC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BKC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.1" y="-1.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3" y1="-1.5" x2="-2" y2="-1.3" layer="51"/>
 <rectangle x1="-3" y1="-1.1" x2="-2" y2="-0.9" layer="51"/>
@@ -4716,10 +4912,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm w
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-32-40P-400W-400L-160H-EP">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.60mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BKC-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BKC-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.1" y="-1.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3" y1="-1.5" x2="-2" y2="-1.3" layer="51"/>
 <rectangle x1="-3" y1="-1.1" x2="-2" y2="-0.9" layer="51"/>
@@ -4733,6 +4929,8 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm w
 <rectangle x1="-1.5" y1="2" x2="-1.3" y2="3" layer="51"/>
 <rectangle x1="-1.1" y1="-3" x2="-0.9" y2="-2" layer="51"/>
 <rectangle x1="-1.1" y1="2" x2="-0.9" y2="3" layer="51"/>
+<rectangle x1="-1" y1="-1" x2="1" y2="1" layer="29"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
 <rectangle x1="-0.7" y1="-3" x2="-0.5" y2="-2" layer="51"/>
 <rectangle x1="-0.7" y1="2" x2="-0.5" y2="3" layer="51"/>
 <rectangle x1="-0.3" y1="-3" x2="-0.1" y2="-2" layer="51"/>
@@ -4785,7 +4983,8 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm w
 <smd name="30" x="-2.8" y="-0.6" dx="1.2" dy="0.23" layer="1"/>
 <smd name="31" x="-2.8" y="-1" dx="1.2" dy="0.23" layer="1"/>
 <smd name="32" x="-2.8" y="-1.4" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="2" dy="2" layer="1"/><text x="-1.5" y="-5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="2.2" dy="2.2" layer="1" stop="no" cream="no"/>
+<text x="-1.5" y="-5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-1.5" y="4" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-1.9" y1="-1.5" x2="-1.5" y2="-1.9" width="0.2032" layer="21"/>
 <wire x1="-1.9" y1="1.9" x2="-1.9" y2="-1.5" width="0.2032" layer="21"/>
@@ -4794,10 +4993,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm w
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-40-40P-500W-500L-160H">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.60mm max height, 40 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BAB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BAB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.6" y="-1.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3.5" y1="-1.9" x2="-2.5" y2="-1.7" layer="51"/>
 <rectangle x1="-3.5" y1="-1.5" x2="-2.5" y2="-1.3" layer="51"/>
@@ -4888,10 +5087,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm w
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-40-40P-500W-500L-160H-EP">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.60mm max height, 40 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BAB-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BAB-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.6" y="-1.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3.5" y1="-1.9" x2="-2.5" y2="-1.7" layer="51"/>
 <rectangle x1="-3.5" y1="-1.5" x2="-2.5" y2="-1.3" layer="51"/>
@@ -4907,6 +5106,9 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm w
 <rectangle x1="-1.9" y1="2.5" x2="-1.7" y2="3.5" layer="51"/>
 <rectangle x1="-1.5" y1="-3.5" x2="-1.3" y2="-2.5" layer="51"/>
 <rectangle x1="-1.5" y1="2.5" x2="-1.3" y2="3.5" layer="51"/>
+<rectangle x1="-1.25" y1="-1.25" x2="1.25" y2="1.25" layer="29"/>
+<rectangle x1="-1.1479" y1="-1.1479" x2="-0.1021" y2="-0.1021" layer="31"/>
+<rectangle x1="-1.1479" y1="0.1021" x2="-0.1021" y2="1.1479" layer="31"/>
 <rectangle x1="-1.1" y1="-3.5" x2="-0.9" y2="-2.5" layer="51"/>
 <rectangle x1="-1.1" y1="2.5" x2="-0.9" y2="3.5" layer="51"/>
 <rectangle x1="-0.7" y1="-3.5" x2="-0.5" y2="-2.5" layer="51"/>
@@ -4915,6 +5117,8 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm w
 <rectangle x1="-0.3" y1="2.5" x2="-0.1" y2="3.5" layer="51"/>
 <rectangle x1="0.1" y1="-3.5" x2="0.3" y2="-2.5" layer="51"/>
 <rectangle x1="0.1" y1="2.5" x2="0.3" y2="3.5" layer="51"/>
+<rectangle x1="0.1021" y1="-1.1479" x2="1.1479" y2="-0.1021" layer="31"/>
+<rectangle x1="0.1021" y1="0.1021" x2="1.1479" y2="1.1479" layer="31"/>
 <rectangle x1="0.5" y1="-3.5" x2="0.7" y2="-2.5" layer="51"/>
 <rectangle x1="0.5" y1="2.5" x2="0.7" y2="3.5" layer="51"/>
 <rectangle x1="0.9" y1="-3.5" x2="1.1" y2="-2.5" layer="51"/>
@@ -4973,7 +5177,8 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm w
 <smd name="38" x="-3.3" y="-1" dx="1.2" dy="0.23" layer="1"/>
 <smd name="39" x="-3.3" y="-1.4" dx="1.2" dy="0.23" layer="1"/>
 <smd name="40" x="-3.3" y="-1.8" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="2.5" dy="2.5" layer="1"/><text x="-2" y="-5.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="2.7" dy="2.7" layer="1" stop="no" cream="no"/>
+<text x="-2" y="-5.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2" y="4.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-2.4" y1="-2" x2="-2" y2="-2.4" width="0.2032" layer="21"/>
 <wire x1="-2.4" y1="2.4" x2="-2.4" y2="-2" width="0.2032" layer="21"/>
@@ -4982,10 +5187,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm w
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-64-40P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBD, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBD, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3.1" x2="-3.5" y2="-2.9" layer="51"/>
 <rectangle x1="-4.5" y1="-2.7" x2="-3.5" y2="-2.5" layer="51"/>
@@ -5124,10 +5329,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-64-40P-700W-700L-160H-EP">
-<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.40mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBD-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBD-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3.1" x2="-3.5" y2="-2.9" layer="51"/>
 <rectangle x1="-4.5" y1="-2.7" x2="-3.5" y2="-2.5" layer="51"/>
@@ -5153,6 +5358,9 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm w
 <rectangle x1="-2.3" y1="3.5" x2="-2.1" y2="4.5" layer="51"/>
 <rectangle x1="-1.9" y1="-4.5" x2="-1.7" y2="-3.5" layer="51"/>
 <rectangle x1="-1.9" y1="3.5" x2="-1.7" y2="4.5" layer="51"/>
+<rectangle x1="-1.75" y1="-1.75" x2="1.75" y2="1.75" layer="29"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
 <rectangle x1="-1.5" y1="-4.5" x2="-1.3" y2="-3.5" layer="51"/>
 <rectangle x1="-1.5" y1="3.5" x2="-1.3" y2="4.5" layer="51"/>
 <rectangle x1="-1.1" y1="-4.5" x2="-0.9" y2="-3.5" layer="51"/>
@@ -5163,6 +5371,8 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm w
 <rectangle x1="-0.3" y1="3.5" x2="-0.1" y2="4.5" layer="51"/>
 <rectangle x1="0.1" y1="-4.5" x2="0.3" y2="-3.5" layer="51"/>
 <rectangle x1="0.1" y1="3.5" x2="0.3" y2="4.5" layer="51"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
 <rectangle x1="0.5" y1="-4.5" x2="0.7" y2="-3.5" layer="51"/>
 <rectangle x1="0.5" y1="3.5" x2="0.7" y2="4.5" layer="51"/>
 <rectangle x1="0.9" y1="-4.5" x2="1.1" y2="-3.5" layer="51"/>
@@ -5257,7 +5467,8 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm w
 <smd name="62" x="-4.3" y="-2.2" dx="1.2" dy="0.23" layer="1"/>
 <smd name="63" x="-4.3" y="-2.6" dx="1.2" dy="0.23" layer="1"/>
 <smd name="64" x="-4.3" y="-3" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="3.5" dy="3.5" layer="1"/><text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="3.7" dy="3.7" layer="1" stop="no" cream="no"/>
+<text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3" y="5.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-3.4" y1="-3" x2="-3" y2="-3.4" width="0.2032" layer="21"/>
 <wire x1="-3.4" y1="3.4" x2="-3.4" y2="-3" width="0.2032" layer="21"/>
@@ -5266,10 +5477,10 @@ Low profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-64-50P-1000W-1000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>
@@ -5408,10 +5619,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-64-50P-1000W-1000L-160H-EP">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCD-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCD-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>
@@ -5435,20 +5646,30 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <rectangle x1="-3.375" y1="5" x2="-3.125" y2="6" layer="51"/>
 <rectangle x1="-2.875" y1="-6" x2="-2.625" y2="-5" layer="51"/>
 <rectangle x1="-2.875" y1="5" x2="-2.625" y2="6" layer="51"/>
+<rectangle x1="-2.5" y1="-2.5" x2="2.5" y2="2.5" layer="29"/>
 <rectangle x1="-2.375" y1="-6" x2="-2.125" y2="-5" layer="51"/>
 <rectangle x1="-2.375" y1="5" x2="-2.125" y2="6" layer="51"/>
+<rectangle x1="-2.3639" y1="-2.3639" x2="-0.9694" y2="-0.9694" layer="31"/>
+<rectangle x1="-2.3639" y1="-0.6972" x2="-0.9694" y2="0.6972" layer="31"/>
+<rectangle x1="-2.3639" y1="0.9694" x2="-0.9694" y2="2.3639" layer="31"/>
 <rectangle x1="-1.875" y1="-6" x2="-1.625" y2="-5" layer="51"/>
 <rectangle x1="-1.875" y1="5" x2="-1.625" y2="6" layer="51"/>
 <rectangle x1="-1.375" y1="-6" x2="-1.125" y2="-5" layer="51"/>
 <rectangle x1="-1.375" y1="5" x2="-1.125" y2="6" layer="51"/>
 <rectangle x1="-0.875" y1="-6" x2="-0.625" y2="-5" layer="51"/>
 <rectangle x1="-0.875" y1="5" x2="-0.625" y2="6" layer="51"/>
+<rectangle x1="-0.6972" y1="-2.3639" x2="0.6972" y2="-0.9694" layer="31"/>
+<rectangle x1="-0.6972" y1="-0.6972" x2="0.6972" y2="0.6972" layer="31"/>
+<rectangle x1="-0.6972" y1="0.9694" x2="0.6972" y2="2.3639" layer="31"/>
 <rectangle x1="-0.375" y1="-6" x2="-0.125" y2="-5" layer="51"/>
 <rectangle x1="-0.375" y1="5" x2="-0.125" y2="6" layer="51"/>
 <rectangle x1="0.125" y1="-6" x2="0.375" y2="-5" layer="51"/>
 <rectangle x1="0.125" y1="5" x2="0.375" y2="6" layer="51"/>
 <rectangle x1="0.625" y1="-6" x2="0.875" y2="-5" layer="51"/>
 <rectangle x1="0.625" y1="5" x2="0.875" y2="6" layer="51"/>
+<rectangle x1="0.9694" y1="-2.3639" x2="2.3639" y2="-0.9694" layer="31"/>
+<rectangle x1="0.9694" y1="-0.6972" x2="2.3639" y2="0.6972" layer="31"/>
+<rectangle x1="0.9694" y1="0.9694" x2="2.3639" y2="2.3639" layer="31"/>
 <rectangle x1="1.125" y1="-6" x2="1.375" y2="-5" layer="51"/>
 <rectangle x1="1.125" y1="5" x2="1.375" y2="6" layer="51"/>
 <rectangle x1="1.625" y1="-6" x2="1.875" y2="-5" layer="51"/>
@@ -5541,7 +5762,8 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <smd name="62" x="-5.9" y="-2.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="63" x="-5.9" y="-3.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="64" x="-5.9" y="-3.75" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="5" dy="5" layer="1"/><text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="5.2" dy="5.2" layer="1" stop="no" cream="no"/>
+<text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-4.5" y="7" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-4.9" y1="-4.5" x2="-4.5" y2="-4.9" width="0.2032" layer="21"/>
 <wire x1="-4.9" y1="4.9" x2="-4.9" y2="-4.5" width="0.2032" layer="21"/>
@@ -5550,10 +5772,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-80-50P-1200W-1200L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BDD, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BDD, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-4.875" x2="-6" y2="-4.625" layer="51"/>
 <rectangle x1="-7" y1="-4.375" x2="-6" y2="-4.125" layer="51"/>
@@ -5724,10 +5946,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-80-50P-1200W-1200L-160H-EP">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BDD-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BDD-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-4.875" x2="-6" y2="-4.625" layer="51"/>
 <rectangle x1="-7" y1="-4.375" x2="-6" y2="-4.125" layer="51"/>
@@ -5757,8 +5979,12 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm
 <rectangle x1="-3.875" y1="6" x2="-3.625" y2="7" layer="51"/>
 <rectangle x1="-3.375" y1="-7" x2="-3.125" y2="-6" layer="51"/>
 <rectangle x1="-3.375" y1="6" x2="-3.125" y2="7" layer="51"/>
+<rectangle x1="-3" y1="-3" x2="3" y2="3" layer="29"/>
 <rectangle x1="-2.875" y1="-7" x2="-2.625" y2="-6" layer="51"/>
 <rectangle x1="-2.875" y1="6" x2="-2.625" y2="7" layer="51"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
 <rectangle x1="-2.375" y1="-7" x2="-2.125" y2="-6" layer="51"/>
 <rectangle x1="-2.375" y1="6" x2="-2.125" y2="7" layer="51"/>
 <rectangle x1="-1.875" y1="-7" x2="-1.625" y2="-6" layer="51"/>
@@ -5767,6 +5993,9 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm
 <rectangle x1="-1.375" y1="6" x2="-1.125" y2="7" layer="51"/>
 <rectangle x1="-0.875" y1="-7" x2="-0.625" y2="-6" layer="51"/>
 <rectangle x1="-0.875" y1="6" x2="-0.625" y2="7" layer="51"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
 <rectangle x1="-0.375" y1="-7" x2="-0.125" y2="-6" layer="51"/>
 <rectangle x1="-0.375" y1="6" x2="-0.125" y2="7" layer="51"/>
 <rectangle x1="0.125" y1="-7" x2="0.375" y2="-6" layer="51"/>
@@ -5775,6 +6004,9 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm
 <rectangle x1="0.625" y1="6" x2="0.875" y2="7" layer="51"/>
 <rectangle x1="1.125" y1="-7" x2="1.375" y2="-6" layer="51"/>
 <rectangle x1="1.125" y1="6" x2="1.375" y2="7" layer="51"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
 <rectangle x1="1.625" y1="-7" x2="1.875" y2="-6" layer="51"/>
 <rectangle x1="1.625" y1="6" x2="1.875" y2="7" layer="51"/>
 <rectangle x1="2.125" y1="-7" x2="2.375" y2="-6" layer="51"/>
@@ -5889,7 +6121,8 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm
 <smd name="78" x="-6.9" y="-3.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="79" x="-6.9" y="-4.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="80" x="-6.9" y="-4.75" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="6" dy="6" layer="1"/><text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="6.2" dy="6.2" layer="1" stop="no" cream="no"/>
+<text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-5.5" y="8" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-5.9" y1="-5.5" x2="-5.5" y2="-5.9" width="0.2032" layer="21"/>
 <wire x1="-5.9" y1="5.9" x2="-5.9" y2="-5.5" width="0.2032" layer="21"/>
@@ -5898,10 +6131,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-100-50P-1400W-1400L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BED, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BED, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -6112,10 +6345,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-100-50P-1400W-1400L-160H-EP">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BED-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BED-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -6154,6 +6387,11 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <rectangle x1="-4.125" y1="7" x2="-3.875" y2="8" layer="51"/>
 <rectangle x1="-3.625" y1="-8" x2="-3.375" y2="-7" layer="51"/>
 <rectangle x1="-3.625" y1="7" x2="-3.375" y2="8" layer="51"/>
+<rectangle x1="-3.5" y1="-3.5" x2="3.5" y2="3.5" layer="29"/>
+<rectangle x1="-3.3571" y1="-3.3571" x2="-1.8929" y2="-1.8929" layer="31"/>
+<rectangle x1="-3.3571" y1="-1.6071" x2="-1.8929" y2="-0.1429" layer="31"/>
+<rectangle x1="-3.3571" y1="0.1429" x2="-1.8929" y2="1.6071" layer="31"/>
+<rectangle x1="-3.3571" y1="1.8929" x2="-1.8929" y2="3.3571" layer="31"/>
 <rectangle x1="-3.125" y1="-8" x2="-2.875" y2="-7" layer="51"/>
 <rectangle x1="-3.125" y1="7" x2="-2.875" y2="8" layer="51"/>
 <rectangle x1="-2.625" y1="-8" x2="-2.375" y2="-7" layer="51"/>
@@ -6162,12 +6400,20 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <rectangle x1="-2.125" y1="7" x2="-1.875" y2="8" layer="51"/>
 <rectangle x1="-1.625" y1="-8" x2="-1.375" y2="-7" layer="51"/>
 <rectangle x1="-1.625" y1="7" x2="-1.375" y2="8" layer="51"/>
+<rectangle x1="-1.6071" y1="-3.3571" x2="-0.1429" y2="-1.8929" layer="31"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
+<rectangle x1="-1.6071" y1="1.8929" x2="-0.1429" y2="3.3571" layer="31"/>
 <rectangle x1="-1.125" y1="-8" x2="-0.875" y2="-7" layer="51"/>
 <rectangle x1="-1.125" y1="7" x2="-0.875" y2="8" layer="51"/>
 <rectangle x1="-0.625" y1="-8" x2="-0.375" y2="-7" layer="51"/>
 <rectangle x1="-0.625" y1="7" x2="-0.375" y2="8" layer="51"/>
 <rectangle x1="-0.125" y1="-8" x2="0.125" y2="-7" layer="51"/>
 <rectangle x1="-0.125" y1="7" x2="0.125" y2="8" layer="51"/>
+<rectangle x1="0.1429" y1="-3.3571" x2="1.6071" y2="-1.8929" layer="31"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
+<rectangle x1="0.1429" y1="1.8929" x2="1.6071" y2="3.3571" layer="31"/>
 <rectangle x1="0.375" y1="-8" x2="0.625" y2="-7" layer="51"/>
 <rectangle x1="0.375" y1="7" x2="0.625" y2="8" layer="51"/>
 <rectangle x1="0.875" y1="-8" x2="1.125" y2="-7" layer="51"/>
@@ -6176,6 +6422,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <rectangle x1="1.375" y1="7" x2="1.625" y2="8" layer="51"/>
 <rectangle x1="1.875" y1="-8" x2="2.125" y2="-7" layer="51"/>
 <rectangle x1="1.875" y1="7" x2="2.125" y2="8" layer="51"/>
+<rectangle x1="1.8929" y1="-3.3571" x2="3.3571" y2="-1.8929" layer="31"/>
+<rectangle x1="1.8929" y1="-1.6071" x2="3.3571" y2="-0.1429" layer="31"/>
+<rectangle x1="1.8929" y1="0.1429" x2="3.3571" y2="1.6071" layer="31"/>
+<rectangle x1="1.8929" y1="1.8929" x2="3.3571" y2="3.3571" layer="31"/>
 <rectangle x1="2.375" y1="-8" x2="2.625" y2="-7" layer="51"/>
 <rectangle x1="2.375" y1="7" x2="2.625" y2="8" layer="51"/>
 <rectangle x1="2.875" y1="-8" x2="3.125" y2="-7" layer="51"/>
@@ -6317,7 +6567,8 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <smd name="98" x="-7.9" y="-5" dx="1.5" dy="0.27" layer="1"/>
 <smd name="99" x="-7.9" y="-5.5" dx="1.5" dy="0.27" layer="1"/>
 <smd name="100" x="-7.9" y="-6" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="7" dy="7" layer="1"/><text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="7.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-6.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-6.9" y1="-6.5" x2="-6.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-6.9" y1="6.9" x2="-6.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -6326,10 +6577,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-128-50P-1400W-2000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.60mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.60mm max height, 128 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.60mm max height, 128 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BHB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BHB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-6.375" x2="-10" y2="-6.125" layer="51"/>
 <rectangle x1="-11" y1="-5.875" x2="-10" y2="-5.625" layer="51"/>
@@ -6596,10 +6847,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-128-50P-1400W-2000L-160H-EP">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.60mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.60mm max height, 128 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.60mm max height, 128 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BHB-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BHB-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-6.375" x2="-10" y2="-6.125" layer="51"/>
 <rectangle x1="-11" y1="-5.875" x2="-10" y2="-5.625" layer="51"/>
@@ -6645,8 +6896,13 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm
 <rectangle x1="-5.875" y1="7" x2="-5.625" y2="8" layer="51"/>
 <rectangle x1="-5.375" y1="-8" x2="-5.125" y2="-7" layer="51"/>
 <rectangle x1="-5.375" y1="7" x2="-5.125" y2="8" layer="51"/>
+<rectangle x1="-5" y1="-3.5" x2="5" y2="3.5" layer="29"/>
 <rectangle x1="-4.875" y1="-8" x2="-4.625" y2="-7" layer="51"/>
 <rectangle x1="-4.875" y1="7" x2="-4.625" y2="8" layer="51"/>
+<rectangle x1="-4.8367" y1="-3.3571" x2="-3.1633" y2="-1.8929" layer="31"/>
+<rectangle x1="-4.8367" y1="-1.6071" x2="-3.1633" y2="-0.1429" layer="31"/>
+<rectangle x1="-4.8367" y1="0.1429" x2="-3.1633" y2="1.6071" layer="31"/>
+<rectangle x1="-4.8367" y1="1.8929" x2="-3.1633" y2="3.3571" layer="31"/>
 <rectangle x1="-4.375" y1="-8" x2="-4.125" y2="-7" layer="51"/>
 <rectangle x1="-4.375" y1="7" x2="-4.125" y2="8" layer="51"/>
 <rectangle x1="-3.875" y1="-8" x2="-3.625" y2="-7" layer="51"/>
@@ -6655,6 +6911,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm
 <rectangle x1="-3.375" y1="7" x2="-3.125" y2="8" layer="51"/>
 <rectangle x1="-2.875" y1="-8" x2="-2.625" y2="-7" layer="51"/>
 <rectangle x1="-2.875" y1="7" x2="-2.625" y2="8" layer="51"/>
+<rectangle x1="-2.8367" y1="-3.3571" x2="-1.1633" y2="-1.8929" layer="31"/>
+<rectangle x1="-2.8367" y1="-1.6071" x2="-1.1633" y2="-0.1429" layer="31"/>
+<rectangle x1="-2.8367" y1="0.1429" x2="-1.1633" y2="1.6071" layer="31"/>
+<rectangle x1="-2.8367" y1="1.8929" x2="-1.1633" y2="3.3571" layer="31"/>
 <rectangle x1="-2.375" y1="-8" x2="-2.125" y2="-7" layer="51"/>
 <rectangle x1="-2.375" y1="7" x2="-2.125" y2="8" layer="51"/>
 <rectangle x1="-1.875" y1="-8" x2="-1.625" y2="-7" layer="51"/>
@@ -6663,6 +6923,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm
 <rectangle x1="-1.375" y1="7" x2="-1.125" y2="8" layer="51"/>
 <rectangle x1="-0.875" y1="-8" x2="-0.625" y2="-7" layer="51"/>
 <rectangle x1="-0.875" y1="7" x2="-0.625" y2="8" layer="51"/>
+<rectangle x1="-0.8367" y1="-3.3571" x2="0.8367" y2="-1.8929" layer="31"/>
+<rectangle x1="-0.8367" y1="-1.6071" x2="0.8367" y2="-0.1429" layer="31"/>
+<rectangle x1="-0.8367" y1="0.1429" x2="0.8367" y2="1.6071" layer="31"/>
+<rectangle x1="-0.8367" y1="1.8929" x2="0.8367" y2="3.3571" layer="31"/>
 <rectangle x1="-0.375" y1="-8" x2="-0.125" y2="-7" layer="51"/>
 <rectangle x1="-0.375" y1="7" x2="-0.125" y2="8" layer="51"/>
 <rectangle x1="0.125" y1="-8" x2="0.375" y2="-7" layer="51"/>
@@ -6671,6 +6935,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm
 <rectangle x1="0.625" y1="7" x2="0.875" y2="8" layer="51"/>
 <rectangle x1="1.125" y1="-8" x2="1.375" y2="-7" layer="51"/>
 <rectangle x1="1.125" y1="7" x2="1.375" y2="8" layer="51"/>
+<rectangle x1="1.1633" y1="-3.3571" x2="2.8367" y2="-1.8929" layer="31"/>
+<rectangle x1="1.1633" y1="-1.6071" x2="2.8367" y2="-0.1429" layer="31"/>
+<rectangle x1="1.1633" y1="0.1429" x2="2.8367" y2="1.6071" layer="31"/>
+<rectangle x1="1.1633" y1="1.8929" x2="2.8367" y2="3.3571" layer="31"/>
 <rectangle x1="1.625" y1="-8" x2="1.875" y2="-7" layer="51"/>
 <rectangle x1="1.625" y1="7" x2="1.875" y2="8" layer="51"/>
 <rectangle x1="2.125" y1="-8" x2="2.375" y2="-7" layer="51"/>
@@ -6679,6 +6947,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm
 <rectangle x1="2.625" y1="7" x2="2.875" y2="8" layer="51"/>
 <rectangle x1="3.125" y1="-8" x2="3.375" y2="-7" layer="51"/>
 <rectangle x1="3.125" y1="7" x2="3.375" y2="8" layer="51"/>
+<rectangle x1="3.1633" y1="-3.3571" x2="4.8367" y2="-1.8929" layer="31"/>
+<rectangle x1="3.1633" y1="-1.6071" x2="4.8367" y2="-0.1429" layer="31"/>
+<rectangle x1="3.1633" y1="0.1429" x2="4.8367" y2="1.6071" layer="31"/>
+<rectangle x1="3.1633" y1="1.8929" x2="4.8367" y2="3.3571" layer="31"/>
 <rectangle x1="3.625" y1="-8" x2="3.875" y2="-7" layer="51"/>
 <rectangle x1="3.625" y1="7" x2="3.875" y2="8" layer="51"/>
 <rectangle x1="4.125" y1="-8" x2="4.375" y2="-7" layer="51"/>
@@ -6857,7 +7129,8 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm
 <smd name="126" x="-10.9" y="-5.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="127" x="-10.9" y="-5.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="128" x="-10.9" y="-6.25" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="10" dy="7" layer="1"/><text x="-9.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="10.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-9.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-9.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-9.9" y1="-6.5" x2="-9.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-9.9" y1="6.9" x2="-9.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -6866,10 +7139,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-144-50P-2000W-2000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -7168,10 +7441,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-144-50P-2000W-2000L-160H-EP">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BFB-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BFB-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -7225,8 +7498,14 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <rectangle x1="-5.875" y1="10" x2="-5.625" y2="11" layer="51"/>
 <rectangle x1="-5.375" y1="-11" x2="-5.125" y2="-10" layer="51"/>
 <rectangle x1="-5.375" y1="10" x2="-5.125" y2="11" layer="51"/>
+<rectangle x1="-5" y1="-5" x2="5" y2="5" layer="29"/>
 <rectangle x1="-4.875" y1="-11" x2="-4.625" y2="-10" layer="51"/>
 <rectangle x1="-4.875" y1="10" x2="-4.625" y2="11" layer="51"/>
+<rectangle x1="-4.8367" y1="-4.8367" x2="-3.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-2.8367" x2="-3.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-0.8367" x2="-3.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="1.1633" x2="-3.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="3.1633" x2="-3.1633" y2="4.8367" layer="31"/>
 <rectangle x1="-4.375" y1="-11" x2="-4.125" y2="-10" layer="51"/>
 <rectangle x1="-4.375" y1="10" x2="-4.125" y2="11" layer="51"/>
 <rectangle x1="-3.875" y1="-11" x2="-3.625" y2="-10" layer="51"/>
@@ -7235,6 +7514,11 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <rectangle x1="-3.375" y1="10" x2="-3.125" y2="11" layer="51"/>
 <rectangle x1="-2.875" y1="-11" x2="-2.625" y2="-10" layer="51"/>
 <rectangle x1="-2.875" y1="10" x2="-2.625" y2="11" layer="51"/>
+<rectangle x1="-2.8367" y1="-4.8367" x2="-1.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="3.1633" x2="-1.1633" y2="4.8367" layer="31"/>
 <rectangle x1="-2.375" y1="-11" x2="-2.125" y2="-10" layer="51"/>
 <rectangle x1="-2.375" y1="10" x2="-2.125" y2="11" layer="51"/>
 <rectangle x1="-1.875" y1="-11" x2="-1.625" y2="-10" layer="51"/>
@@ -7243,6 +7527,11 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <rectangle x1="-1.375" y1="10" x2="-1.125" y2="11" layer="51"/>
 <rectangle x1="-0.875" y1="-11" x2="-0.625" y2="-10" layer="51"/>
 <rectangle x1="-0.875" y1="10" x2="-0.625" y2="11" layer="51"/>
+<rectangle x1="-0.8367" y1="-4.8367" x2="0.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="3.1633" x2="0.8367" y2="4.8367" layer="31"/>
 <rectangle x1="-0.375" y1="-11" x2="-0.125" y2="-10" layer="51"/>
 <rectangle x1="-0.375" y1="10" x2="-0.125" y2="11" layer="51"/>
 <rectangle x1="0.125" y1="-11" x2="0.375" y2="-10" layer="51"/>
@@ -7251,6 +7540,11 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <rectangle x1="0.625" y1="10" x2="0.875" y2="11" layer="51"/>
 <rectangle x1="1.125" y1="-11" x2="1.375" y2="-10" layer="51"/>
 <rectangle x1="1.125" y1="10" x2="1.375" y2="11" layer="51"/>
+<rectangle x1="1.1633" y1="-4.8367" x2="2.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
+<rectangle x1="1.1633" y1="3.1633" x2="2.8367" y2="4.8367" layer="31"/>
 <rectangle x1="1.625" y1="-11" x2="1.875" y2="-10" layer="51"/>
 <rectangle x1="1.625" y1="10" x2="1.875" y2="11" layer="51"/>
 <rectangle x1="2.125" y1="-11" x2="2.375" y2="-10" layer="51"/>
@@ -7259,6 +7553,11 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <rectangle x1="2.625" y1="10" x2="2.875" y2="11" layer="51"/>
 <rectangle x1="3.125" y1="-11" x2="3.375" y2="-10" layer="51"/>
 <rectangle x1="3.125" y1="10" x2="3.375" y2="11" layer="51"/>
+<rectangle x1="3.1633" y1="-4.8367" x2="4.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-2.8367" x2="4.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-0.8367" x2="4.8367" y2="0.8367" layer="31"/>
+<rectangle x1="3.1633" y1="1.1633" x2="4.8367" y2="2.8367" layer="31"/>
+<rectangle x1="3.1633" y1="3.1633" x2="4.8367" y2="4.8367" layer="31"/>
 <rectangle x1="3.625" y1="-11" x2="3.875" y2="-10" layer="51"/>
 <rectangle x1="3.625" y1="10" x2="3.875" y2="11" layer="51"/>
 <rectangle x1="4.125" y1="-11" x2="4.375" y2="-10" layer="51"/>
@@ -7461,7 +7760,8 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <smd name="142" x="-10.9" y="-7.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="143" x="-10.9" y="-8.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="144" x="-10.9" y="-8.75" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="10" dy="10" layer="1"/><text x="-9.5" y="-13" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="10.2" dy="10.2" layer="1" stop="no" cream="no"/>
+<text x="-9.5" y="-13" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-9.5" y="12" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-9.9" y1="-9.5" x2="-9.5" y2="-9.9" width="0.2032" layer="21"/>
 <wire x1="-9.9" y1="9.9" x2="-9.9" y2="-9.5" width="0.2032" layer="21"/>
@@ -7470,10 +7770,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-176-50P-2400W-2400L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.60mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.60mm max height, 176 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.60mm max height, 176 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BGA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BGA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-11.1" y="-11.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-13" y1="-10.875" x2="-12" y2="-10.625" layer="51"/>
 <rectangle x1="-13" y1="-10.375" x2="-12" y2="-10.125" layer="51"/>
@@ -7836,10 +8136,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-176-50P-2400W-2400L-160H-EP">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.60mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.60mm max height, 176 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.60mm max height, 176 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BGA-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BGA-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-11.1" y="-11.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-13" y1="-10.875" x2="-12" y2="-10.625" layer="51"/>
 <rectangle x1="-13" y1="-10.375" x2="-12" y2="-10.125" layer="51"/>
@@ -7905,8 +8205,15 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm
 <rectangle x1="-6.875" y1="12" x2="-6.625" y2="13" layer="51"/>
 <rectangle x1="-6.375" y1="-13" x2="-6.125" y2="-12" layer="51"/>
 <rectangle x1="-6.375" y1="12" x2="-6.125" y2="13" layer="51"/>
+<rectangle x1="-6" y1="-6" x2="6" y2="6" layer="29"/>
 <rectangle x1="-5.875" y1="-13" x2="-5.625" y2="-12" layer="51"/>
 <rectangle x1="-5.875" y1="12" x2="-5.625" y2="13" layer="51"/>
+<rectangle x1="-5.8367" y1="-5.8367" x2="-4.1633" y2="-4.1633" layer="31"/>
+<rectangle x1="-5.8367" y1="-3.8367" x2="-4.1633" y2="-2.1633" layer="31"/>
+<rectangle x1="-5.8367" y1="-1.8367" x2="-4.1633" y2="-0.1633" layer="31"/>
+<rectangle x1="-5.8367" y1="0.1633" x2="-4.1633" y2="1.8367" layer="31"/>
+<rectangle x1="-5.8367" y1="2.1633" x2="-4.1633" y2="3.8367" layer="31"/>
+<rectangle x1="-5.8367" y1="4.1633" x2="-4.1633" y2="5.8367" layer="31"/>
 <rectangle x1="-5.375" y1="-13" x2="-5.125" y2="-12" layer="51"/>
 <rectangle x1="-5.375" y1="12" x2="-5.125" y2="13" layer="51"/>
 <rectangle x1="-4.875" y1="-13" x2="-4.625" y2="-12" layer="51"/>
@@ -7915,6 +8222,12 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm
 <rectangle x1="-4.375" y1="12" x2="-4.125" y2="13" layer="51"/>
 <rectangle x1="-3.875" y1="-13" x2="-3.625" y2="-12" layer="51"/>
 <rectangle x1="-3.875" y1="12" x2="-3.625" y2="13" layer="51"/>
+<rectangle x1="-3.8367" y1="-5.8367" x2="-2.1633" y2="-4.1633" layer="31"/>
+<rectangle x1="-3.8367" y1="-3.8367" x2="-2.1633" y2="-2.1633" layer="31"/>
+<rectangle x1="-3.8367" y1="-1.8367" x2="-2.1633" y2="-0.1633" layer="31"/>
+<rectangle x1="-3.8367" y1="0.1633" x2="-2.1633" y2="1.8367" layer="31"/>
+<rectangle x1="-3.8367" y1="2.1633" x2="-2.1633" y2="3.8367" layer="31"/>
+<rectangle x1="-3.8367" y1="4.1633" x2="-2.1633" y2="5.8367" layer="31"/>
 <rectangle x1="-3.375" y1="-13" x2="-3.125" y2="-12" layer="51"/>
 <rectangle x1="-3.375" y1="12" x2="-3.125" y2="13" layer="51"/>
 <rectangle x1="-2.875" y1="-13" x2="-2.625" y2="-12" layer="51"/>
@@ -7923,6 +8236,12 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm
 <rectangle x1="-2.375" y1="12" x2="-2.125" y2="13" layer="51"/>
 <rectangle x1="-1.875" y1="-13" x2="-1.625" y2="-12" layer="51"/>
 <rectangle x1="-1.875" y1="12" x2="-1.625" y2="13" layer="51"/>
+<rectangle x1="-1.8367" y1="-5.8367" x2="-0.1633" y2="-4.1633" layer="31"/>
+<rectangle x1="-1.8367" y1="-3.8367" x2="-0.1633" y2="-2.1633" layer="31"/>
+<rectangle x1="-1.8367" y1="-1.8367" x2="-0.1633" y2="-0.1633" layer="31"/>
+<rectangle x1="-1.8367" y1="0.1633" x2="-0.1633" y2="1.8367" layer="31"/>
+<rectangle x1="-1.8367" y1="2.1633" x2="-0.1633" y2="3.8367" layer="31"/>
+<rectangle x1="-1.8367" y1="4.1633" x2="-0.1633" y2="5.8367" layer="31"/>
 <rectangle x1="-1.375" y1="-13" x2="-1.125" y2="-12" layer="51"/>
 <rectangle x1="-1.375" y1="12" x2="-1.125" y2="13" layer="51"/>
 <rectangle x1="-0.875" y1="-13" x2="-0.625" y2="-12" layer="51"/>
@@ -7931,6 +8250,12 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm
 <rectangle x1="-0.375" y1="12" x2="-0.125" y2="13" layer="51"/>
 <rectangle x1="0.125" y1="-13" x2="0.375" y2="-12" layer="51"/>
 <rectangle x1="0.125" y1="12" x2="0.375" y2="13" layer="51"/>
+<rectangle x1="0.1633" y1="-5.8367" x2="1.8367" y2="-4.1633" layer="31"/>
+<rectangle x1="0.1633" y1="-3.8367" x2="1.8367" y2="-2.1633" layer="31"/>
+<rectangle x1="0.1633" y1="-1.8367" x2="1.8367" y2="-0.1633" layer="31"/>
+<rectangle x1="0.1633" y1="0.1633" x2="1.8367" y2="1.8367" layer="31"/>
+<rectangle x1="0.1633" y1="2.1633" x2="1.8367" y2="3.8367" layer="31"/>
+<rectangle x1="0.1633" y1="4.1633" x2="1.8367" y2="5.8367" layer="31"/>
 <rectangle x1="0.625" y1="-13" x2="0.875" y2="-12" layer="51"/>
 <rectangle x1="0.625" y1="12" x2="0.875" y2="13" layer="51"/>
 <rectangle x1="1.125" y1="-13" x2="1.375" y2="-12" layer="51"/>
@@ -7939,6 +8264,12 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm
 <rectangle x1="1.625" y1="12" x2="1.875" y2="13" layer="51"/>
 <rectangle x1="2.125" y1="-13" x2="2.375" y2="-12" layer="51"/>
 <rectangle x1="2.125" y1="12" x2="2.375" y2="13" layer="51"/>
+<rectangle x1="2.1633" y1="-5.8367" x2="3.8367" y2="-4.1633" layer="31"/>
+<rectangle x1="2.1633" y1="-3.8367" x2="3.8367" y2="-2.1633" layer="31"/>
+<rectangle x1="2.1633" y1="-1.8367" x2="3.8367" y2="-0.1633" layer="31"/>
+<rectangle x1="2.1633" y1="0.1633" x2="3.8367" y2="1.8367" layer="31"/>
+<rectangle x1="2.1633" y1="2.1633" x2="3.8367" y2="3.8367" layer="31"/>
+<rectangle x1="2.1633" y1="4.1633" x2="3.8367" y2="5.8367" layer="31"/>
 <rectangle x1="2.625" y1="-13" x2="2.875" y2="-12" layer="51"/>
 <rectangle x1="2.625" y1="12" x2="2.875" y2="13" layer="51"/>
 <rectangle x1="3.125" y1="-13" x2="3.375" y2="-12" layer="51"/>
@@ -7947,6 +8278,12 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm
 <rectangle x1="3.625" y1="12" x2="3.875" y2="13" layer="51"/>
 <rectangle x1="4.125" y1="-13" x2="4.375" y2="-12" layer="51"/>
 <rectangle x1="4.125" y1="12" x2="4.375" y2="13" layer="51"/>
+<rectangle x1="4.1633" y1="-5.8367" x2="5.8367" y2="-4.1633" layer="31"/>
+<rectangle x1="4.1633" y1="-3.8367" x2="5.8367" y2="-2.1633" layer="31"/>
+<rectangle x1="4.1633" y1="-1.8367" x2="5.8367" y2="-0.1633" layer="31"/>
+<rectangle x1="4.1633" y1="0.1633" x2="5.8367" y2="1.8367" layer="31"/>
+<rectangle x1="4.1633" y1="2.1633" x2="5.8367" y2="3.8367" layer="31"/>
+<rectangle x1="4.1633" y1="4.1633" x2="5.8367" y2="5.8367" layer="31"/>
 <rectangle x1="4.625" y1="-13" x2="4.875" y2="-12" layer="51"/>
 <rectangle x1="4.625" y1="12" x2="4.875" y2="13" layer="51"/>
 <rectangle x1="5.125" y1="-13" x2="5.375" y2="-12" layer="51"/>
@@ -8193,7 +8530,8 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm
 <smd name="174" x="-12.9" y="-9.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="175" x="-12.9" y="-10.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="176" x="-12.9" y="-10.75" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="12" dy="12" layer="1"/><text x="-11.5" y="-15" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="12.2" dy="12.2" layer="1" stop="no" cream="no"/>
+<text x="-11.5" y="-15" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-11.5" y="14" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-11.9" y1="-11.5" x2="-11.5" y2="-11.9" width="0.2032" layer="21"/>
 <wire x1="-11.9" y1="11.9" x2="-11.9" y2="-11.5" width="0.2032" layer="21"/>
@@ -8202,10 +8540,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-208-50P-2800W-2800L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 208 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 208 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BJB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BJB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15" y1="-12.875" x2="-14" y2="-12.625" layer="51"/>
 <rectangle x1="-15" y1="-12.375" x2="-14" y2="-12.125" layer="51"/>
@@ -8632,10 +8970,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-208-50P-2800W-2800L-160H-EP">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 208 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 208 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BJB-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BJB-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15" y1="-12.875" x2="-14" y2="-12.625" layer="51"/>
 <rectangle x1="-15" y1="-12.375" x2="-14" y2="-12.125" layer="51"/>
@@ -8713,8 +9051,16 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="-7.875" y1="14" x2="-7.625" y2="15" layer="51"/>
 <rectangle x1="-7.375" y1="-15" x2="-7.125" y2="-14" layer="51"/>
 <rectangle x1="-7.375" y1="14" x2="-7.125" y2="15" layer="51"/>
+<rectangle x1="-7" y1="-7" x2="7" y2="7" layer="29"/>
 <rectangle x1="-6.875" y1="-15" x2="-6.625" y2="-14" layer="51"/>
 <rectangle x1="-6.875" y1="14" x2="-6.625" y2="15" layer="51"/>
+<rectangle x1="-6.8367" y1="-6.8367" x2="-5.1633" y2="-5.1633" layer="31"/>
+<rectangle x1="-6.8367" y1="-4.8367" x2="-5.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-6.8367" y1="-2.8367" x2="-5.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-6.8367" y1="-0.8367" x2="-5.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-6.8367" y1="1.1633" x2="-5.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-6.8367" y1="3.1633" x2="-5.1633" y2="4.8367" layer="31"/>
+<rectangle x1="-6.8367" y1="5.1633" x2="-5.1633" y2="6.8367" layer="31"/>
 <rectangle x1="-6.375" y1="-15" x2="-6.125" y2="-14" layer="51"/>
 <rectangle x1="-6.375" y1="14" x2="-6.125" y2="15" layer="51"/>
 <rectangle x1="-5.875" y1="-15" x2="-5.625" y2="-14" layer="51"/>
@@ -8723,6 +9069,13 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="-5.375" y1="14" x2="-5.125" y2="15" layer="51"/>
 <rectangle x1="-4.875" y1="-15" x2="-4.625" y2="-14" layer="51"/>
 <rectangle x1="-4.875" y1="14" x2="-4.625" y2="15" layer="51"/>
+<rectangle x1="-4.8367" y1="-6.8367" x2="-3.1633" y2="-5.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-4.8367" x2="-3.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-2.8367" x2="-3.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-0.8367" x2="-3.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="1.1633" x2="-3.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="3.1633" x2="-3.1633" y2="4.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="5.1633" x2="-3.1633" y2="6.8367" layer="31"/>
 <rectangle x1="-4.375" y1="-15" x2="-4.125" y2="-14" layer="51"/>
 <rectangle x1="-4.375" y1="14" x2="-4.125" y2="15" layer="51"/>
 <rectangle x1="-3.875" y1="-15" x2="-3.625" y2="-14" layer="51"/>
@@ -8731,6 +9084,13 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="-3.375" y1="14" x2="-3.125" y2="15" layer="51"/>
 <rectangle x1="-2.875" y1="-15" x2="-2.625" y2="-14" layer="51"/>
 <rectangle x1="-2.875" y1="14" x2="-2.625" y2="15" layer="51"/>
+<rectangle x1="-2.8367" y1="-6.8367" x2="-1.1633" y2="-5.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-4.8367" x2="-1.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="3.1633" x2="-1.1633" y2="4.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="5.1633" x2="-1.1633" y2="6.8367" layer="31"/>
 <rectangle x1="-2.375" y1="-15" x2="-2.125" y2="-14" layer="51"/>
 <rectangle x1="-2.375" y1="14" x2="-2.125" y2="15" layer="51"/>
 <rectangle x1="-1.875" y1="-15" x2="-1.625" y2="-14" layer="51"/>
@@ -8739,6 +9099,13 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="-1.375" y1="14" x2="-1.125" y2="15" layer="51"/>
 <rectangle x1="-0.875" y1="-15" x2="-0.625" y2="-14" layer="51"/>
 <rectangle x1="-0.875" y1="14" x2="-0.625" y2="15" layer="51"/>
+<rectangle x1="-0.8367" y1="-6.8367" x2="0.8367" y2="-5.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-4.8367" x2="0.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="3.1633" x2="0.8367" y2="4.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="5.1633" x2="0.8367" y2="6.8367" layer="31"/>
 <rectangle x1="-0.375" y1="-15" x2="-0.125" y2="-14" layer="51"/>
 <rectangle x1="-0.375" y1="14" x2="-0.125" y2="15" layer="51"/>
 <rectangle x1="0.125" y1="-15" x2="0.375" y2="-14" layer="51"/>
@@ -8747,6 +9114,13 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="0.625" y1="14" x2="0.875" y2="15" layer="51"/>
 <rectangle x1="1.125" y1="-15" x2="1.375" y2="-14" layer="51"/>
 <rectangle x1="1.125" y1="14" x2="1.375" y2="15" layer="51"/>
+<rectangle x1="1.1633" y1="-6.8367" x2="2.8367" y2="-5.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-4.8367" x2="2.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
+<rectangle x1="1.1633" y1="3.1633" x2="2.8367" y2="4.8367" layer="31"/>
+<rectangle x1="1.1633" y1="5.1633" x2="2.8367" y2="6.8367" layer="31"/>
 <rectangle x1="1.625" y1="-15" x2="1.875" y2="-14" layer="51"/>
 <rectangle x1="1.625" y1="14" x2="1.875" y2="15" layer="51"/>
 <rectangle x1="2.125" y1="-15" x2="2.375" y2="-14" layer="51"/>
@@ -8755,6 +9129,13 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="2.625" y1="14" x2="2.875" y2="15" layer="51"/>
 <rectangle x1="3.125" y1="-15" x2="3.375" y2="-14" layer="51"/>
 <rectangle x1="3.125" y1="14" x2="3.375" y2="15" layer="51"/>
+<rectangle x1="3.1633" y1="-6.8367" x2="4.8367" y2="-5.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-4.8367" x2="4.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-2.8367" x2="4.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-0.8367" x2="4.8367" y2="0.8367" layer="31"/>
+<rectangle x1="3.1633" y1="1.1633" x2="4.8367" y2="2.8367" layer="31"/>
+<rectangle x1="3.1633" y1="3.1633" x2="4.8367" y2="4.8367" layer="31"/>
+<rectangle x1="3.1633" y1="5.1633" x2="4.8367" y2="6.8367" layer="31"/>
 <rectangle x1="3.625" y1="-15" x2="3.875" y2="-14" layer="51"/>
 <rectangle x1="3.625" y1="14" x2="3.875" y2="15" layer="51"/>
 <rectangle x1="4.125" y1="-15" x2="4.375" y2="-14" layer="51"/>
@@ -8763,6 +9144,13 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="4.625" y1="14" x2="4.875" y2="15" layer="51"/>
 <rectangle x1="5.125" y1="-15" x2="5.375" y2="-14" layer="51"/>
 <rectangle x1="5.125" y1="14" x2="5.375" y2="15" layer="51"/>
+<rectangle x1="5.1633" y1="-6.8367" x2="6.8367" y2="-5.1633" layer="31"/>
+<rectangle x1="5.1633" y1="-4.8367" x2="6.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="5.1633" y1="-2.8367" x2="6.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="5.1633" y1="-0.8367" x2="6.8367" y2="0.8367" layer="31"/>
+<rectangle x1="5.1633" y1="1.1633" x2="6.8367" y2="2.8367" layer="31"/>
+<rectangle x1="5.1633" y1="3.1633" x2="6.8367" y2="4.8367" layer="31"/>
+<rectangle x1="5.1633" y1="5.1633" x2="6.8367" y2="6.8367" layer="31"/>
 <rectangle x1="5.625" y1="-15" x2="5.875" y2="-14" layer="51"/>
 <rectangle x1="5.625" y1="14" x2="5.875" y2="15" layer="51"/>
 <rectangle x1="6.125" y1="-15" x2="6.375" y2="-14" layer="51"/>
@@ -9053,7 +9441,8 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm
 <smd name="206" x="-14.9" y="-11.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="207" x="-14.9" y="-12.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="208" x="-14.9" y="-12.75" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="14" dy="14" layer="1"/><text x="-13.5" y="-17" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="14.2" dy="14.2" layer="1" stop="no" cream="no"/>
+<text x="-13.5" y="-17" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-13.5" y="16" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-13.9" y1="-13.5" x2="-13.5" y2="-13.9" width="0.2032" layer="21"/>
 <wire x1="-13.9" y1="13.9" x2="-13.9" y2="-13.5" width="0.2032" layer="21"/>
@@ -9062,10 +9451,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 28mm length, 28mm
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-24-50P-400W-400L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 24 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.60mm max height, 24 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BKB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BKB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.1" y="-1.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3" y1="-1.375" x2="-2" y2="-1.125" layer="51"/>
 <rectangle x1="-3" y1="-0.875" x2="-2" y2="-0.625" layer="51"/>
@@ -9124,10 +9513,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm w
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-24-50P-400W-400L-160H-EP">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 24 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.60mm max height, 24 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BKB-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BKB-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.1" y="-1.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3" y1="-1.375" x2="-2" y2="-1.125" layer="51"/>
 <rectangle x1="-3" y1="-0.875" x2="-2" y2="-0.625" layer="51"/>
@@ -9137,8 +9526,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm w
 <rectangle x1="-3" y1="1.125" x2="-2" y2="1.375" layer="51"/>
 <rectangle x1="-1.375" y1="-3" x2="-1.125" y2="-2" layer="51"/>
 <rectangle x1="-1.375" y1="2" x2="-1.125" y2="3" layer="51"/>
+<rectangle x1="-1" y1="-1" x2="1" y2="1" layer="29"/>
 <rectangle x1="-0.875" y1="-3" x2="-0.625" y2="-2" layer="51"/>
 <rectangle x1="-0.875" y1="2" x2="-0.625" y2="3" layer="51"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
 <rectangle x1="-0.375" y1="-3" x2="-0.125" y2="-2" layer="51"/>
 <rectangle x1="-0.375" y1="2" x2="-0.125" y2="3" layer="51"/>
 <rectangle x1="0.125" y1="-3" x2="0.375" y2="-2" layer="51"/>
@@ -9177,7 +9568,8 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm w
 <smd name="22" x="-2.9" y="-0.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="23" x="-2.9" y="-0.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="24" x="-2.9" y="-1.25" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="2" dy="2" layer="1"/><text x="-1.5" y="-5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="2.2" dy="2.2" layer="1" stop="no" cream="no"/>
+<text x="-1.5" y="-5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-1.5" y="4" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-1.9" y1="-1.5" x2="-1.5" y2="-1.9" width="0.2032" layer="21"/>
 <wire x1="-1.9" y1="1.9" x2="-1.9" y2="-1.5" width="0.2032" layer="21"/>
@@ -9186,10 +9578,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm w
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-32-50P-500W-500L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.60mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BAA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BAA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.6" y="-1.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3.5" y1="-1.875" x2="-2.5" y2="-1.625" layer="51"/>
 <rectangle x1="-3.5" y1="-1.375" x2="-2.5" y2="-1.125" layer="51"/>
@@ -9264,10 +9656,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm w
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-32-50P-500W-500L-160H-EP">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.60mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BAA-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BAA-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.6" y="-1.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3.5" y1="-1.875" x2="-2.5" y2="-1.625" layer="51"/>
 <rectangle x1="-3.5" y1="-1.375" x2="-2.5" y2="-1.125" layer="51"/>
@@ -9281,10 +9673,15 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm w
 <rectangle x1="-1.875" y1="2.5" x2="-1.625" y2="3.5" layer="51"/>
 <rectangle x1="-1.375" y1="-3.5" x2="-1.125" y2="-2.5" layer="51"/>
 <rectangle x1="-1.375" y1="2.5" x2="-1.125" y2="3.5" layer="51"/>
+<rectangle x1="-1.25" y1="-1.25" x2="1.25" y2="1.25" layer="29"/>
+<rectangle x1="-1.1479" y1="-1.1479" x2="-0.1021" y2="-0.1021" layer="31"/>
+<rectangle x1="-1.1479" y1="0.1021" x2="-0.1021" y2="1.1479" layer="31"/>
 <rectangle x1="-0.875" y1="-3.5" x2="-0.625" y2="-2.5" layer="51"/>
 <rectangle x1="-0.875" y1="2.5" x2="-0.625" y2="3.5" layer="51"/>
 <rectangle x1="-0.375" y1="-3.5" x2="-0.125" y2="-2.5" layer="51"/>
 <rectangle x1="-0.375" y1="2.5" x2="-0.125" y2="3.5" layer="51"/>
+<rectangle x1="0.1021" y1="-1.1479" x2="1.1479" y2="-0.1021" layer="31"/>
+<rectangle x1="0.1021" y1="0.1021" x2="1.1479" y2="1.1479" layer="31"/>
 <rectangle x1="0.125" y1="-3.5" x2="0.375" y2="-2.5" layer="51"/>
 <rectangle x1="0.125" y1="2.5" x2="0.375" y2="3.5" layer="51"/>
 <rectangle x1="0.625" y1="-3.5" x2="0.875" y2="-2.5" layer="51"/>
@@ -9333,7 +9730,8 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm w
 <smd name="30" x="-3.4" y="-0.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="31" x="-3.4" y="-1.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="32" x="-3.4" y="-1.75" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="2.5" dy="2.5" layer="1"/><text x="-2" y="-5.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="2.7" dy="2.7" layer="1" stop="no" cream="no"/>
+<text x="-2" y="-5.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2" y="4.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-2.4" y1="-2" x2="-2" y2="-2.4" width="0.2032" layer="21"/>
 <wire x1="-2.4" y1="2.4" x2="-2.4" y2="-2" width="0.2032" layer="21"/>
@@ -9342,10 +9740,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm w
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-48-50P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -9452,10 +9850,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-48-50P-700W-700L-160H-EP">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -9475,6 +9873,9 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <rectangle x1="-2.375" y1="3.5" x2="-2.125" y2="4.5" layer="51"/>
 <rectangle x1="-1.875" y1="-4.5" x2="-1.625" y2="-3.5" layer="51"/>
 <rectangle x1="-1.875" y1="3.5" x2="-1.625" y2="4.5" layer="51"/>
+<rectangle x1="-1.75" y1="-1.75" x2="1.75" y2="1.75" layer="29"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
 <rectangle x1="-1.375" y1="-4.5" x2="-1.125" y2="-3.5" layer="51"/>
 <rectangle x1="-1.375" y1="3.5" x2="-1.125" y2="4.5" layer="51"/>
 <rectangle x1="-0.875" y1="-4.5" x2="-0.625" y2="-3.5" layer="51"/>
@@ -9483,6 +9884,8 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <rectangle x1="-0.375" y1="3.5" x2="-0.125" y2="4.5" layer="51"/>
 <rectangle x1="0.125" y1="-4.5" x2="0.375" y2="-3.5" layer="51"/>
 <rectangle x1="0.125" y1="3.5" x2="0.375" y2="4.5" layer="51"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
 <rectangle x1="0.625" y1="-4.5" x2="0.875" y2="-3.5" layer="51"/>
 <rectangle x1="0.625" y1="3.5" x2="0.875" y2="4.5" layer="51"/>
 <rectangle x1="1.125" y1="-4.5" x2="1.375" y2="-3.5" layer="51"/>
@@ -9553,7 +9956,8 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <smd name="46" x="-4.4" y="-1.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="47" x="-4.4" y="-2.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="48" x="-4.4" y="-2.75" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="3.5" dy="3.5" layer="1"/><text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="3.7" dy="3.7" layer="1" stop="no" cream="no"/>
+<text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3" y="5.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-3.4" y1="-3" x2="-3" y2="-3.4" width="0.2032" layer="21"/>
 <wire x1="-3.4" y1="3.4" x2="-3.4" y2="-3" width="0.2032" layer="21"/>
@@ -9562,10 +9966,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-52-65P-1000W-1000L-160H">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.075" x2="-5" y2="-3.725" layer="51"/>
 <rectangle x1="-6" y1="-3.425" x2="-5" y2="-3.075" layer="51"/>
@@ -9680,10 +10084,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-52-65P-1000W-1000L-160H-EP">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCC-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCC-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.075" x2="-5" y2="-3.725" layer="51"/>
 <rectangle x1="-6" y1="-3.425" x2="-5" y2="-3.075" layer="51"/>
@@ -9704,16 +10108,26 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm
 <rectangle x1="-3.425" y1="5" x2="-3.075" y2="6" layer="51"/>
 <rectangle x1="-2.775" y1="-6" x2="-2.425" y2="-5" layer="51"/>
 <rectangle x1="-2.775" y1="5" x2="-2.425" y2="6" layer="51"/>
+<rectangle x1="-2.5" y1="-2.5" x2="2.5" y2="2.5" layer="29"/>
+<rectangle x1="-2.3639" y1="-2.3639" x2="-0.9694" y2="-0.9694" layer="31"/>
+<rectangle x1="-2.3639" y1="-0.6972" x2="-0.9694" y2="0.6972" layer="31"/>
+<rectangle x1="-2.3639" y1="0.9694" x2="-0.9694" y2="2.3639" layer="31"/>
 <rectangle x1="-2.125" y1="-6" x2="-1.775" y2="-5" layer="51"/>
 <rectangle x1="-2.125" y1="5" x2="-1.775" y2="6" layer="51"/>
 <rectangle x1="-1.475" y1="-6" x2="-1.125" y2="-5" layer="51"/>
 <rectangle x1="-1.475" y1="5" x2="-1.125" y2="6" layer="51"/>
 <rectangle x1="-0.825" y1="-6" x2="-0.475" y2="-5" layer="51"/>
 <rectangle x1="-0.825" y1="5" x2="-0.475" y2="6" layer="51"/>
+<rectangle x1="-0.6972" y1="-2.3639" x2="0.6972" y2="-0.9694" layer="31"/>
+<rectangle x1="-0.6972" y1="-0.6972" x2="0.6972" y2="0.6972" layer="31"/>
+<rectangle x1="-0.6972" y1="0.9694" x2="0.6972" y2="2.3639" layer="31"/>
 <rectangle x1="-0.175" y1="-6" x2="0.175" y2="-5" layer="51"/>
 <rectangle x1="-0.175" y1="5" x2="0.175" y2="6" layer="51"/>
 <rectangle x1="0.475" y1="-6" x2="0.825" y2="-5" layer="51"/>
 <rectangle x1="0.475" y1="5" x2="0.825" y2="6" layer="51"/>
+<rectangle x1="0.9694" y1="-2.3639" x2="2.3639" y2="-0.9694" layer="31"/>
+<rectangle x1="0.9694" y1="-0.6972" x2="2.3639" y2="0.6972" layer="31"/>
+<rectangle x1="0.9694" y1="0.9694" x2="2.3639" y2="2.3639" layer="31"/>
 <rectangle x1="1.125" y1="-6" x2="1.475" y2="-5" layer="51"/>
 <rectangle x1="1.125" y1="5" x2="1.475" y2="6" layer="51"/>
 <rectangle x1="1.775" y1="-6" x2="2.125" y2="-5" layer="51"/>
@@ -9789,7 +10203,8 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm
 <smd name="50" x="-5.9" y="-2.6" dx="1.5" dy="0.4" layer="1"/>
 <smd name="51" x="-5.9" y="-3.25" dx="1.5" dy="0.4" layer="1"/>
 <smd name="52" x="-5.9" y="-3.9" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="5" dy="5" layer="1"/><text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="5.2" dy="5.2" layer="1" stop="no" cream="no"/>
+<text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-4.5" y="7" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-4.9" y1="-4.5" x2="-4.5" y2="-4.9" width="0.2032" layer="21"/>
 <wire x1="-4.9" y1="4.9" x2="-4.9" y2="-4.5" width="0.2032" layer="21"/>
@@ -9798,10 +10213,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-64-65P-1200W-1200L-160H">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BDC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BDC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-5.05" x2="-6" y2="-4.7" layer="51"/>
 <rectangle x1="-7" y1="-4.4" x2="-6" y2="-4.05" layer="51"/>
@@ -9940,10 +10355,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-64-65P-1200W-1200L-160H-EP">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BDC-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BDC-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-5.05" x2="-6" y2="-4.7" layer="51"/>
 <rectangle x1="-7" y1="-4.4" x2="-6" y2="-4.05" layer="51"/>
@@ -9969,18 +10384,28 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm
 <rectangle x1="-3.75" y1="6" x2="-3.4" y2="7" layer="51"/>
 <rectangle x1="-3.1" y1="-7" x2="-2.75" y2="-6" layer="51"/>
 <rectangle x1="-3.1" y1="6" x2="-2.75" y2="7" layer="51"/>
+<rectangle x1="-3" y1="-3" x2="3" y2="3" layer="29"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
 <rectangle x1="-2.45" y1="-7" x2="-2.1" y2="-6" layer="51"/>
 <rectangle x1="-2.45" y1="6" x2="-2.1" y2="7" layer="51"/>
 <rectangle x1="-1.8" y1="-7" x2="-1.45" y2="-6" layer="51"/>
 <rectangle x1="-1.8" y1="6" x2="-1.45" y2="7" layer="51"/>
 <rectangle x1="-1.15" y1="-7" x2="-0.8" y2="-6" layer="51"/>
 <rectangle x1="-1.15" y1="6" x2="-0.8" y2="7" layer="51"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
 <rectangle x1="-0.5" y1="-7" x2="-0.15" y2="-6" layer="51"/>
 <rectangle x1="-0.5" y1="6" x2="-0.15" y2="7" layer="51"/>
 <rectangle x1="0.15" y1="-7" x2="0.5" y2="-6" layer="51"/>
 <rectangle x1="0.15" y1="6" x2="0.5" y2="7" layer="51"/>
 <rectangle x1="0.8" y1="-7" x2="1.15" y2="-6" layer="51"/>
 <rectangle x1="0.8" y1="6" x2="1.15" y2="7" layer="51"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
 <rectangle x1="1.45" y1="-7" x2="1.8" y2="-6" layer="51"/>
 <rectangle x1="1.45" y1="6" x2="1.8" y2="7" layer="51"/>
 <rectangle x1="2.1" y1="-7" x2="2.45" y2="-6" layer="51"/>
@@ -10073,7 +10498,8 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm
 <smd name="62" x="-6.9" y="-3.575" dx="1.5" dy="0.4" layer="1"/>
 <smd name="63" x="-6.9" y="-4.225" dx="1.5" dy="0.4" layer="1"/>
 <smd name="64" x="-6.9" y="-4.875" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="6" dy="6" layer="1"/><text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="6.2" dy="6.2" layer="1" stop="no" cream="no"/>
+<text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-5.5" y="8" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-5.9" y1="-5.5" x2="-5.5" y2="-5.9" width="0.2032" layer="21"/>
 <wire x1="-5.9" y1="5.9" x2="-5.9" y2="-5.5" width="0.2032" layer="21"/>
@@ -10082,10 +10508,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-80-65P-1400W-1400L-160H">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BEC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BEC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.35" x2="-7" y2="-6" layer="51"/>
 <rectangle x1="-8" y1="-5.7" x2="-7" y2="-5.35" layer="51"/>
@@ -10256,10 +10682,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-80-65P-1400W-1400L-160H-EP">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BEC-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BEC-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.35" x2="-7" y2="-6" layer="51"/>
 <rectangle x1="-8" y1="-5.7" x2="-7" y2="-5.35" layer="51"/>
@@ -10291,22 +10717,39 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm
 <rectangle x1="-4.4" y1="7" x2="-4.05" y2="8" layer="51"/>
 <rectangle x1="-3.75" y1="-8" x2="-3.4" y2="-7" layer="51"/>
 <rectangle x1="-3.75" y1="7" x2="-3.4" y2="8" layer="51"/>
+<rectangle x1="-3.5" y1="-3.5" x2="3.5" y2="3.5" layer="29"/>
+<rectangle x1="-3.3571" y1="-3.3571" x2="-1.8929" y2="-1.8929" layer="31"/>
+<rectangle x1="-3.3571" y1="-1.6071" x2="-1.8929" y2="-0.1429" layer="31"/>
+<rectangle x1="-3.3571" y1="0.1429" x2="-1.8929" y2="1.6071" layer="31"/>
+<rectangle x1="-3.3571" y1="1.8929" x2="-1.8929" y2="3.3571" layer="31"/>
 <rectangle x1="-3.1" y1="-8" x2="-2.75" y2="-7" layer="51"/>
 <rectangle x1="-3.1" y1="7" x2="-2.75" y2="8" layer="51"/>
 <rectangle x1="-2.45" y1="-8" x2="-2.1" y2="-7" layer="51"/>
 <rectangle x1="-2.45" y1="7" x2="-2.1" y2="8" layer="51"/>
 <rectangle x1="-1.8" y1="-8" x2="-1.45" y2="-7" layer="51"/>
 <rectangle x1="-1.8" y1="7" x2="-1.45" y2="8" layer="51"/>
+<rectangle x1="-1.6071" y1="-3.3571" x2="-0.1429" y2="-1.8929" layer="31"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
+<rectangle x1="-1.6071" y1="1.8929" x2="-0.1429" y2="3.3571" layer="31"/>
 <rectangle x1="-1.15" y1="-8" x2="-0.8" y2="-7" layer="51"/>
 <rectangle x1="-1.15" y1="7" x2="-0.8" y2="8" layer="51"/>
 <rectangle x1="-0.5" y1="-8" x2="-0.15" y2="-7" layer="51"/>
 <rectangle x1="-0.5" y1="7" x2="-0.15" y2="8" layer="51"/>
+<rectangle x1="0.1429" y1="-3.3571" x2="1.6071" y2="-1.8929" layer="31"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
+<rectangle x1="0.1429" y1="1.8929" x2="1.6071" y2="3.3571" layer="31"/>
 <rectangle x1="0.15" y1="-8" x2="0.5" y2="-7" layer="51"/>
 <rectangle x1="0.15" y1="7" x2="0.5" y2="8" layer="51"/>
 <rectangle x1="0.8" y1="-8" x2="1.15" y2="-7" layer="51"/>
 <rectangle x1="0.8" y1="7" x2="1.15" y2="8" layer="51"/>
 <rectangle x1="1.45" y1="-8" x2="1.8" y2="-7" layer="51"/>
 <rectangle x1="1.45" y1="7" x2="1.8" y2="8" layer="51"/>
+<rectangle x1="1.8929" y1="-3.3571" x2="3.3571" y2="-1.8929" layer="31"/>
+<rectangle x1="1.8929" y1="-1.6071" x2="3.3571" y2="-0.1429" layer="31"/>
+<rectangle x1="1.8929" y1="0.1429" x2="3.3571" y2="1.6071" layer="31"/>
+<rectangle x1="1.8929" y1="1.8929" x2="3.3571" y2="3.3571" layer="31"/>
 <rectangle x1="2.1" y1="-8" x2="2.45" y2="-7" layer="51"/>
 <rectangle x1="2.1" y1="7" x2="2.45" y2="8" layer="51"/>
 <rectangle x1="2.75" y1="-8" x2="3.1" y2="-7" layer="51"/>
@@ -10421,7 +10864,8 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm
 <smd name="78" x="-7.9" y="-4.875" dx="1.5" dy="0.4" layer="1"/>
 <smd name="79" x="-7.9" y="-5.525" dx="1.5" dy="0.4" layer="1"/>
 <smd name="80" x="-7.9" y="-6.175" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="7" dy="7" layer="1"/><text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="7.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-6.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-6.9" y1="-6.5" x2="-6.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-6.9" y1="6.9" x2="-6.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -10430,10 +10874,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-100-65P-1400W-2000L-160H">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.60mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BHA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BHA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-6.35" x2="-10" y2="-6" layer="51"/>
 <rectangle x1="-11" y1="-5.7" x2="-10" y2="-5.35" layer="51"/>
@@ -10644,10 +11088,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-100-65P-1400W-2000L-160H-EP">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.60mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BHA-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BHA-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-6.35" x2="-10" y2="-6" layer="51"/>
 <rectangle x1="-11" y1="-5.7" x2="-10" y2="-5.35" layer="51"/>
@@ -10685,30 +11129,51 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm
 <rectangle x1="-5.7" y1="7" x2="-5.35" y2="8" layer="51"/>
 <rectangle x1="-5.05" y1="-8" x2="-4.7" y2="-7" layer="51"/>
 <rectangle x1="-5.05" y1="7" x2="-4.7" y2="8" layer="51"/>
+<rectangle x1="-5" y1="-3.5" x2="5" y2="3.5" layer="29"/>
+<rectangle x1="-4.8367" y1="-3.3571" x2="-3.1633" y2="-1.8929" layer="31"/>
+<rectangle x1="-4.8367" y1="-1.6071" x2="-3.1633" y2="-0.1429" layer="31"/>
+<rectangle x1="-4.8367" y1="0.1429" x2="-3.1633" y2="1.6071" layer="31"/>
+<rectangle x1="-4.8367" y1="1.8929" x2="-3.1633" y2="3.3571" layer="31"/>
 <rectangle x1="-4.4" y1="-8" x2="-4.05" y2="-7" layer="51"/>
 <rectangle x1="-4.4" y1="7" x2="-4.05" y2="8" layer="51"/>
 <rectangle x1="-3.75" y1="-8" x2="-3.4" y2="-7" layer="51"/>
 <rectangle x1="-3.75" y1="7" x2="-3.4" y2="8" layer="51"/>
 <rectangle x1="-3.1" y1="-8" x2="-2.75" y2="-7" layer="51"/>
 <rectangle x1="-3.1" y1="7" x2="-2.75" y2="8" layer="51"/>
+<rectangle x1="-2.8367" y1="-3.3571" x2="-1.1633" y2="-1.8929" layer="31"/>
+<rectangle x1="-2.8367" y1="-1.6071" x2="-1.1633" y2="-0.1429" layer="31"/>
+<rectangle x1="-2.8367" y1="0.1429" x2="-1.1633" y2="1.6071" layer="31"/>
+<rectangle x1="-2.8367" y1="1.8929" x2="-1.1633" y2="3.3571" layer="31"/>
 <rectangle x1="-2.45" y1="-8" x2="-2.1" y2="-7" layer="51"/>
 <rectangle x1="-2.45" y1="7" x2="-2.1" y2="8" layer="51"/>
 <rectangle x1="-1.8" y1="-8" x2="-1.45" y2="-7" layer="51"/>
 <rectangle x1="-1.8" y1="7" x2="-1.45" y2="8" layer="51"/>
 <rectangle x1="-1.15" y1="-8" x2="-0.8" y2="-7" layer="51"/>
 <rectangle x1="-1.15" y1="7" x2="-0.8" y2="8" layer="51"/>
+<rectangle x1="-0.8367" y1="-3.3571" x2="0.8367" y2="-1.8929" layer="31"/>
+<rectangle x1="-0.8367" y1="-1.6071" x2="0.8367" y2="-0.1429" layer="31"/>
+<rectangle x1="-0.8367" y1="0.1429" x2="0.8367" y2="1.6071" layer="31"/>
+<rectangle x1="-0.8367" y1="1.8929" x2="0.8367" y2="3.3571" layer="31"/>
 <rectangle x1="-0.5" y1="-8" x2="-0.15" y2="-7" layer="51"/>
 <rectangle x1="-0.5" y1="7" x2="-0.15" y2="8" layer="51"/>
 <rectangle x1="0.15" y1="-8" x2="0.5" y2="-7" layer="51"/>
 <rectangle x1="0.15" y1="7" x2="0.5" y2="8" layer="51"/>
 <rectangle x1="0.8" y1="-8" x2="1.15" y2="-7" layer="51"/>
 <rectangle x1="0.8" y1="7" x2="1.15" y2="8" layer="51"/>
+<rectangle x1="1.1633" y1="-3.3571" x2="2.8367" y2="-1.8929" layer="31"/>
+<rectangle x1="1.1633" y1="-1.6071" x2="2.8367" y2="-0.1429" layer="31"/>
+<rectangle x1="1.1633" y1="0.1429" x2="2.8367" y2="1.6071" layer="31"/>
+<rectangle x1="1.1633" y1="1.8929" x2="2.8367" y2="3.3571" layer="31"/>
 <rectangle x1="1.45" y1="-8" x2="1.8" y2="-7" layer="51"/>
 <rectangle x1="1.45" y1="7" x2="1.8" y2="8" layer="51"/>
 <rectangle x1="2.1" y1="-8" x2="2.45" y2="-7" layer="51"/>
 <rectangle x1="2.1" y1="7" x2="2.45" y2="8" layer="51"/>
 <rectangle x1="2.75" y1="-8" x2="3.1" y2="-7" layer="51"/>
 <rectangle x1="2.75" y1="7" x2="3.1" y2="8" layer="51"/>
+<rectangle x1="3.1633" y1="-3.3571" x2="4.8367" y2="-1.8929" layer="31"/>
+<rectangle x1="3.1633" y1="-1.6071" x2="4.8367" y2="-0.1429" layer="31"/>
+<rectangle x1="3.1633" y1="0.1429" x2="4.8367" y2="1.6071" layer="31"/>
+<rectangle x1="3.1633" y1="1.8929" x2="4.8367" y2="3.3571" layer="31"/>
 <rectangle x1="3.4" y1="-8" x2="3.75" y2="-7" layer="51"/>
 <rectangle x1="3.4" y1="7" x2="3.75" y2="8" layer="51"/>
 <rectangle x1="4.05" y1="-8" x2="4.4" y2="-7" layer="51"/>
@@ -10849,7 +11314,8 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm
 <smd name="98" x="-10.9" y="-4.875" dx="1.5" dy="0.4" layer="1"/>
 <smd name="99" x="-10.9" y="-5.525" dx="1.5" dy="0.4" layer="1"/>
 <smd name="100" x="-10.9" y="-6.175" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="10" dy="7" layer="1"/><text x="-9.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="10.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-9.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-9.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-9.9" y1="-6.5" x2="-9.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-9.9" y1="6.9" x2="-9.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -10858,10 +11324,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-112-65P-2000W-2000L-160H">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 112 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 112 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BFA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BFA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.95" x2="-10" y2="-8.6" layer="51"/>
 <rectangle x1="-11" y1="-8.3" x2="-10" y2="-7.95" layer="51"/>
@@ -11096,10 +11562,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-112-65P-2000W-2000L-160H-EP">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 112 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 112 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BFA-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BFA-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.95" x2="-10" y2="-8.6" layer="51"/>
 <rectangle x1="-11" y1="-8.3" x2="-10" y2="-7.95" layer="51"/>
@@ -11143,30 +11609,56 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm
 <rectangle x1="-5.7" y1="10" x2="-5.35" y2="11" layer="51"/>
 <rectangle x1="-5.05" y1="-11" x2="-4.7" y2="-10" layer="51"/>
 <rectangle x1="-5.05" y1="10" x2="-4.7" y2="11" layer="51"/>
+<rectangle x1="-5" y1="-5" x2="5" y2="5" layer="29"/>
+<rectangle x1="-4.8367" y1="-4.8367" x2="-3.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-2.8367" x2="-3.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-0.8367" x2="-3.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="1.1633" x2="-3.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="3.1633" x2="-3.1633" y2="4.8367" layer="31"/>
 <rectangle x1="-4.4" y1="-11" x2="-4.05" y2="-10" layer="51"/>
 <rectangle x1="-4.4" y1="10" x2="-4.05" y2="11" layer="51"/>
 <rectangle x1="-3.75" y1="-11" x2="-3.4" y2="-10" layer="51"/>
 <rectangle x1="-3.75" y1="10" x2="-3.4" y2="11" layer="51"/>
 <rectangle x1="-3.1" y1="-11" x2="-2.75" y2="-10" layer="51"/>
 <rectangle x1="-3.1" y1="10" x2="-2.75" y2="11" layer="51"/>
+<rectangle x1="-2.8367" y1="-4.8367" x2="-1.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="3.1633" x2="-1.1633" y2="4.8367" layer="31"/>
 <rectangle x1="-2.45" y1="-11" x2="-2.1" y2="-10" layer="51"/>
 <rectangle x1="-2.45" y1="10" x2="-2.1" y2="11" layer="51"/>
 <rectangle x1="-1.8" y1="-11" x2="-1.45" y2="-10" layer="51"/>
 <rectangle x1="-1.8" y1="10" x2="-1.45" y2="11" layer="51"/>
 <rectangle x1="-1.15" y1="-11" x2="-0.8" y2="-10" layer="51"/>
 <rectangle x1="-1.15" y1="10" x2="-0.8" y2="11" layer="51"/>
+<rectangle x1="-0.8367" y1="-4.8367" x2="0.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="3.1633" x2="0.8367" y2="4.8367" layer="31"/>
 <rectangle x1="-0.5" y1="-11" x2="-0.15" y2="-10" layer="51"/>
 <rectangle x1="-0.5" y1="10" x2="-0.15" y2="11" layer="51"/>
 <rectangle x1="0.15" y1="-11" x2="0.5" y2="-10" layer="51"/>
 <rectangle x1="0.15" y1="10" x2="0.5" y2="11" layer="51"/>
 <rectangle x1="0.8" y1="-11" x2="1.15" y2="-10" layer="51"/>
 <rectangle x1="0.8" y1="10" x2="1.15" y2="11" layer="51"/>
+<rectangle x1="1.1633" y1="-4.8367" x2="2.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
+<rectangle x1="1.1633" y1="3.1633" x2="2.8367" y2="4.8367" layer="31"/>
 <rectangle x1="1.45" y1="-11" x2="1.8" y2="-10" layer="51"/>
 <rectangle x1="1.45" y1="10" x2="1.8" y2="11" layer="51"/>
 <rectangle x1="2.1" y1="-11" x2="2.45" y2="-10" layer="51"/>
 <rectangle x1="2.1" y1="10" x2="2.45" y2="11" layer="51"/>
 <rectangle x1="2.75" y1="-11" x2="3.1" y2="-10" layer="51"/>
 <rectangle x1="2.75" y1="10" x2="3.1" y2="11" layer="51"/>
+<rectangle x1="3.1633" y1="-4.8367" x2="4.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-2.8367" x2="4.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-0.8367" x2="4.8367" y2="0.8367" layer="31"/>
+<rectangle x1="3.1633" y1="1.1633" x2="4.8367" y2="2.8367" layer="31"/>
+<rectangle x1="3.1633" y1="3.1633" x2="4.8367" y2="4.8367" layer="31"/>
 <rectangle x1="3.4" y1="-11" x2="3.75" y2="-10" layer="51"/>
 <rectangle x1="3.4" y1="10" x2="3.75" y2="11" layer="51"/>
 <rectangle x1="4.05" y1="-11" x2="4.4" y2="-10" layer="51"/>
@@ -11325,7 +11817,8 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm
 <smd name="110" x="-10.9" y="-7.475" dx="1.5" dy="0.4" layer="1"/>
 <smd name="111" x="-10.9" y="-8.125" dx="1.5" dy="0.4" layer="1"/>
 <smd name="112" x="-10.9" y="-8.775" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="10" dy="10" layer="1"/><text x="-9.5" y="-13" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="10.2" dy="10.2" layer="1" stop="no" cream="no"/>
+<text x="-9.5" y="-13" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-9.5" y="12" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-9.9" y1="-9.5" x2="-9.5" y2="-9.9" width="0.2032" layer="21"/>
 <wire x1="-9.9" y1="9.9" x2="-9.9" y2="-9.5" width="0.2032" layer="21"/>
@@ -11334,10 +11827,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-160-65P-2800W-2800L-160H">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 160 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 160 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BJA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BJA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15" y1="-12.85" x2="-14" y2="-12.5" layer="51"/>
 <rectangle x1="-15" y1="-12.2" x2="-14" y2="-11.85" layer="51"/>
@@ -11668,10 +12161,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 28mm length, 28mm
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-160-65P-2800W-2800L-160H-EP">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 28mm length, 28mm width, 1.60mm max height, 160 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 28mm length, 28mm width, 1.60mm max height, 160 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BJA-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BJA-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15" y1="-12.85" x2="-14" y2="-12.5" layer="51"/>
 <rectangle x1="-15" y1="-12.2" x2="-14" y2="-11.85" layer="51"/>
@@ -11732,43 +12225,93 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 28mm length, 28mm
 <rectangle x1="-7.65" y1="-15" x2="-7.3" y2="-14" layer="51"/>
 <rectangle x1="-7.65" y1="14" x2="-7.3" y2="15" layer="51"/>
 <rectangle x1="-7" y1="-15" x2="-6.65" y2="-14" layer="51"/>
+<rectangle x1="-7" y1="-7" x2="7" y2="7" layer="29"/>
 <rectangle x1="-7" y1="14" x2="-6.65" y2="15" layer="51"/>
+<rectangle x1="-6.8367" y1="-6.8367" x2="-5.1633" y2="-5.1633" layer="31"/>
+<rectangle x1="-6.8367" y1="-4.8367" x2="-5.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-6.8367" y1="-2.8367" x2="-5.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-6.8367" y1="-0.8367" x2="-5.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-6.8367" y1="1.1633" x2="-5.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-6.8367" y1="3.1633" x2="-5.1633" y2="4.8367" layer="31"/>
+<rectangle x1="-6.8367" y1="5.1633" x2="-5.1633" y2="6.8367" layer="31"/>
 <rectangle x1="-6.35" y1="-15" x2="-6" y2="-14" layer="51"/>
 <rectangle x1="-6.35" y1="14" x2="-6" y2="15" layer="51"/>
 <rectangle x1="-5.7" y1="-15" x2="-5.35" y2="-14" layer="51"/>
 <rectangle x1="-5.7" y1="14" x2="-5.35" y2="15" layer="51"/>
 <rectangle x1="-5.05" y1="-15" x2="-4.7" y2="-14" layer="51"/>
 <rectangle x1="-5.05" y1="14" x2="-4.7" y2="15" layer="51"/>
+<rectangle x1="-4.8367" y1="-6.8367" x2="-3.1633" y2="-5.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-4.8367" x2="-3.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-2.8367" x2="-3.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-0.8367" x2="-3.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="1.1633" x2="-3.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="3.1633" x2="-3.1633" y2="4.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="5.1633" x2="-3.1633" y2="6.8367" layer="31"/>
 <rectangle x1="-4.4" y1="-15" x2="-4.05" y2="-14" layer="51"/>
 <rectangle x1="-4.4" y1="14" x2="-4.05" y2="15" layer="51"/>
 <rectangle x1="-3.75" y1="-15" x2="-3.4" y2="-14" layer="51"/>
 <rectangle x1="-3.75" y1="14" x2="-3.4" y2="15" layer="51"/>
 <rectangle x1="-3.1" y1="-15" x2="-2.75" y2="-14" layer="51"/>
 <rectangle x1="-3.1" y1="14" x2="-2.75" y2="15" layer="51"/>
+<rectangle x1="-2.8367" y1="-6.8367" x2="-1.1633" y2="-5.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-4.8367" x2="-1.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="3.1633" x2="-1.1633" y2="4.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="5.1633" x2="-1.1633" y2="6.8367" layer="31"/>
 <rectangle x1="-2.45" y1="-15" x2="-2.1" y2="-14" layer="51"/>
 <rectangle x1="-2.45" y1="14" x2="-2.1" y2="15" layer="51"/>
 <rectangle x1="-1.8" y1="-15" x2="-1.45" y2="-14" layer="51"/>
 <rectangle x1="-1.8" y1="14" x2="-1.45" y2="15" layer="51"/>
 <rectangle x1="-1.15" y1="-15" x2="-0.8" y2="-14" layer="51"/>
 <rectangle x1="-1.15" y1="14" x2="-0.8" y2="15" layer="51"/>
+<rectangle x1="-0.8367" y1="-6.8367" x2="0.8367" y2="-5.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-4.8367" x2="0.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="3.1633" x2="0.8367" y2="4.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="5.1633" x2="0.8367" y2="6.8367" layer="31"/>
 <rectangle x1="-0.5" y1="-15" x2="-0.15" y2="-14" layer="51"/>
 <rectangle x1="-0.5" y1="14" x2="-0.15" y2="15" layer="51"/>
 <rectangle x1="0.15" y1="-15" x2="0.5" y2="-14" layer="51"/>
 <rectangle x1="0.15" y1="14" x2="0.5" y2="15" layer="51"/>
 <rectangle x1="0.8" y1="-15" x2="1.15" y2="-14" layer="51"/>
 <rectangle x1="0.8" y1="14" x2="1.15" y2="15" layer="51"/>
+<rectangle x1="1.1633" y1="-6.8367" x2="2.8367" y2="-5.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-4.8367" x2="2.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
+<rectangle x1="1.1633" y1="3.1633" x2="2.8367" y2="4.8367" layer="31"/>
+<rectangle x1="1.1633" y1="5.1633" x2="2.8367" y2="6.8367" layer="31"/>
 <rectangle x1="1.45" y1="-15" x2="1.8" y2="-14" layer="51"/>
 <rectangle x1="1.45" y1="14" x2="1.8" y2="15" layer="51"/>
 <rectangle x1="2.1" y1="-15" x2="2.45" y2="-14" layer="51"/>
 <rectangle x1="2.1" y1="14" x2="2.45" y2="15" layer="51"/>
 <rectangle x1="2.75" y1="-15" x2="3.1" y2="-14" layer="51"/>
 <rectangle x1="2.75" y1="14" x2="3.1" y2="15" layer="51"/>
+<rectangle x1="3.1633" y1="-6.8367" x2="4.8367" y2="-5.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-4.8367" x2="4.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-2.8367" x2="4.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-0.8367" x2="4.8367" y2="0.8367" layer="31"/>
+<rectangle x1="3.1633" y1="1.1633" x2="4.8367" y2="2.8367" layer="31"/>
+<rectangle x1="3.1633" y1="3.1633" x2="4.8367" y2="4.8367" layer="31"/>
+<rectangle x1="3.1633" y1="5.1633" x2="4.8367" y2="6.8367" layer="31"/>
 <rectangle x1="3.4" y1="-15" x2="3.75" y2="-14" layer="51"/>
 <rectangle x1="3.4" y1="14" x2="3.75" y2="15" layer="51"/>
 <rectangle x1="4.05" y1="-15" x2="4.4" y2="-14" layer="51"/>
 <rectangle x1="4.05" y1="14" x2="4.4" y2="15" layer="51"/>
 <rectangle x1="4.7" y1="-15" x2="5.05" y2="-14" layer="51"/>
 <rectangle x1="4.7" y1="14" x2="5.05" y2="15" layer="51"/>
+<rectangle x1="5.1633" y1="-6.8367" x2="6.8367" y2="-5.1633" layer="31"/>
+<rectangle x1="5.1633" y1="-4.8367" x2="6.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="5.1633" y1="-2.8367" x2="6.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="5.1633" y1="-0.8367" x2="6.8367" y2="0.8367" layer="31"/>
+<rectangle x1="5.1633" y1="1.1633" x2="6.8367" y2="2.8367" layer="31"/>
+<rectangle x1="5.1633" y1="3.1633" x2="6.8367" y2="4.8367" layer="31"/>
+<rectangle x1="5.1633" y1="5.1633" x2="6.8367" y2="6.8367" layer="31"/>
 <rectangle x1="5.35" y1="-15" x2="5.7" y2="-14" layer="51"/>
 <rectangle x1="5.35" y1="14" x2="5.7" y2="15" layer="51"/>
 <rectangle x1="6" y1="-15" x2="6.35" y2="-14" layer="51"/>
@@ -11993,7 +12536,8 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 28mm length, 28mm
 <smd name="158" x="-14.9" y="-11.375" dx="1.5" dy="0.4" layer="1"/>
 <smd name="159" x="-14.9" y="-12.025" dx="1.5" dy="0.4" layer="1"/>
 <smd name="160" x="-14.9" y="-12.675" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="14" dy="14" layer="1"/><text x="-13.5" y="-17" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="14.2" dy="14.2" layer="1" stop="no" cream="no"/>
+<text x="-13.5" y="-17" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-13.5" y="16" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-13.9" y1="-13.5" x2="-13.5" y2="-13.9" width="0.2032" layer="21"/>
 <wire x1="-13.9" y1="13.9" x2="-13.9" y2="-13.5" width="0.2032" layer="21"/>
@@ -12002,10 +12546,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 28mm length, 28mm
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-20-65P-400W-400L-160H">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 20 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.60mm max height, 20 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BKA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BKA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.1" y="-1.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3" y1="-1.475" x2="-2" y2="-1.125" layer="51"/>
 <rectangle x1="-3" y1="-0.825" x2="-2" y2="-0.475" layer="51"/>
@@ -12056,10 +12600,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm w
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-20-65P-400W-400L-160H-EP">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 20 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.60mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.60mm max height, 20 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BKA-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BKA-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.1" y="-1.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3" y1="-1.475" x2="-2" y2="-1.125" layer="51"/>
 <rectangle x1="-3" y1="-0.825" x2="-2" y2="-0.475" layer="51"/>
@@ -12068,6 +12612,8 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm w
 <rectangle x1="-3" y1="1.125" x2="-2" y2="1.475" layer="51"/>
 <rectangle x1="-1.475" y1="-3" x2="-1.125" y2="-2" layer="51"/>
 <rectangle x1="-1.475" y1="2" x2="-1.125" y2="3" layer="51"/>
+<rectangle x1="-1" y1="-1" x2="1" y2="1" layer="29"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
 <rectangle x1="-0.825" y1="-3" x2="-0.475" y2="-2" layer="51"/>
 <rectangle x1="-0.825" y1="2" x2="-0.475" y2="3" layer="51"/>
 <rectangle x1="-0.175" y1="-3" x2="0.175" y2="-2" layer="51"/>
@@ -12101,7 +12647,8 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm w
 <smd name="18" x="-2.9" y="0" dx="1.5" dy="0.4" layer="1"/>
 <smd name="19" x="-2.9" y="-0.65" dx="1.5" dy="0.4" layer="1"/>
 <smd name="20" x="-2.9" y="-1.3" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="2" dy="2" layer="1"/><text x="-1.5" y="-5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="2.2" dy="2.2" layer="1" stop="no" cream="no"/>
+<text x="-1.5" y="-5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-1.5" y="4" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-1.9" y1="-1.5" x2="-1.5" y2="-1.9" width="0.2032" layer="21"/>
 <wire x1="-1.9" y1="1.9" x2="-1.9" y2="-1.5" width="0.2032" layer="21"/>
@@ -12110,10 +12657,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm w
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-40-65P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 40 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3.1" x2="-3.5" y2="-2.75" layer="51"/>
 <rectangle x1="-4.5" y1="-2.45" x2="-3.5" y2="-2.1" layer="51"/>
@@ -12204,10 +12751,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-40-65P-700W-700L-160H-EP">
-<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.65mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 40 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBB-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBB-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3.1" x2="-3.5" y2="-2.75" layer="51"/>
 <rectangle x1="-4.5" y1="-2.45" x2="-3.5" y2="-2.1" layer="51"/>
@@ -12225,10 +12772,15 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm w
 <rectangle x1="-2.45" y1="3.5" x2="-2.1" y2="4.5" layer="51"/>
 <rectangle x1="-1.8" y1="-4.5" x2="-1.45" y2="-3.5" layer="51"/>
 <rectangle x1="-1.8" y1="3.5" x2="-1.45" y2="4.5" layer="51"/>
+<rectangle x1="-1.75" y1="-1.75" x2="1.75" y2="1.75" layer="29"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
 <rectangle x1="-1.15" y1="-4.5" x2="-0.8" y2="-3.5" layer="51"/>
 <rectangle x1="-1.15" y1="3.5" x2="-0.8" y2="4.5" layer="51"/>
 <rectangle x1="-0.5" y1="-4.5" x2="-0.15" y2="-3.5" layer="51"/>
 <rectangle x1="-0.5" y1="3.5" x2="-0.15" y2="4.5" layer="51"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
 <rectangle x1="0.15" y1="-4.5" x2="0.5" y2="-3.5" layer="51"/>
 <rectangle x1="0.15" y1="3.5" x2="0.5" y2="4.5" layer="51"/>
 <rectangle x1="0.8" y1="-4.5" x2="1.15" y2="-3.5" layer="51"/>
@@ -12289,7 +12841,8 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm w
 <smd name="38" x="-4.4" y="-1.625" dx="1.5" dy="0.4" layer="1"/>
 <smd name="39" x="-4.4" y="-2.275" dx="1.5" dy="0.4" layer="1"/>
 <smd name="40" x="-4.4" y="-2.925" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="3.5" dy="3.5" layer="1"/><text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="3.7" dy="3.7" layer="1" stop="no" cream="no"/>
+<text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3" y="5.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-3.4" y1="-3" x2="-3" y2="-3.4" width="0.2032" layer="21"/>
 <wire x1="-3.4" y1="3.4" x2="-3.4" y2="-3" width="0.2032" layer="21"/>
@@ -12298,10 +12851,10 @@ Low profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-44-80P-1000W-1000L-160H">
-<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -12400,10 +12953,10 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-44-80P-1000W-1000L-160H-EP">
-<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCB-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCB-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -12422,14 +12975,24 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm
 <rectangle x1="-3.4" y1="5" x2="-3" y2="6" layer="51"/>
 <rectangle x1="-2.6" y1="-6" x2="-2.2" y2="-5" layer="51"/>
 <rectangle x1="-2.6" y1="5" x2="-2.2" y2="6" layer="51"/>
+<rectangle x1="-2.5" y1="-2.5" x2="2.5" y2="2.5" layer="29"/>
+<rectangle x1="-2.3639" y1="-2.3639" x2="-0.9694" y2="-0.9694" layer="31"/>
+<rectangle x1="-2.3639" y1="-0.6972" x2="-0.9694" y2="0.6972" layer="31"/>
+<rectangle x1="-2.3639" y1="0.9694" x2="-0.9694" y2="2.3639" layer="31"/>
 <rectangle x1="-1.8" y1="-6" x2="-1.4" y2="-5" layer="51"/>
 <rectangle x1="-1.8" y1="5" x2="-1.4" y2="6" layer="51"/>
 <rectangle x1="-1" y1="-6" x2="-0.6" y2="-5" layer="51"/>
 <rectangle x1="-1" y1="5" x2="-0.6" y2="6" layer="51"/>
+<rectangle x1="-0.6972" y1="-2.3639" x2="0.6972" y2="-0.9694" layer="31"/>
+<rectangle x1="-0.6972" y1="-0.6972" x2="0.6972" y2="0.6972" layer="31"/>
+<rectangle x1="-0.6972" y1="0.9694" x2="0.6972" y2="2.3639" layer="31"/>
 <rectangle x1="-0.2" y1="-6" x2="0.2" y2="-5" layer="51"/>
 <rectangle x1="-0.2" y1="5" x2="0.2" y2="6" layer="51"/>
 <rectangle x1="0.6" y1="-6" x2="1" y2="-5" layer="51"/>
 <rectangle x1="0.6" y1="5" x2="1" y2="6" layer="51"/>
+<rectangle x1="0.9694" y1="-2.3639" x2="2.3639" y2="-0.9694" layer="31"/>
+<rectangle x1="0.9694" y1="-0.6972" x2="2.3639" y2="0.6972" layer="31"/>
+<rectangle x1="0.9694" y1="0.9694" x2="2.3639" y2="2.3639" layer="31"/>
 <rectangle x1="1.4" y1="-6" x2="1.8" y2="-5" layer="51"/>
 <rectangle x1="1.4" y1="5" x2="1.8" y2="6" layer="51"/>
 <rectangle x1="2.2" y1="-6" x2="2.6" y2="-5" layer="51"/>
@@ -12493,7 +13056,8 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm
 <smd name="42" x="-5.9" y="-2.4" dx="1.5" dy="0.5" layer="1"/>
 <smd name="43" x="-5.9" y="-3.2" dx="1.5" dy="0.5" layer="1"/>
 <smd name="44" x="-5.9" y="-4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="EP" x="0" y="0" dx="5" dy="5" layer="1"/><text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="5.2" dy="5.2" layer="1" stop="no" cream="no"/>
+<text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-4.5" y="7" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-4.9" y1="-4.5" x2="-4.5" y2="-4.9" width="0.2032" layer="21"/>
 <wire x1="-4.9" y1="4.9" x2="-4.9" y2="-4.5" width="0.2032" layer="21"/>
@@ -12502,10 +13066,10 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-52-80P-1200W-1200L-160H">
-<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BDB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BDB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-5" x2="-6" y2="-4.6" layer="51"/>
 <rectangle x1="-7" y1="-4.2" x2="-6" y2="-3.8" layer="51"/>
@@ -12620,10 +13184,10 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-52-80P-1200W-1200L-160H-EP">
-<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.60mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.60mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BDB-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BDB-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-5" x2="-6" y2="-4.6" layer="51"/>
 <rectangle x1="-7" y1="-4.2" x2="-6" y2="-3.8" layer="51"/>
@@ -12644,16 +13208,26 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm
 <rectangle x1="-4.2" y1="6" x2="-3.8" y2="7" layer="51"/>
 <rectangle x1="-3.4" y1="-7" x2="-3" y2="-6" layer="51"/>
 <rectangle x1="-3.4" y1="6" x2="-3" y2="7" layer="51"/>
+<rectangle x1="-3" y1="-3" x2="3" y2="3" layer="29"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
 <rectangle x1="-2.6" y1="-7" x2="-2.2" y2="-6" layer="51"/>
 <rectangle x1="-2.6" y1="6" x2="-2.2" y2="7" layer="51"/>
 <rectangle x1="-1.8" y1="-7" x2="-1.4" y2="-6" layer="51"/>
 <rectangle x1="-1.8" y1="6" x2="-1.4" y2="7" layer="51"/>
 <rectangle x1="-1" y1="-7" x2="-0.6" y2="-6" layer="51"/>
 <rectangle x1="-1" y1="6" x2="-0.6" y2="7" layer="51"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
 <rectangle x1="-0.2" y1="-7" x2="0.2" y2="-6" layer="51"/>
 <rectangle x1="-0.2" y1="6" x2="0.2" y2="7" layer="51"/>
 <rectangle x1="0.6" y1="-7" x2="1" y2="-6" layer="51"/>
 <rectangle x1="0.6" y1="6" x2="1" y2="7" layer="51"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
 <rectangle x1="1.4" y1="-7" x2="1.8" y2="-6" layer="51"/>
 <rectangle x1="1.4" y1="6" x2="1.8" y2="7" layer="51"/>
 <rectangle x1="2.2" y1="-7" x2="2.6" y2="-6" layer="51"/>
@@ -12729,7 +13303,8 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm
 <smd name="50" x="-6.9" y="-3.2" dx="1.5" dy="0.5" layer="1"/>
 <smd name="51" x="-6.9" y="-4" dx="1.5" dy="0.5" layer="1"/>
 <smd name="52" x="-6.9" y="-4.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="EP" x="0" y="0" dx="6" dy="6" layer="1"/><text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="6.2" dy="6.2" layer="1" stop="no" cream="no"/>
+<text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-5.5" y="8" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-5.9" y1="-5.5" x2="-5.5" y2="-5.9" width="0.2032" layer="21"/>
 <wire x1="-5.9" y1="5.9" x2="-5.9" y2="-5.5" width="0.2032" layer="21"/>
@@ -12738,10 +13313,10 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-64-80P-1400W-1400L-160H">
-<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BEB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BEB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -12880,10 +13455,10 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-64-80P-1400W-1400L-160H-EP">
-<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BEB-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BEB-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -12909,20 +13484,37 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm
 <rectangle x1="-4.6" y1="7" x2="-4.2" y2="8" layer="51"/>
 <rectangle x1="-3.8" y1="-8" x2="-3.4" y2="-7" layer="51"/>
 <rectangle x1="-3.8" y1="7" x2="-3.4" y2="8" layer="51"/>
+<rectangle x1="-3.5" y1="-3.5" x2="3.5" y2="3.5" layer="29"/>
+<rectangle x1="-3.3571" y1="-3.3571" x2="-1.8929" y2="-1.8929" layer="31"/>
+<rectangle x1="-3.3571" y1="-1.6071" x2="-1.8929" y2="-0.1429" layer="31"/>
+<rectangle x1="-3.3571" y1="0.1429" x2="-1.8929" y2="1.6071" layer="31"/>
+<rectangle x1="-3.3571" y1="1.8929" x2="-1.8929" y2="3.3571" layer="31"/>
 <rectangle x1="-3" y1="-8" x2="-2.6" y2="-7" layer="51"/>
 <rectangle x1="-3" y1="7" x2="-2.6" y2="8" layer="51"/>
 <rectangle x1="-2.2" y1="-8" x2="-1.8" y2="-7" layer="51"/>
 <rectangle x1="-2.2" y1="7" x2="-1.8" y2="8" layer="51"/>
+<rectangle x1="-1.6071" y1="-3.3571" x2="-0.1429" y2="-1.8929" layer="31"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
+<rectangle x1="-1.6071" y1="1.8929" x2="-0.1429" y2="3.3571" layer="31"/>
 <rectangle x1="-1.4" y1="-8" x2="-1" y2="-7" layer="51"/>
 <rectangle x1="-1.4" y1="7" x2="-1" y2="8" layer="51"/>
 <rectangle x1="-0.6" y1="-8" x2="-0.2" y2="-7" layer="51"/>
 <rectangle x1="-0.6" y1="7" x2="-0.2" y2="8" layer="51"/>
+<rectangle x1="0.1429" y1="-3.3571" x2="1.6071" y2="-1.8929" layer="31"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
+<rectangle x1="0.1429" y1="1.8929" x2="1.6071" y2="3.3571" layer="31"/>
 <rectangle x1="0.2" y1="-8" x2="0.6" y2="-7" layer="51"/>
 <rectangle x1="0.2" y1="7" x2="0.6" y2="8" layer="51"/>
 <rectangle x1="1" y1="-8" x2="1.4" y2="-7" layer="51"/>
 <rectangle x1="1" y1="7" x2="1.4" y2="8" layer="51"/>
 <rectangle x1="1.8" y1="-8" x2="2.2" y2="-7" layer="51"/>
 <rectangle x1="1.8" y1="7" x2="2.2" y2="8" layer="51"/>
+<rectangle x1="1.8929" y1="-3.3571" x2="3.3571" y2="-1.8929" layer="31"/>
+<rectangle x1="1.8929" y1="-1.6071" x2="3.3571" y2="-0.1429" layer="31"/>
+<rectangle x1="1.8929" y1="0.1429" x2="3.3571" y2="1.6071" layer="31"/>
+<rectangle x1="1.8929" y1="1.8929" x2="3.3571" y2="3.3571" layer="31"/>
 <rectangle x1="2.6" y1="-8" x2="3" y2="-7" layer="51"/>
 <rectangle x1="2.6" y1="7" x2="3" y2="8" layer="51"/>
 <rectangle x1="3.4" y1="-8" x2="3.8" y2="-7" layer="51"/>
@@ -13013,7 +13605,8 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm
 <smd name="62" x="-7.9" y="-4.4" dx="1.5" dy="0.5" layer="1"/>
 <smd name="63" x="-7.9" y="-5.2" dx="1.5" dy="0.5" layer="1"/>
 <smd name="64" x="-7.9" y="-6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="EP" x="0" y="0" dx="7" dy="7" layer="1"/><text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="7.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-6.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-6.9" y1="-6.5" x2="-6.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-6.9" y1="6.9" x2="-6.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -13022,10 +13615,10 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-32-80P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3" x2="-3.5" y2="-2.6" layer="51"/>
 <rectangle x1="-4.5" y1="-2.2" x2="-3.5" y2="-1.8" layer="51"/>
@@ -13100,10 +13693,10 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm w
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-32-80P-700W-700L-160H-EP">
-<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBA-HD, HL-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBA-HD, HL-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3" x2="-3.5" y2="-2.6" layer="51"/>
 <rectangle x1="-4.5" y1="-2.2" x2="-3.5" y2="-1.8" layer="51"/>
@@ -13117,10 +13710,15 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm w
 <rectangle x1="-3" y1="3.5" x2="-2.6" y2="4.5" layer="51"/>
 <rectangle x1="-2.2" y1="-4.5" x2="-1.8" y2="-3.5" layer="51"/>
 <rectangle x1="-2.2" y1="3.5" x2="-1.8" y2="4.5" layer="51"/>
+<rectangle x1="-1.75" y1="-1.75" x2="1.75" y2="1.75" layer="29"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
 <rectangle x1="-1.4" y1="-4.5" x2="-1" y2="-3.5" layer="51"/>
 <rectangle x1="-1.4" y1="3.5" x2="-1" y2="4.5" layer="51"/>
 <rectangle x1="-0.6" y1="-4.5" x2="-0.2" y2="-3.5" layer="51"/>
 <rectangle x1="-0.6" y1="3.5" x2="-0.2" y2="4.5" layer="51"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
 <rectangle x1="0.2" y1="-4.5" x2="0.6" y2="-3.5" layer="51"/>
 <rectangle x1="0.2" y1="3.5" x2="0.6" y2="4.5" layer="51"/>
 <rectangle x1="1" y1="-4.5" x2="1.4" y2="-3.5" layer="51"/>
@@ -13169,7 +13767,8 @@ Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm w
 <smd name="30" x="-4.4" y="-1.2" dx="1.5" dy="0.5" layer="1"/>
 <smd name="31" x="-4.4" y="-2" dx="1.5" dy="0.5" layer="1"/>
 <smd name="32" x="-4.4" y="-2.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="EP" x="0" y="0" dx="3.5" dy="3.5" layer="1"/><text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="3.7" dy="3.7" layer="1" stop="no" cream="no"/>
+<text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3" y="5.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-3.4" y1="-3" x2="-3" y2="-3.4" width="0.2032" layer="21"/>
 <wire x1="-3.4" y1="3.4" x2="-3.4" y2="-3" width="0.2032" layer="21"/>

--- a/ref-packages-qfp.lbr
+++ b/ref-packages-qfp.lbr
@@ -66,10 +66,10 @@
 NOTE: This library is used to globally update common IC packages in all other libraries.&lt;p&gt;</description>
 <packages>
 <package name="QFP-36-100P-1000W-1000L-245H-160F">
-<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 36 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 36 leads.
-&lt;p/&gt;JEDEC MS-022B, variation AA, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation AA, PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.6" y1="-4.225" x2="-5" y2="-3.775" layer="21"/>
 <rectangle x1="-6.6" y1="-3.225" x2="-5" y2="-2.775" layer="21"/>
@@ -152,10 +152,10 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-52-100P-1400W-1400L-245H-160F">
-<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-022B, variation BA, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation BA, PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.6" y1="-6.225" x2="-7" y2="-5.775" layer="21"/>
 <rectangle x1="-8.6" y1="-5.225" x2="-7" y2="-4.775" layer="21"/>
@@ -270,10 +270,10 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-52-100P-1400W-1400L-245H-195F">
-<description>&lt;b&gt;QFP (1.00mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (1.00mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 52 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation BA-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation BA-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.95" y1="-6.225" x2="-7" y2="-5.775" layer="21"/>
 <rectangle x1="-8.95" y1="-5.225" x2="-7" y2="-4.775" layer="21"/>
@@ -388,10 +388,10 @@ Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 14mm length, 14mm wi
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-52-100P-1400W-1400L-315H-160F">
-<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 14mm length, 14mm width, 3.15mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-022B, variation BD, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation BD, PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.6" y1="-6.225" x2="-7" y2="-5.775" layer="21"/>
 <rectangle x1="-8.6" y1="-5.225" x2="-7" y2="-4.775" layer="21"/>
@@ -506,10 +506,10 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-52-100P-1400W-1400L-340H-195F">
-<description>&lt;b&gt;QFP (1.00mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (1.00mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 52 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation BB-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation BB-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.95" y1="-6.225" x2="-7" y2="-5.775" layer="21"/>
 <rectangle x1="-8.95" y1="-5.225" x2="-7" y2="-4.775" layer="21"/>
@@ -624,10 +624,10 @@ Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 14mm length, 14mm wi
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-64-100P-1400W-2000L-315H-160F">
-<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-022B, variation GA-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation GA-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-6.225" x2="-10" y2="-5.775" layer="21"/>
 <rectangle x1="-11.6" y1="-5.225" x2="-10" y2="-4.775" layer="21"/>
@@ -766,10 +766,10 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-64-100P-1400W-2000L-340H-160F">
-<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.40mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.40mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.40mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-022B, variation GA-1, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation GA-1, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-6.225" x2="-10" y2="-5.775" layer="21"/>
 <rectangle x1="-11.6" y1="-5.225" x2="-10" y2="-4.775" layer="21"/>
@@ -908,10 +908,10 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-64-100P-1400W-2000L-345H-195F">
-<description>&lt;b&gt;QFP (1.00mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (1.00mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.45mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.45mm max height, 64 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation CA-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation CA-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.95" y1="-6.225" x2="-10" y2="-5.775" layer="21"/>
 <rectangle x1="-11.95" y1="-5.225" x2="-10" y2="-4.775" layer="21"/>
@@ -1050,10 +1050,10 @@ Metric quad flat package. 1.00mm pitch, 1.95mm lead length, 20mm length, 14mm wi
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-76-100P-2000W-2000L-315H-160F">
-<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.15mm max height, 76 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.15mm max height, 76 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 20mm width, 3.15mm max height, 76 leads.
-&lt;p/&gt;JEDEC MS-022B, variation CA-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation CA-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-9.225" x2="-10" y2="-8.775" layer="21"/>
 <rectangle x1="-11.6" y1="-8.225" x2="-10" y2="-7.775" layer="21"/>
@@ -1216,10 +1216,10 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 20mm widt
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-76-100P-2000W-2000L-345H-160F">
-<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.45mm max height, 76 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.45mm max height, 76 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 20mm width, 3.45mm max height, 76 leads.
-&lt;p/&gt;JEDEC MS-022B, variation CA-1, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation CA-1, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-9.225" x2="-10" y2="-8.775" layer="21"/>
 <rectangle x1="-11.6" y1="-8.225" x2="-10" y2="-7.775" layer="21"/>
@@ -1384,8 +1384,8 @@ Metric quad flat package. 1.00mm pitch, 1.6mm lead length 20mm length, 20mm widt
 <package name="QFP-80-40P-1000W-1000L-245H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 10mm length, 10mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 10mm length, 10mm width, 2.45mm max height, 80 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation AB, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation AB, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.3" y1="-3.9" x2="-5" y2="-3.7" layer="51"/>
 <rectangle x1="-6.3" y1="-3.5" x2="-5" y2="-3.3" layer="51"/>
@@ -1558,8 +1558,8 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 10mm lengt
 <package name="QFP-100-40P-1200W-1200L-245H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 12mm length, 12mm width, 2.45mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 12mm length, 12mm width, 2.45mm max height, 100 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation BC, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation BC, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7.3" y1="-4.9" x2="-6" y2="-4.7" layer="51"/>
 <rectangle x1="-7.3" y1="-4.5" x2="-6" y2="-4.3" layer="51"/>
@@ -1772,8 +1772,8 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 12mm lengt
 <package name="QFP-120-40P-1400W-1400L-245H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 14mm length, 14mm width, 2.45mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 14mm length, 14mm width, 2.45mm max height, 120 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation CC, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation CC, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.3" y1="-5.9" x2="-7" y2="-5.7" layer="51"/>
 <rectangle x1="-8.3" y1="-5.5" x2="-7" y2="-5.3" layer="51"/>
@@ -2026,8 +2026,8 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 14mm lengt
 <package name="QFP-120-40P-1400W-1400L-315H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 14mm length, 14mm width, 3.15mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 14mm length, 14mm width, 3.15mm max height, 120 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation CD, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation CD, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.3" y1="-5.9" x2="-7" y2="-5.7" layer="51"/>
 <rectangle x1="-8.3" y1="-5.5" x2="-7" y2="-5.3" layer="51"/>
@@ -2280,8 +2280,8 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 14mm lengt
 <package name="QFP-176-40P-2000W-2000L-245H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 20mm length, 20mm width, 2.45mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 20mm length, 20mm width, 2.45mm max height, 176 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation DC-2, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation DC-2, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.3" y1="-8.7" x2="-10" y2="-8.5" layer="51"/>
 <rectangle x1="-11.3" y1="-8.3" x2="-10" y2="-8.1" layer="51"/>
@@ -2646,8 +2646,8 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 20mm lengt
 <package name="QFP-176-40P-2000W-2000L-315H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 20mm length, 20mm width, 3.15mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 20mm length, 20mm width, 3.15mm max height, 176 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation DD-2, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation DD-2, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.3" y1="-8.7" x2="-10" y2="-8.5" layer="51"/>
 <rectangle x1="-11.3" y1="-8.3" x2="-10" y2="-8.1" layer="51"/>
@@ -3012,8 +3012,8 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 20mm lengt
 <package name="QFP-216-40P-2400W-2400L-410H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 24mm length, 24mm width, 4.10mm max height, 216 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 24mm length, 24mm width, 4.10mm max height, 216 leads, high standoff.
-&lt;p/&gt;JEDEC MS-029A, variation EB, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation EB, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-11.1" y="-11.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-13.3" y1="-10.7" x2="-12" y2="-10.5" layer="51"/>
 <rectangle x1="-13.3" y1="-10.3" x2="-12" y2="-10.1" layer="51"/>
@@ -3458,8 +3458,8 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 24mm lengt
 <package name="QFP-256-40P-2800W-2800L-385H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 256 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 256 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation FB-2, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation FB-2, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.3" y1="-12.7" x2="-14" y2="-12.5" layer="51"/>
 <rectangle x1="-15.3" y1="-12.3" x2="-14" y2="-12.1" layer="51"/>
@@ -3984,8 +3984,8 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 28mm lengt
 <package name="QFP-256-40P-2800W-2800L-410H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 28mm length, 28mm width, 4.10mm max height, 256 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 28mm length, 28mm width, 4.10mm max height, 256 leads, high standoff.
-&lt;p/&gt;JEDEC MS-029A, variation FB-1, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation FB-1, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.3" y1="-12.7" x2="-14" y2="-12.5" layer="51"/>
 <rectangle x1="-15.3" y1="-12.3" x2="-14" y2="-12.1" layer="51"/>
@@ -4510,8 +4510,8 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 28mm lengt
 <package name="QFP-296-40P-3200W-3200L-410H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 32mm length, 32mm width, 4.10mm max height, 296 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 32mm length, 32mm width, 4.10mm max height, 296 leads, high standoff.
-&lt;p/&gt;JEDEC MS-029A, variation GB, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation GB, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-15.1" y="-15.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-17.3" y1="-14.7" x2="-16" y2="-14.5" layer="51"/>
 <rectangle x1="-17.3" y1="-14.3" x2="-16" y2="-14.1" layer="51"/>
@@ -5116,8 +5116,8 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 32mm lengt
 <package name="QFP-336-40P-3600W-3600L-450H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 36mm length, 36mm width, 4.50mm max height, 336 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 36mm length, 36mm width, 4.50mm max height, 336 leads, high standoff.
-&lt;p/&gt;JEDEC MS-029A, variation HB, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation HB, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-17.1" y="-17.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-19.3" y1="-16.7" x2="-18" y2="-16.5" layer="51"/>
 <rectangle x1="-19.3" y1="-16.3" x2="-18" y2="-16.1" layer="51"/>
@@ -5802,8 +5802,8 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 36mm lengt
 <package name="QFP-376-40P-4000W-4000L-450H-130F">
 <description>&lt;b&gt;FQFP (0.40mm pitch, 1.3mm lead length, 40mm length, 40mm width, 4.50mm max height, 376 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 40mm length, 40mm width, 4.50mm max height, 376 leads, high standoff.
-&lt;p/&gt;JEDEC MS-029A, variation JB, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation JB, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-19.1" y="-19.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-21.3" y1="-18.7" x2="-20" y2="-18.5" layer="51"/>
 <rectangle x1="-21.3" y1="-18.3" x2="-20" y2="-18.1" layer="51"/>
@@ -6568,8 +6568,8 @@ Metric fine-pitch quad flat package. 0.40mm pitch, 1.3mm lead length, 40mm lengt
 <package name="QFP-64-50P-1000W-1000L-245H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 10mm length, 10mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 10mm length, 10mm width, 2.45mm max height, 64 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation AA, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation AA, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.3" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6.3" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>
@@ -6710,8 +6710,8 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 10mm lengt
 <package name="QFP-80-50P-1200W-1200L-245H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 12mm length, 12mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 12mm length, 12mm width, 2.45mm max height, 80 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation BA, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation BA, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7.3" y1="-4.875" x2="-6" y2="-4.625" layer="51"/>
 <rectangle x1="-7.3" y1="-4.375" x2="-6" y2="-4.125" layer="51"/>
@@ -6884,8 +6884,8 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 12mm lengt
 <package name="QFP-80-50P-1200W-1200L-315H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 12mm length, 12mm width, 3.15mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 12mm length, 12mm width, 3.15mm max height, 80 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation BB, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation BB, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7.3" y1="-4.875" x2="-6" y2="-4.625" layer="51"/>
 <rectangle x1="-7.3" y1="-4.375" x2="-6" y2="-4.125" layer="51"/>
@@ -7058,8 +7058,8 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 12mm lengt
 <package name="QFP-100-50P-1400W-1400L-245H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 14mm length, 14mm width, 2.45mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 14mm length, 14mm width, 2.45mm max height, 100 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation CA, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation CA, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.3" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8.3" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -7272,8 +7272,8 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 14mm lengt
 <package name="QFP-100-50P-1400W-1400L-315H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 14mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 14mm length, 14mm width, 3.15mm max height, 100 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation CB, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation CB, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.3" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8.3" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -7486,8 +7486,8 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 14mm lengt
 <package name="QFP-128-50P-1400W-2000L-315H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 20mm length, 14mm width, 3.15mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 20mm length, 14mm width, 3.15mm max height, 128 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation KA, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation KA, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.3" y1="-6.375" x2="-10" y2="-6.125" layer="51"/>
 <rectangle x1="-11.3" y1="-5.875" x2="-10" y2="-5.625" layer="51"/>
@@ -7756,8 +7756,8 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 20mm lengt
 <package name="QFP-144-50P-2000W-2000L-245H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 20mm length, 20mm width, 2.45mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 20mm length, 20mm width, 2.45mm max height, 144 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation DA-2, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation DA-2, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.3" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11.3" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -8058,8 +8058,8 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 20mm lengt
 <package name="QFP-144-50P-2000W-2000L-315H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 20mm length, 20mm width, 3.15mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 20mm length, 20mm width, 3.15mm max height, 144 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation DB-2, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation DB-2, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.3" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11.3" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -8360,8 +8360,8 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 20mm lengt
 <package name="QFP-176-50P-2400W-2400L-410H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 24mm length, 24mm width, 4.10mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 24mm length, 24mm width, 4.10mm max height, 176 leads, high standoff.
-&lt;p/&gt;JEDEC MS-029A, variation EA, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation EA, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-11.1" y="-11.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-13.3" y1="-10.875" x2="-12" y2="-10.625" layer="51"/>
 <rectangle x1="-13.3" y1="-10.375" x2="-12" y2="-10.125" layer="51"/>
@@ -8726,8 +8726,8 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 24mm lengt
 <package name="QFP-208-50P-2800W-2800L-385H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 3.85mm max height, 208 leads, low standoff.
-&lt;p/&gt;JEDEC MS-029A, variation FA-2, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation FA-2, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.3" y1="-12.875" x2="-14" y2="-12.625" layer="51"/>
 <rectangle x1="-15.3" y1="-12.375" x2="-14" y2="-12.125" layer="51"/>
@@ -9156,8 +9156,8 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm lengt
 <package name="QFP-208-50P-2800W-2800L-410H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 4.10mm max height, 208 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm length, 28mm width, 4.10mm max height, 208 leads, high standoff.
-&lt;p/&gt;JEDEC MS-029A, variation FA-1, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation FA-1, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.3" y1="-12.875" x2="-14" y2="-12.625" layer="51"/>
 <rectangle x1="-15.3" y1="-12.375" x2="-14" y2="-12.125" layer="51"/>
@@ -9586,8 +9586,8 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 28mm lengt
 <package name="QFP-240-50P-3200W-3200L-410H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 32mm length, 32mm width, 4.10mm max height, 240 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 32mm length, 32mm width, 4.10mm max height, 240 leads, high standoff.
-&lt;p/&gt;JEDEC MS-029A, variation GA, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation GA, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-15.1" y="-15.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-17.3" y1="-14.875" x2="-16" y2="-14.625" layer="51"/>
 <rectangle x1="-17.3" y1="-14.375" x2="-16" y2="-14.125" layer="51"/>
@@ -10080,8 +10080,8 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 32mm lengt
 <package name="QFP-272-50P-3600W-3600L-450H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 36mm length, 36mm width, 4.50mm max height, 272 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 36mm length, 36mm width, 4.50mm max height, 272 leads, high standoff.
-&lt;p/&gt;JEDEC MS-029A, variation HA, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation HA, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-17.1" y="-17.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-19.3" y1="-16.875" x2="-18" y2="-16.625" layer="51"/>
 <rectangle x1="-19.3" y1="-16.375" x2="-18" y2="-16.125" layer="51"/>
@@ -10638,8 +10638,8 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 36mm lengt
 <package name="QFP-304-50P-4000W-4000L-450H-130F">
 <description>&lt;b&gt;FQFP (0.50mm pitch, 1.3mm lead length, 40mm length, 40mm width, 4.50mm max height, 304 leads)&lt;/b&gt;&lt;p/&gt;
 Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 40mm length, 40mm width, 4.50mm max height, 304 leads, high standoff.
-&lt;p/&gt;JEDEC MS-029A, variation JA, S-R-PQFP.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-029A, variation JA, S-R-PQFP.&lt;/p&gt;</description>
 <circle x="-19.1" y="-19.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-21.3" y1="-18.875" x2="-20" y2="-18.625" layer="51"/>
 <rectangle x1="-21.3" y1="-18.375" x2="-20" y2="-18.125" layer="51"/>
@@ -11258,10 +11258,10 @@ Metric fine-pitch quad flat package. 0.50mm pitch, 1.3mm lead length, 40mm lengt
 <wire x1="19.9" y1="19.9" x2="-19.9" y2="19.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-52-65P-1000W-1000L-245H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-022B, variation AC, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation AC, PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.6" y1="-4.085" x2="-5" y2="-3.715" layer="51"/>
 <rectangle x1="-6.6" y1="-3.435" x2="-5" y2="-3.065" layer="51"/>
@@ -11376,10 +11376,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-52-65P-1000W-1000L-245H-195F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 52 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation AC-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation AC-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.95" y1="-4.075" x2="-5" y2="-3.725" layer="51"/>
 <rectangle x1="-6.95" y1="-3.425" x2="-5" y2="-3.075" layer="51"/>
@@ -11494,10 +11494,10 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 10mm length, 10mm wi
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-52-65P-1000W-1000L-340H-195F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 3.40mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 3.40mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 10mm length, 10mm width, 3.40mm max height, 52 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation AD-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation AD-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.95" y1="-4.075" x2="-5" y2="-3.725" layer="51"/>
 <rectangle x1="-6.95" y1="-3.425" x2="-5" y2="-3.075" layer="51"/>
@@ -11612,10 +11612,10 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 10mm length, 10mm wi
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-80-65P-1400W-1400L-245H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-022B, variation BC, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation BC, PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.6" y1="-6.36" x2="-7" y2="-5.99" layer="51"/>
 <rectangle x1="-8.6" y1="-5.71" x2="-7" y2="-5.34" layer="51"/>
@@ -11786,10 +11786,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-80-65P-1400W-1400L-245H-195F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 80 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation BE-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation BE-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.95" y1="-6.35" x2="-7" y2="-6" layer="51"/>
 <rectangle x1="-8.95" y1="-5.7" x2="-7" y2="-5.35" layer="51"/>
@@ -11960,10 +11960,10 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 14mm length, 14mm wi
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-80-65P-1400W-1400L-315H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm width, 3.15mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-022B, variation BF, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation BF, PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.6" y1="-6.36" x2="-7" y2="-5.99" layer="51"/>
 <rectangle x1="-8.6" y1="-5.71" x2="-7" y2="-5.34" layer="51"/>
@@ -12134,10 +12134,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-80-65P-1400W-1400L-340H-195F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 80 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation BF-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation BF-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.95" y1="-6.35" x2="-7" y2="-6" layer="51"/>
 <rectangle x1="-8.95" y1="-5.7" x2="-7" y2="-5.35" layer="51"/>
@@ -12308,10 +12308,10 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 14mm length, 14mm wi
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-100-65P-1400W-2000L-315H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-022B, variation GC-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation GC-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-6.36" x2="-10" y2="-5.99" layer="51"/>
 <rectangle x1="-11.6" y1="-5.71" x2="-10" y2="-5.34" layer="51"/>
@@ -12522,10 +12522,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-100-65P-1400W-2000L-340H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.40mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-022B, variation GC-1, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation GC-1, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-6.36" x2="-10" y2="-5.99" layer="51"/>
 <rectangle x1="-11.6" y1="-5.71" x2="-10" y2="-5.34" layer="51"/>
@@ -12736,10 +12736,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-100-65P-1400W-2000L-340H-195F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 100 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation CC-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation CC-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.95" y1="-6.35" x2="-10" y2="-6" layer="51"/>
 <rectangle x1="-11.95" y1="-5.7" x2="-10" y2="-5.35" layer="51"/>
@@ -12950,10 +12950,10 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 20mm length, 14mm wi
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-112-65P-2000W-2000L-315H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.15mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.15mm max height, 112 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 20mm width, 3.15mm max height, 112 leads.
-&lt;p/&gt;JEDEC MS-022B, variation CC-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation CC-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-8.96" x2="-10" y2="-8.59" layer="51"/>
 <rectangle x1="-11.6" y1="-8.31" x2="-10" y2="-7.94" layer="51"/>
@@ -13188,10 +13188,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 20mm widt
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-112-65P-2000W-2000L-345H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.45mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.45mm max height, 112 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 20mm width, 3.45mm max height, 112 leads.
-&lt;p/&gt;JEDEC MS-022B, variation CC-1, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation CC-1, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-8.96" x2="-10" y2="-8.59" layer="51"/>
 <rectangle x1="-11.6" y1="-8.31" x2="-10" y2="-7.94" layer="51"/>
@@ -13426,10 +13426,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 20mm length, 20mm widt
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-144-65P-2800W-2800L-385H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DC-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DC-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-11.56" x2="-14" y2="-11.19" layer="51"/>
 <rectangle x1="-15.6" y1="-10.91" x2="-14" y2="-10.54" layer="51"/>
@@ -13728,10 +13728,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-160-65P-2800W-2800L-385H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 160 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 160 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DD-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DD-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-12.86" x2="-14" y2="-12.49" layer="51"/>
 <rectangle x1="-15.6" y1="-12.21" x2="-14" y2="-11.84" layer="51"/>
@@ -14062,10 +14062,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-144-65P-2800W-2800L-392H-195F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 144 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation DC-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation DC-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.95" y1="-11.55" x2="-14" y2="-11.2" layer="51"/>
 <rectangle x1="-15.95" y1="-10.9" x2="-14" y2="-10.55" layer="51"/>
@@ -14364,10 +14364,10 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 28mm length, 28mm wi
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-160-65P-2800W-2800L-392H-195F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 160 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 160 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation DD-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation DD-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.95" y1="-12.85" x2="-14" y2="-12.5" layer="51"/>
 <rectangle x1="-15.95" y1="-12.2" x2="-14" y2="-11.85" layer="51"/>
@@ -14698,10 +14698,10 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 28mm length, 28mm wi
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-144-65P-2800W-2800L-410H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 4.10mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DC-1, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DC-1, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-11.56" x2="-14" y2="-11.19" layer="51"/>
 <rectangle x1="-15.6" y1="-10.91" x2="-14" y2="-10.54" layer="51"/>
@@ -15000,10 +15000,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-160-65P-2800W-2800L-410H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 160 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 160 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 4.10mm max height, 160 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DD-1, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DD-1, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-12.86" x2="-14" y2="-12.49" layer="51"/>
 <rectangle x1="-15.6" y1="-12.21" x2="-14" y2="-11.84" layer="51"/>
@@ -15334,10 +15334,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-184-65P-3200W-3200L-392H-195F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 32mm length, 32mm width, 3.92mm max height, 184 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 32mm length, 32mm width, 3.92mm max height, 184 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 32mm length, 32mm width, 3.92mm max height, 184 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation EA-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation EA-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-15.1" y="-15.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-17.95" y1="-14.8" x2="-16" y2="-14.45" layer="51"/>
 <rectangle x1="-17.95" y1="-14.15" x2="-16" y2="-13.8" layer="51"/>
@@ -15716,10 +15716,10 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 32mm length, 32mm wi
 <wire x1="15.9" y1="15.9" x2="-15.9" y2="15.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-184-65P-3200W-3200L-410H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 32mm length, 32mm width, 4.10mm max height, 184 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 32mm length, 32mm width, 4.10mm max height, 184 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 32mm length, 32mm width, 4.10mm max height, 184 leads.
-&lt;p/&gt;JEDEC MS-022B, variation EA, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation EA, PQFP-G.&lt;/p&gt;</description>
 <circle x="-15.1" y="-15.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-17.6" y1="-14.81" x2="-16" y2="-14.44" layer="51"/>
 <rectangle x1="-17.6" y1="-14.16" x2="-16" y2="-13.79" layer="51"/>
@@ -16098,10 +16098,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 32mm length, 32mm widt
 <wire x1="15.9" y1="15.9" x2="-15.9" y2="15.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-232-65P-4000W-4000L-440H-195F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 40mm length, 40mm width, 4.40mm max height, 232 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.95mm lead length, 40mm length, 40mm width, 4.40mm max height, 232 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 40mm length, 40mm width, 4.40mm max height, 232 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation FA-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation FA-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-19.1" y="-19.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-21.95" y1="-18.7" x2="-20" y2="-18.35" layer="51"/>
 <rectangle x1="-21.95" y1="-18.05" x2="-20" y2="-17.7" layer="51"/>
@@ -16576,10 +16576,10 @@ Metric quad flat package. 0.65mm pitch, 1.95mm lead length, 40mm length, 40mm wi
 <wire x1="19.9" y1="19.9" x2="-19.9" y2="19.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-232-65P-4000W-4000L-450H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 40mm length, 40mm width, 4.50mm max height, 232 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 40mm length, 40mm width, 4.50mm max height, 232 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 40mm length, 40mm width, 4.50mm max height, 232 leads.
-&lt;p/&gt;JEDEC MS-022B, variation FA, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation FA, PQFP-G.&lt;/p&gt;</description>
 <circle x="-19.1" y="-19.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-21.6" y1="-18.71" x2="-20" y2="-18.34" layer="51"/>
 <rectangle x1="-21.6" y1="-18.06" x2="-20" y2="-17.69" layer="51"/>
@@ -17054,10 +17054,10 @@ Metric quad flat package. 0.65mm pitch, 1.6mm lead length 40mm length, 40mm widt
 <wire x1="19.9" y1="19.9" x2="-19.9" y2="19.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-44-80P-1000W-1000L-245H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm width, 2.45mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-022B, variation AB, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation AB, PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6.6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -17156,10 +17156,10 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-44-80P-1000W-1000L-245H-195F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 10mm length, 10mm width, 2.45mm max height, 44 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation AA-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation AA-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.95" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6.95" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -17258,10 +17258,10 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 10mm length, 10mm wi
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-44-80P-1000W-1000L-340H-195F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 10mm length, 10mm width, 3.40mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 10mm length, 10mm width, 3.40mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 10mm length, 10mm width, 3.40mm max height, 44 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation AB-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation AB-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.95" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6.95" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -17360,10 +17360,10 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 10mm length, 10mm wi
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-64-80P-1400W-1400L-245H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-022B, variation BB, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation BB, PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.6" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8.6" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -17502,10 +17502,10 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-64-80P-1400W-1400L-245H-195F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 14mm length, 14mm width, 2.45mm max height, 64 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation BC-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation BC-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.95" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8.95" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -17644,10 +17644,10 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 14mm length, 14mm wi
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-64-80P-1400W-1400L-315H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 14mm length, 14mm width, 3.15mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm width, 3.15mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-022B, variation BE, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation BE, PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.6" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8.6" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -17786,10 +17786,10 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 14mm length, 14mm widt
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-64-80P-1400W-1400L-340H-195F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 14mm length, 14mm width, 3.40mm max height, 64 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation BD-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation BD-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.95" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8.95" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -17928,10 +17928,10 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 14mm length, 14mm wi
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-80-80P-1400W-2000L-315H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.15mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.15mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-022B, variation GB-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation GB-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-7" x2="-10" y2="-6.6" layer="51"/>
 <rectangle x1="-11.6" y1="-6.2" x2="-10" y2="-5.8" layer="51"/>
@@ -18017,90 +18017,90 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <rectangle x1="10" y1="5" x2="11.6" y2="5.4" layer="51"/>
 <rectangle x1="10" y1="5.8" x2="11.6" y2="6.2" layer="51"/>
 <rectangle x1="10" y1="6.6" x2="11.6" y2="7" layer="51"/>
-<smd name="1" x="-11.2" y="-6.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="2" x="-9.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="3" x="-8.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="4" x="-7.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="5" x="-6.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="6" x="-6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="7" x="-5.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="8" x="-4.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="9" x="-3.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="10" x="-2.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="11" x="-2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="12" x="-1.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="13" x="-0.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="14" x="0.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="15" x="1.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="16" x="2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="17" x="2.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="18" x="3.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="19" x="4.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="20" x="5.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="21" x="6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="22" x="6.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="23" x="7.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="24" x="8.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="25" x="9.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="26" x="11.2" y="-6.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="27" x="11.2" y="-6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="28" x="11.2" y="-5.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="29" x="11.2" y="-4.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="30" x="11.2" y="-3.6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="31" x="11.2" y="-2.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="32" x="11.2" y="-2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="33" x="11.2" y="-1.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="34" x="11.2" y="-0.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="35" x="11.2" y="0.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="36" x="11.2" y="1.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="37" x="11.2" y="2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="38" x="11.2" y="2.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="39" x="11.2" y="3.6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="40" x="11.2" y="4.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="41" x="11.2" y="5.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="42" x="11.2" y="6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="43" x="11.2" y="6.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="44" x="9.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="45" x="8.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="46" x="7.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="47" x="6.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="48" x="6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="49" x="5.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="50" x="4.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="51" x="3.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="52" x="2.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="53" x="2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="54" x="1.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="55" x="0.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="56" x="-0.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="57" x="-1.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="58" x="-2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="59" x="-2.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="60" x="-3.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="61" x="-4.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="62" x="-5.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="63" x="-6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="64" x="-6.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="65" x="-7.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="66" x="-8.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="67" x="-9.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="68" x="-11.2" y="6.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="69" x="-11.2" y="6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="70" x="-11.2" y="5.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="71" x="-11.2" y="4.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="72" x="-11.2" y="3.6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="73" x="-11.2" y="2.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="74" x="-11.2" y="2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="75" x="-11.2" y="1.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="76" x="-11.2" y="0.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="77" x="-11.2" y="-0.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="78" x="-11.2" y="-1.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="79" x="-11.2" y="-2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="80" x="-11.2" y="-2.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="81" x="-11.2" y="-3.6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="82" x="-11.2" y="-4.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="83" x="-11.2" y="-5.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="84" x="-11.2" y="-6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="1" x="-9.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="2" x="-8.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="3" x="-7.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="4" x="-6.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="5" x="-6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="6" x="-5.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="7" x="-4.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="8" x="-3.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="9" x="-2.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="10" x="-2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="11" x="-1.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="12" x="-0.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="13" x="0.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="14" x="1.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="15" x="2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="16" x="2.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="17" x="3.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="18" x="4.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="19" x="5.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="20" x="6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="21" x="6.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="22" x="7.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="23" x="8.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="24" x="9.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="25" x="11.2" y="-6.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="26" x="11.2" y="-6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="27" x="11.2" y="-5.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="28" x="11.2" y="-4.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="29" x="11.2" y="-3.6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="30" x="11.2" y="-2.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="31" x="11.2" y="-2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="32" x="11.2" y="-1.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="33" x="11.2" y="-0.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="34" x="11.2" y="0.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="35" x="11.2" y="1.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="36" x="11.2" y="2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="37" x="11.2" y="2.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="38" x="11.2" y="3.6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="39" x="11.2" y="4.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="40" x="11.2" y="5.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="41" x="11.2" y="6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="42" x="11.2" y="6.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="43" x="9.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="44" x="8.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="45" x="7.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="46" x="6.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="47" x="6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="48" x="5.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="49" x="4.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="50" x="3.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="51" x="2.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="52" x="2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="53" x="1.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="54" x="0.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="55" x="-0.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="56" x="-1.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="57" x="-2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="58" x="-2.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="59" x="-3.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="60" x="-4.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="61" x="-5.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="62" x="-6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="63" x="-6.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="64" x="-7.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="65" x="-8.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="66" x="-9.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="67" x="-11.2" y="6.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="68" x="-11.2" y="6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="69" x="-11.2" y="5.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="70" x="-11.2" y="4.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="71" x="-11.2" y="3.6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="72" x="-11.2" y="2.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="73" x="-11.2" y="2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="74" x="-11.2" y="1.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="75" x="-11.2" y="0.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="76" x="-11.2" y="-0.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="77" x="-11.2" y="-1.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="78" x="-11.2" y="-2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="79" x="-11.2" y="-2.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="80" x="-11.2" y="-3.6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="81" x="-11.2" y="-4.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="82" x="-11.2" y="-5.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="83" x="-11.2" y="-6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="84" x="-11.2" y="-6.8" dx="1.5" dy="0.5" layer="1"/>
 <text x="-9.5" y="-10.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-9.5" y="9.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-9.9" y1="-6.5" x2="-9.5" y2="-6.9" width="0.2032" layer="21"/>
@@ -18110,10 +18110,10 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-80-80P-1400W-2000L-340H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.40mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 20mm length, 14mm width, 3.40mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 14mm width, 3.40mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-022B, variation GB-1, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation GB-1, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-7" x2="-10" y2="-6.6" layer="51"/>
 <rectangle x1="-11.6" y1="-6.2" x2="-10" y2="-5.8" layer="51"/>
@@ -18199,90 +18199,90 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <rectangle x1="10" y1="5" x2="11.6" y2="5.4" layer="51"/>
 <rectangle x1="10" y1="5.8" x2="11.6" y2="6.2" layer="51"/>
 <rectangle x1="10" y1="6.6" x2="11.6" y2="7" layer="51"/>
-<smd name="1" x="-11.2" y="-6.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="2" x="-9.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="3" x="-8.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="4" x="-7.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="5" x="-6.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="6" x="-6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="7" x="-5.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="8" x="-4.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="9" x="-3.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="10" x="-2.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="11" x="-2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="12" x="-1.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="13" x="-0.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="14" x="0.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="15" x="1.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="16" x="2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="17" x="2.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="18" x="3.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="19" x="4.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="20" x="5.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="21" x="6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="22" x="6.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="23" x="7.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="24" x="8.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="25" x="9.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="26" x="11.2" y="-6.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="27" x="11.2" y="-6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="28" x="11.2" y="-5.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="29" x="11.2" y="-4.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="30" x="11.2" y="-3.6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="31" x="11.2" y="-2.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="32" x="11.2" y="-2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="33" x="11.2" y="-1.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="34" x="11.2" y="-0.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="35" x="11.2" y="0.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="36" x="11.2" y="1.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="37" x="11.2" y="2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="38" x="11.2" y="2.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="39" x="11.2" y="3.6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="40" x="11.2" y="4.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="41" x="11.2" y="5.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="42" x="11.2" y="6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="43" x="11.2" y="6.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="44" x="9.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="45" x="8.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="46" x="7.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="47" x="6.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="48" x="6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="49" x="5.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="50" x="4.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="51" x="3.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="52" x="2.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="53" x="2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="54" x="1.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="55" x="0.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="56" x="-0.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="57" x="-1.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="58" x="-2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="59" x="-2.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="60" x="-3.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="61" x="-4.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="62" x="-5.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="63" x="-6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="64" x="-6.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="65" x="-7.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="66" x="-8.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="67" x="-9.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
-<smd name="68" x="-11.2" y="6.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="69" x="-11.2" y="6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="70" x="-11.2" y="5.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="71" x="-11.2" y="4.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="72" x="-11.2" y="3.6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="73" x="-11.2" y="2.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="74" x="-11.2" y="2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="75" x="-11.2" y="1.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="76" x="-11.2" y="0.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="77" x="-11.2" y="-0.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="78" x="-11.2" y="-1.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="79" x="-11.2" y="-2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="80" x="-11.2" y="-2.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="81" x="-11.2" y="-3.6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="82" x="-11.2" y="-4.4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="83" x="-11.2" y="-5.2" dx="1.5" dy="0.5" layer="1"/>
-<smd name="84" x="-11.2" y="-6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="1" x="-9.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="2" x="-8.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="3" x="-7.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="4" x="-6.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="5" x="-6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="6" x="-5.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="7" x="-4.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="8" x="-3.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="9" x="-2.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="10" x="-2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="11" x="-1.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="12" x="-0.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="13" x="0.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="14" x="1.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="15" x="2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="16" x="2.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="17" x="3.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="18" x="4.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="19" x="5.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="20" x="6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="21" x="6.8" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="22" x="7.6" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="23" x="8.4" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="24" x="9.2" y="-8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="25" x="11.2" y="-6.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="26" x="11.2" y="-6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="27" x="11.2" y="-5.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="28" x="11.2" y="-4.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="29" x="11.2" y="-3.6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="30" x="11.2" y="-2.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="31" x="11.2" y="-2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="32" x="11.2" y="-1.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="33" x="11.2" y="-0.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="34" x="11.2" y="0.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="35" x="11.2" y="1.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="36" x="11.2" y="2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="37" x="11.2" y="2.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="38" x="11.2" y="3.6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="39" x="11.2" y="4.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="40" x="11.2" y="5.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="41" x="11.2" y="6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="42" x="11.2" y="6.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="43" x="9.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="44" x="8.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="45" x="7.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="46" x="6.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="47" x="6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="48" x="5.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="49" x="4.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="50" x="3.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="51" x="2.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="52" x="2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="53" x="1.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="54" x="0.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="55" x="-0.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="56" x="-1.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="57" x="-2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="58" x="-2.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="59" x="-3.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="60" x="-4.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="61" x="-5.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="62" x="-6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="63" x="-6.8" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="64" x="-7.6" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="65" x="-8.4" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="66" x="-9.2" y="8.2" dx="0.5" dy="1.5" layer="1"/>
+<smd name="67" x="-11.2" y="6.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="68" x="-11.2" y="6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="69" x="-11.2" y="5.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="70" x="-11.2" y="4.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="71" x="-11.2" y="3.6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="72" x="-11.2" y="2.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="73" x="-11.2" y="2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="74" x="-11.2" y="1.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="75" x="-11.2" y="0.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="76" x="-11.2" y="-0.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="77" x="-11.2" y="-1.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="78" x="-11.2" y="-2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="79" x="-11.2" y="-2.8" dx="1.5" dy="0.5" layer="1"/>
+<smd name="80" x="-11.2" y="-3.6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="81" x="-11.2" y="-4.4" dx="1.5" dy="0.5" layer="1"/>
+<smd name="82" x="-11.2" y="-5.2" dx="1.5" dy="0.5" layer="1"/>
+<smd name="83" x="-11.2" y="-6" dx="1.5" dy="0.5" layer="1"/>
+<smd name="84" x="-11.2" y="-6.8" dx="1.5" dy="0.5" layer="1"/>
 <text x="-9.5" y="-10.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-9.5" y="9.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-9.9" y1="-6.5" x2="-9.5" y2="-6.9" width="0.2032" layer="21"/>
@@ -18292,10 +18292,10 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 14mm widt
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-80-80P-1400W-2000L-340H-195F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 20mm length, 14mm width, 3.40mm max height, 80 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation CB-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation CB-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.95" y1="-7" x2="-10" y2="-6.6" layer="51"/>
 <rectangle x1="-11.95" y1="-6.2" x2="-10" y2="-5.8" layer="51"/>
@@ -18381,90 +18381,90 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 20mm length, 14mm wi
 <rectangle x1="10" y1="5" x2="11.95" y2="5.4" layer="51"/>
 <rectangle x1="10" y1="5.8" x2="11.95" y2="6.2" layer="51"/>
 <rectangle x1="10" y1="6.6" x2="11.95" y2="7" layer="51"/>
-<smd name="1" x="-11.55" y="-6.8" dx="2.2" dy="0.5" layer="1"/>
-<smd name="2" x="-9.2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="3" x="-8.4" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="4" x="-7.6" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="5" x="-6.8" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="6" x="-6" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="7" x="-5.2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="8" x="-4.4" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="9" x="-3.6" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="10" x="-2.8" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="11" x="-2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="12" x="-1.2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="13" x="-0.4" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="14" x="0.4" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="15" x="1.2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="16" x="2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="17" x="2.8" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="18" x="3.6" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="19" x="4.4" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="20" x="5.2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="21" x="6" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="22" x="6.8" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="23" x="7.6" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="24" x="8.4" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="25" x="9.2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="26" x="11.55" y="-6.8" dx="2.2" dy="0.5" layer="1"/>
-<smd name="27" x="11.55" y="-6" dx="2.2" dy="0.5" layer="1"/>
-<smd name="28" x="11.55" y="-5.2" dx="2.2" dy="0.5" layer="1"/>
-<smd name="29" x="11.55" y="-4.4" dx="2.2" dy="0.5" layer="1"/>
-<smd name="30" x="11.55" y="-3.6" dx="2.2" dy="0.5" layer="1"/>
-<smd name="31" x="11.55" y="-2.8" dx="2.2" dy="0.5" layer="1"/>
-<smd name="32" x="11.55" y="-2" dx="2.2" dy="0.5" layer="1"/>
-<smd name="33" x="11.55" y="-1.2" dx="2.2" dy="0.5" layer="1"/>
-<smd name="34" x="11.55" y="-0.4" dx="2.2" dy="0.5" layer="1"/>
-<smd name="35" x="11.55" y="0.4" dx="2.2" dy="0.5" layer="1"/>
-<smd name="36" x="11.55" y="1.2" dx="2.2" dy="0.5" layer="1"/>
-<smd name="37" x="11.55" y="2" dx="2.2" dy="0.5" layer="1"/>
-<smd name="38" x="11.55" y="2.8" dx="2.2" dy="0.5" layer="1"/>
-<smd name="39" x="11.55" y="3.6" dx="2.2" dy="0.5" layer="1"/>
-<smd name="40" x="11.55" y="4.4" dx="2.2" dy="0.5" layer="1"/>
-<smd name="41" x="11.55" y="5.2" dx="2.2" dy="0.5" layer="1"/>
-<smd name="42" x="11.55" y="6" dx="2.2" dy="0.5" layer="1"/>
-<smd name="43" x="11.55" y="6.8" dx="2.2" dy="0.5" layer="1"/>
-<smd name="44" x="9.2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="45" x="8.4" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="46" x="7.6" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="47" x="6.8" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="48" x="6" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="49" x="5.2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="50" x="4.4" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="51" x="3.6" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="52" x="2.8" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="53" x="2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="54" x="1.2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="55" x="0.4" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="56" x="-0.4" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="57" x="-1.2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="58" x="-2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="59" x="-2.8" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="60" x="-3.6" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="61" x="-4.4" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="62" x="-5.2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="63" x="-6" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="64" x="-6.8" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="65" x="-7.6" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="66" x="-8.4" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="67" x="-9.2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
-<smd name="68" x="-11.55" y="6.8" dx="2.2" dy="0.5" layer="1"/>
-<smd name="69" x="-11.55" y="6" dx="2.2" dy="0.5" layer="1"/>
-<smd name="70" x="-11.55" y="5.2" dx="2.2" dy="0.5" layer="1"/>
-<smd name="71" x="-11.55" y="4.4" dx="2.2" dy="0.5" layer="1"/>
-<smd name="72" x="-11.55" y="3.6" dx="2.2" dy="0.5" layer="1"/>
-<smd name="73" x="-11.55" y="2.8" dx="2.2" dy="0.5" layer="1"/>
-<smd name="74" x="-11.55" y="2" dx="2.2" dy="0.5" layer="1"/>
-<smd name="75" x="-11.55" y="1.2" dx="2.2" dy="0.5" layer="1"/>
-<smd name="76" x="-11.55" y="0.4" dx="2.2" dy="0.5" layer="1"/>
-<smd name="77" x="-11.55" y="-0.4" dx="2.2" dy="0.5" layer="1"/>
-<smd name="78" x="-11.55" y="-1.2" dx="2.2" dy="0.5" layer="1"/>
-<smd name="79" x="-11.55" y="-2" dx="2.2" dy="0.5" layer="1"/>
-<smd name="80" x="-11.55" y="-2.8" dx="2.2" dy="0.5" layer="1"/>
-<smd name="81" x="-11.55" y="-3.6" dx="2.2" dy="0.5" layer="1"/>
-<smd name="82" x="-11.55" y="-4.4" dx="2.2" dy="0.5" layer="1"/>
-<smd name="83" x="-11.55" y="-5.2" dx="2.2" dy="0.5" layer="1"/>
-<smd name="84" x="-11.55" y="-6" dx="2.2" dy="0.5" layer="1"/>
+<smd name="1" x="-9.2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="2" x="-8.4" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="3" x="-7.6" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="4" x="-6.8" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="5" x="-6" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="6" x="-5.2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="7" x="-4.4" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="8" x="-3.6" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="9" x="-2.8" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="10" x="-2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="11" x="-1.2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="12" x="-0.4" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="13" x="0.4" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="14" x="1.2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="15" x="2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="16" x="2.8" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="17" x="3.6" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="18" x="4.4" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="19" x="5.2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="20" x="6" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="21" x="6.8" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="22" x="7.6" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="23" x="8.4" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="24" x="9.2" y="-8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="25" x="11.55" y="-6.8" dx="2.2" dy="0.5" layer="1"/>
+<smd name="26" x="11.55" y="-6" dx="2.2" dy="0.5" layer="1"/>
+<smd name="27" x="11.55" y="-5.2" dx="2.2" dy="0.5" layer="1"/>
+<smd name="28" x="11.55" y="-4.4" dx="2.2" dy="0.5" layer="1"/>
+<smd name="29" x="11.55" y="-3.6" dx="2.2" dy="0.5" layer="1"/>
+<smd name="30" x="11.55" y="-2.8" dx="2.2" dy="0.5" layer="1"/>
+<smd name="31" x="11.55" y="-2" dx="2.2" dy="0.5" layer="1"/>
+<smd name="32" x="11.55" y="-1.2" dx="2.2" dy="0.5" layer="1"/>
+<smd name="33" x="11.55" y="-0.4" dx="2.2" dy="0.5" layer="1"/>
+<smd name="34" x="11.55" y="0.4" dx="2.2" dy="0.5" layer="1"/>
+<smd name="35" x="11.55" y="1.2" dx="2.2" dy="0.5" layer="1"/>
+<smd name="36" x="11.55" y="2" dx="2.2" dy="0.5" layer="1"/>
+<smd name="37" x="11.55" y="2.8" dx="2.2" dy="0.5" layer="1"/>
+<smd name="38" x="11.55" y="3.6" dx="2.2" dy="0.5" layer="1"/>
+<smd name="39" x="11.55" y="4.4" dx="2.2" dy="0.5" layer="1"/>
+<smd name="40" x="11.55" y="5.2" dx="2.2" dy="0.5" layer="1"/>
+<smd name="41" x="11.55" y="6" dx="2.2" dy="0.5" layer="1"/>
+<smd name="42" x="11.55" y="6.8" dx="2.2" dy="0.5" layer="1"/>
+<smd name="43" x="9.2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="44" x="8.4" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="45" x="7.6" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="46" x="6.8" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="47" x="6" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="48" x="5.2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="49" x="4.4" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="50" x="3.6" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="51" x="2.8" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="52" x="2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="53" x="1.2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="54" x="0.4" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="55" x="-0.4" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="56" x="-1.2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="57" x="-2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="58" x="-2.8" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="59" x="-3.6" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="60" x="-4.4" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="61" x="-5.2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="62" x="-6" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="63" x="-6.8" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="64" x="-7.6" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="65" x="-8.4" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="66" x="-9.2" y="8.55" dx="0.5" dy="2.2" layer="1"/>
+<smd name="67" x="-11.55" y="6.8" dx="2.2" dy="0.5" layer="1"/>
+<smd name="68" x="-11.55" y="6" dx="2.2" dy="0.5" layer="1"/>
+<smd name="69" x="-11.55" y="5.2" dx="2.2" dy="0.5" layer="1"/>
+<smd name="70" x="-11.55" y="4.4" dx="2.2" dy="0.5" layer="1"/>
+<smd name="71" x="-11.55" y="3.6" dx="2.2" dy="0.5" layer="1"/>
+<smd name="72" x="-11.55" y="2.8" dx="2.2" dy="0.5" layer="1"/>
+<smd name="73" x="-11.55" y="2" dx="2.2" dy="0.5" layer="1"/>
+<smd name="74" x="-11.55" y="1.2" dx="2.2" dy="0.5" layer="1"/>
+<smd name="75" x="-11.55" y="0.4" dx="2.2" dy="0.5" layer="1"/>
+<smd name="76" x="-11.55" y="-0.4" dx="2.2" dy="0.5" layer="1"/>
+<smd name="77" x="-11.55" y="-1.2" dx="2.2" dy="0.5" layer="1"/>
+<smd name="78" x="-11.55" y="-2" dx="2.2" dy="0.5" layer="1"/>
+<smd name="79" x="-11.55" y="-2.8" dx="2.2" dy="0.5" layer="1"/>
+<smd name="80" x="-11.55" y="-3.6" dx="2.2" dy="0.5" layer="1"/>
+<smd name="81" x="-11.55" y="-4.4" dx="2.2" dy="0.5" layer="1"/>
+<smd name="82" x="-11.55" y="-5.2" dx="2.2" dy="0.5" layer="1"/>
+<smd name="83" x="-11.55" y="-6" dx="2.2" dy="0.5" layer="1"/>
+<smd name="84" x="-11.55" y="-6.8" dx="2.2" dy="0.5" layer="1"/>
 <text x="-9.5" y="-11" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-9.5" y="10" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-9.9" y1="-6.5" x2="-9.5" y2="-6.9" width="0.2032" layer="21"/>
@@ -18474,10 +18474,10 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 20mm length, 14mm wi
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-88-80P-2000W-2000L-315H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.15mm max height, 88 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.15mm max height, 88 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 20mm width, 3.15mm max height, 88 leads.
-&lt;p/&gt;JEDEC MS-022B, variation CB-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation CB-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-8.6" x2="-10" y2="-8.2" layer="51"/>
 <rectangle x1="-11.6" y1="-7.8" x2="-10" y2="-7.4" layer="51"/>
@@ -18664,10 +18664,10 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 20mm widt
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-88-80P-2000W-2000L-345H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.45mm max height, 88 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 20mm length, 20mm width, 3.45mm max height, 88 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 20mm width, 3.45mm max height, 88 leads.
-&lt;p/&gt;JEDEC MS-022B, variation CB-1, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation CB-1, PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11.6" y1="-8.6" x2="-10" y2="-8.2" layer="51"/>
 <rectangle x1="-11.6" y1="-7.8" x2="-10" y2="-7.4" layer="51"/>
@@ -18854,10 +18854,10 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 20mm length, 20mm widt
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-120-80P-2800W-2800L-385H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 120 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 120 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DA-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DA-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-11.8" x2="-14" y2="-11.4" layer="51"/>
 <rectangle x1="-15.6" y1="-11" x2="-14" y2="-10.6" layer="51"/>
@@ -19108,10 +19108,10 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-128-80P-2800W-2800L-385H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 3.85mm max height, 128 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm width, 3.85mm max height, 128 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DB-2, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DB-2, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-12.6" x2="-14" y2="-12.2" layer="51"/>
 <rectangle x1="-15.6" y1="-11.8" x2="-14" y2="-11.4" layer="51"/>
@@ -19378,10 +19378,10 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-120-80P-2800W-2800L-392H-195F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 120 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 120 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation DA-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation DA-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.95" y1="-11.8" x2="-14" y2="-11.4" layer="51"/>
 <rectangle x1="-15.95" y1="-11" x2="-14" y2="-10.6" layer="51"/>
@@ -19632,10 +19632,10 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 28mm length, 28mm wi
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-128-80P-2800W-2800L-392H-195F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 128 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 28mm length, 28mm width, 3.92mm max height, 128 leads, low standoff.
-&lt;p/&gt;JEDEC MO-112B, variation DB-2, S-R-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MO-112B, variation DB-2, S-R-PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.95" y1="-12.6" x2="-14" y2="-12.2" layer="51"/>
 <rectangle x1="-15.95" y1="-11.8" x2="-14" y2="-11.4" layer="51"/>
@@ -19902,10 +19902,10 @@ Metric quad flat package. 0.80mm pitch, 1.95mm lead length, 28mm length, 28mm wi
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-120-80P-2800W-2800L-410H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 120 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm width, 4.10mm max height, 120 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DA-1, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DA-1, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-11.8" x2="-14" y2="-11.4" layer="51"/>
 <rectangle x1="-15.6" y1="-11" x2="-14" y2="-10.6" layer="51"/>
@@ -20156,10 +20156,10 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm widt
 <wire x1="13.9" y1="13.9" x2="-13.9" y2="13.9" width="0.2032" layer="21"/>
 </package>
 <package name="QFP-128-80P-2800W-2800L-410H-160F">
-<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.80mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 128 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.80mm pitch, 1.6mm lead length 28mm length, 28mm width, 4.10mm max height, 128 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DB-1, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DB-1, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-12.6" x2="-14" y2="-12.2" layer="51"/>
 <rectangle x1="-15.6" y1="-11.8" x2="-14" y2="-11.4" layer="51"/>

--- a/ref-packages-tqfp.lbr
+++ b/ref-packages-tqfp.lbr
@@ -66,10 +66,10 @@
 NOTE: This library is used to globally update common IC packages in all other libraries.&lt;p&gt;</description>
 <packages>
 <package name="TQFP-36-100P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 36 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.225" x2="-5" y2="-3.775" layer="51"/>
 <rectangle x1="-6" y1="-3.225" x2="-5" y2="-2.775" layer="51"/>
@@ -152,10 +152,10 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-36-100P-1000W-1000L-120H-EP">
-<description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 36 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACA-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACA-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.225" x2="-5" y2="-3.775" layer="51"/>
 <rectangle x1="-6" y1="-3.225" x2="-5" y2="-2.775" layer="51"/>
@@ -170,14 +170,24 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10m
 <rectangle x1="-4.225" y1="5" x2="-3.775" y2="6" layer="51"/>
 <rectangle x1="-3.225" y1="-6" x2="-2.775" y2="-5" layer="51"/>
 <rectangle x1="-3.225" y1="5" x2="-2.775" y2="6" layer="51"/>
+<rectangle x1="-2.5" y1="-2.5" x2="2.5" y2="2.5" layer="29"/>
+<rectangle x1="-2.3639" y1="-2.3639" x2="-0.9694" y2="-0.9694" layer="31"/>
+<rectangle x1="-2.3639" y1="-0.6972" x2="-0.9694" y2="0.6972" layer="31"/>
+<rectangle x1="-2.3639" y1="0.9694" x2="-0.9694" y2="2.3639" layer="31"/>
 <rectangle x1="-2.225" y1="-6" x2="-1.775" y2="-5" layer="51"/>
 <rectangle x1="-2.225" y1="5" x2="-1.775" y2="6" layer="51"/>
 <rectangle x1="-1.225" y1="-6" x2="-0.775" y2="-5" layer="51"/>
 <rectangle x1="-1.225" y1="5" x2="-0.775" y2="6" layer="51"/>
+<rectangle x1="-0.6972" y1="-2.3639" x2="0.6972" y2="-0.9694" layer="31"/>
+<rectangle x1="-0.6972" y1="-0.6972" x2="0.6972" y2="0.6972" layer="31"/>
+<rectangle x1="-0.6972" y1="0.9694" x2="0.6972" y2="2.3639" layer="31"/>
 <rectangle x1="-0.225" y1="-6" x2="0.225" y2="-5" layer="51"/>
 <rectangle x1="-0.225" y1="5" x2="0.225" y2="6" layer="51"/>
 <rectangle x1="0.775" y1="-6" x2="1.225" y2="-5" layer="51"/>
 <rectangle x1="0.775" y1="5" x2="1.225" y2="6" layer="51"/>
+<rectangle x1="0.9694" y1="-2.3639" x2="2.3639" y2="-0.9694" layer="31"/>
+<rectangle x1="0.9694" y1="-0.6972" x2="2.3639" y2="0.6972" layer="31"/>
+<rectangle x1="0.9694" y1="0.9694" x2="2.3639" y2="2.3639" layer="31"/>
 <rectangle x1="1.775" y1="-6" x2="2.225" y2="-5" layer="51"/>
 <rectangle x1="1.775" y1="5" x2="2.225" y2="6" layer="51"/>
 <rectangle x1="2.775" y1="-6" x2="3.225" y2="-5" layer="51"/>
@@ -229,7 +239,8 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10m
 <smd name="34" x="-5.9" y="-2" dx="1.5" dy="0.55" layer="1"/>
 <smd name="35" x="-5.9" y="-3" dx="1.5" dy="0.55" layer="1"/>
 <smd name="36" x="-5.9" y="-4" dx="1.5" dy="0.55" layer="1"/>
-<smd name="EP" x="0" y="0" dx="5" dy="5" layer="1"/><text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="5.2" dy="5.2" layer="1" stop="no" cream="no"/>
+<text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-4.5" y="7" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-4.9" y1="-4.5" x2="-4.5" y2="-4.9" width="0.2032" layer="21"/>
 <wire x1="-4.9" y1="4.9" x2="-4.9" y2="-4.5" width="0.2032" layer="21"/>
@@ -238,10 +249,10 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-44-100P-1200W-1200L-120H">
-<description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ADA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ADA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-5.225" x2="-6" y2="-4.775" layer="51"/>
 <rectangle x1="-7" y1="-4.225" x2="-6" y2="-3.775" layer="51"/>
@@ -340,10 +351,10 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-44-100P-1200W-1200L-120H-EP">
-<description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ADA-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ADA-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-5.225" x2="-6" y2="-4.775" layer="51"/>
 <rectangle x1="-7" y1="-4.225" x2="-6" y2="-3.775" layer="51"/>
@@ -362,14 +373,24 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12m
 <rectangle x1="-4.225" y1="6" x2="-3.775" y2="7" layer="51"/>
 <rectangle x1="-3.225" y1="-7" x2="-2.775" y2="-6" layer="51"/>
 <rectangle x1="-3.225" y1="6" x2="-2.775" y2="7" layer="51"/>
+<rectangle x1="-3" y1="-3" x2="3" y2="3" layer="29"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
 <rectangle x1="-2.225" y1="-7" x2="-1.775" y2="-6" layer="51"/>
 <rectangle x1="-2.225" y1="6" x2="-1.775" y2="7" layer="51"/>
 <rectangle x1="-1.225" y1="-7" x2="-0.775" y2="-6" layer="51"/>
 <rectangle x1="-1.225" y1="6" x2="-0.775" y2="7" layer="51"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
 <rectangle x1="-0.225" y1="-7" x2="0.225" y2="-6" layer="51"/>
 <rectangle x1="-0.225" y1="6" x2="0.225" y2="7" layer="51"/>
 <rectangle x1="0.775" y1="-7" x2="1.225" y2="-6" layer="51"/>
 <rectangle x1="0.775" y1="6" x2="1.225" y2="7" layer="51"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
 <rectangle x1="1.775" y1="-7" x2="2.225" y2="-6" layer="51"/>
 <rectangle x1="1.775" y1="6" x2="2.225" y2="7" layer="51"/>
 <rectangle x1="2.775" y1="-7" x2="3.225" y2="-6" layer="51"/>
@@ -433,7 +454,8 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12m
 <smd name="42" x="-6.9" y="-3" dx="1.5" dy="0.55" layer="1"/>
 <smd name="43" x="-6.9" y="-4" dx="1.5" dy="0.55" layer="1"/>
 <smd name="44" x="-6.9" y="-5" dx="1.5" dy="0.55" layer="1"/>
-<smd name="EP" x="0" y="0" dx="6" dy="6" layer="1"/><text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="6.2" dy="6.2" layer="1" stop="no" cream="no"/>
+<text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-5.5" y="8" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-5.9" y1="-5.5" x2="-5.5" y2="-5.9" width="0.2032" layer="21"/>
 <wire x1="-5.9" y1="5.9" x2="-5.9" y2="-5.5" width="0.2032" layer="21"/>
@@ -442,10 +464,10 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-52-100P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.225" x2="-7" y2="-5.775" layer="51"/>
 <rectangle x1="-8" y1="-5.225" x2="-7" y2="-4.775" layer="51"/>
@@ -560,10 +582,10 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-52-100P-1400W-1400L-120H-EP">
-<description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (1.00mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEA-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEA-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.225" x2="-7" y2="-5.775" layer="51"/>
 <rectangle x1="-8" y1="-5.225" x2="-7" y2="-4.775" layer="51"/>
@@ -584,18 +606,35 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14m
 <rectangle x1="-5.225" y1="7" x2="-4.775" y2="8" layer="51"/>
 <rectangle x1="-4.225" y1="-8" x2="-3.775" y2="-7" layer="51"/>
 <rectangle x1="-4.225" y1="7" x2="-3.775" y2="8" layer="51"/>
+<rectangle x1="-3.5" y1="-3.5" x2="3.5" y2="3.5" layer="29"/>
+<rectangle x1="-3.3571" y1="-3.3571" x2="-1.8929" y2="-1.8929" layer="31"/>
+<rectangle x1="-3.3571" y1="-1.6071" x2="-1.8929" y2="-0.1429" layer="31"/>
+<rectangle x1="-3.3571" y1="0.1429" x2="-1.8929" y2="1.6071" layer="31"/>
+<rectangle x1="-3.3571" y1="1.8929" x2="-1.8929" y2="3.3571" layer="31"/>
 <rectangle x1="-3.225" y1="-8" x2="-2.775" y2="-7" layer="51"/>
 <rectangle x1="-3.225" y1="7" x2="-2.775" y2="8" layer="51"/>
 <rectangle x1="-2.225" y1="-8" x2="-1.775" y2="-7" layer="51"/>
 <rectangle x1="-2.225" y1="7" x2="-1.775" y2="8" layer="51"/>
+<rectangle x1="-1.6071" y1="-3.3571" x2="-0.1429" y2="-1.8929" layer="31"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
+<rectangle x1="-1.6071" y1="1.8929" x2="-0.1429" y2="3.3571" layer="31"/>
 <rectangle x1="-1.225" y1="-8" x2="-0.775" y2="-7" layer="51"/>
 <rectangle x1="-1.225" y1="7" x2="-0.775" y2="8" layer="51"/>
 <rectangle x1="-0.225" y1="-8" x2="0.225" y2="-7" layer="51"/>
 <rectangle x1="-0.225" y1="7" x2="0.225" y2="8" layer="51"/>
+<rectangle x1="0.1429" y1="-3.3571" x2="1.6071" y2="-1.8929" layer="31"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
+<rectangle x1="0.1429" y1="1.8929" x2="1.6071" y2="3.3571" layer="31"/>
 <rectangle x1="0.775" y1="-8" x2="1.225" y2="-7" layer="51"/>
 <rectangle x1="0.775" y1="7" x2="1.225" y2="8" layer="51"/>
 <rectangle x1="1.775" y1="-8" x2="2.225" y2="-7" layer="51"/>
 <rectangle x1="1.775" y1="7" x2="2.225" y2="8" layer="51"/>
+<rectangle x1="1.8929" y1="-3.3571" x2="3.3571" y2="-1.8929" layer="31"/>
+<rectangle x1="1.8929" y1="-1.6071" x2="3.3571" y2="-0.1429" layer="31"/>
+<rectangle x1="1.8929" y1="0.1429" x2="3.3571" y2="1.6071" layer="31"/>
+<rectangle x1="1.8929" y1="1.8929" x2="3.3571" y2="3.3571" layer="31"/>
 <rectangle x1="2.775" y1="-8" x2="3.225" y2="-7" layer="51"/>
 <rectangle x1="2.775" y1="7" x2="3.225" y2="8" layer="51"/>
 <rectangle x1="3.775" y1="-8" x2="4.225" y2="-7" layer="51"/>
@@ -669,7 +708,8 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14m
 <smd name="50" x="-7.9" y="-4" dx="1.5" dy="0.55" layer="1"/>
 <smd name="51" x="-7.9" y="-5" dx="1.5" dy="0.55" layer="1"/>
 <smd name="52" x="-7.9" y="-6" dx="1.5" dy="0.55" layer="1"/>
-<smd name="EP" x="0" y="0" dx="7" dy="7" layer="1"/><text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="7.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-6.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-6.9" y1="-6.5" x2="-6.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-6.9" y1="6.9" x2="-6.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -678,10 +718,10 @@ Thin profile Quad Flat Package. 1.00mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-80-40P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACE, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACE, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.9" x2="-5" y2="-3.7" layer="51"/>
 <rectangle x1="-6" y1="-3.5" x2="-5" y2="-3.3" layer="51"/>
@@ -852,10 +892,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-80-40P-1000W-1000L-120H-EP">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACE-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACE-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.9" x2="-5" y2="-3.7" layer="51"/>
 <rectangle x1="-6" y1="-3.5" x2="-5" y2="-3.3" layer="51"/>
@@ -885,6 +925,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10m
 <rectangle x1="-3.1" y1="5" x2="-2.9" y2="6" layer="51"/>
 <rectangle x1="-2.7" y1="-6" x2="-2.5" y2="-5" layer="51"/>
 <rectangle x1="-2.7" y1="5" x2="-2.5" y2="6" layer="51"/>
+<rectangle x1="-2.5" y1="-2.5" x2="2.5" y2="2.5" layer="29"/>
+<rectangle x1="-2.3639" y1="-2.3639" x2="-0.9694" y2="-0.9694" layer="31"/>
+<rectangle x1="-2.3639" y1="-0.6972" x2="-0.9694" y2="0.6972" layer="31"/>
+<rectangle x1="-2.3639" y1="0.9694" x2="-0.9694" y2="2.3639" layer="31"/>
 <rectangle x1="-2.3" y1="-6" x2="-2.1" y2="-5" layer="51"/>
 <rectangle x1="-2.3" y1="5" x2="-2.1" y2="6" layer="51"/>
 <rectangle x1="-1.9" y1="-6" x2="-1.7" y2="-5" layer="51"/>
@@ -895,6 +939,9 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10m
 <rectangle x1="-1.1" y1="5" x2="-0.9" y2="6" layer="51"/>
 <rectangle x1="-0.7" y1="-6" x2="-0.5" y2="-5" layer="51"/>
 <rectangle x1="-0.7" y1="5" x2="-0.5" y2="6" layer="51"/>
+<rectangle x1="-0.6972" y1="-2.3639" x2="0.6972" y2="-0.9694" layer="31"/>
+<rectangle x1="-0.6972" y1="-0.6972" x2="0.6972" y2="0.6972" layer="31"/>
+<rectangle x1="-0.6972" y1="0.9694" x2="0.6972" y2="2.3639" layer="31"/>
 <rectangle x1="-0.3" y1="-6" x2="-0.1" y2="-5" layer="51"/>
 <rectangle x1="-0.3" y1="5" x2="-0.1" y2="6" layer="51"/>
 <rectangle x1="0.1" y1="-6" x2="0.3" y2="-5" layer="51"/>
@@ -903,6 +950,9 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10m
 <rectangle x1="0.5" y1="5" x2="0.7" y2="6" layer="51"/>
 <rectangle x1="0.9" y1="-6" x2="1.1" y2="-5" layer="51"/>
 <rectangle x1="0.9" y1="5" x2="1.1" y2="6" layer="51"/>
+<rectangle x1="0.9694" y1="-2.3639" x2="2.3639" y2="-0.9694" layer="31"/>
+<rectangle x1="0.9694" y1="-0.6972" x2="2.3639" y2="0.6972" layer="31"/>
+<rectangle x1="0.9694" y1="0.9694" x2="2.3639" y2="2.3639" layer="31"/>
 <rectangle x1="1.3" y1="-6" x2="1.5" y2="-5" layer="51"/>
 <rectangle x1="1.3" y1="5" x2="1.5" y2="6" layer="51"/>
 <rectangle x1="1.7" y1="-6" x2="1.9" y2="-5" layer="51"/>
@@ -1017,7 +1067,8 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10m
 <smd name="78" x="-5.8" y="-3" dx="1.2" dy="0.23" layer="1"/>
 <smd name="79" x="-5.8" y="-3.4" dx="1.2" dy="0.23" layer="1"/>
 <smd name="80" x="-5.8" y="-3.8" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="5" dy="5" layer="1"/><text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="5.2" dy="5.2" layer="1" stop="no" cream="no"/>
+<text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-4.5" y="7" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-4.9" y1="-4.5" x2="-4.5" y2="-4.9" width="0.2032" layer="21"/>
 <wire x1="-4.9" y1="4.9" x2="-4.9" y2="-4.5" width="0.2032" layer="21"/>
@@ -1026,10 +1077,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-40P-1200W-1200L-120H">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ADE, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ADE, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-4.9" x2="-6" y2="-4.7" layer="51"/>
 <rectangle x1="-7" y1="-4.5" x2="-6" y2="-4.3" layer="51"/>
@@ -1240,10 +1291,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-40P-1200W-1200L-120H-EP">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ADE-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ADE-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-4.9" x2="-6" y2="-4.7" layer="51"/>
 <rectangle x1="-7" y1="-4.5" x2="-6" y2="-4.3" layer="51"/>
@@ -1280,8 +1331,12 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12m
 <rectangle x1="-3.7" y1="6" x2="-3.5" y2="7" layer="51"/>
 <rectangle x1="-3.3" y1="-7" x2="-3.1" y2="-6" layer="51"/>
 <rectangle x1="-3.3" y1="6" x2="-3.1" y2="7" layer="51"/>
+<rectangle x1="-3" y1="-3" x2="3" y2="3" layer="29"/>
 <rectangle x1="-2.9" y1="-7" x2="-2.7" y2="-6" layer="51"/>
 <rectangle x1="-2.9" y1="6" x2="-2.7" y2="7" layer="51"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
 <rectangle x1="-2.5" y1="-7" x2="-2.3" y2="-6" layer="51"/>
 <rectangle x1="-2.5" y1="6" x2="-2.3" y2="7" layer="51"/>
 <rectangle x1="-2.1" y1="-7" x2="-1.9" y2="-6" layer="51"/>
@@ -1292,6 +1347,9 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12m
 <rectangle x1="-1.3" y1="6" x2="-1.1" y2="7" layer="51"/>
 <rectangle x1="-0.9" y1="-7" x2="-0.7" y2="-6" layer="51"/>
 <rectangle x1="-0.9" y1="6" x2="-0.7" y2="7" layer="51"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
 <rectangle x1="-0.5" y1="-7" x2="-0.3" y2="-6" layer="51"/>
 <rectangle x1="-0.5" y1="6" x2="-0.3" y2="7" layer="51"/>
 <rectangle x1="-0.1" y1="-7" x2="0.1" y2="-6" layer="51"/>
@@ -1302,6 +1360,9 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12m
 <rectangle x1="0.7" y1="6" x2="0.9" y2="7" layer="51"/>
 <rectangle x1="1.1" y1="-7" x2="1.3" y2="-6" layer="51"/>
 <rectangle x1="1.1" y1="6" x2="1.3" y2="7" layer="51"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
 <rectangle x1="1.5" y1="-7" x2="1.7" y2="-6" layer="51"/>
 <rectangle x1="1.5" y1="6" x2="1.7" y2="7" layer="51"/>
 <rectangle x1="1.9" y1="-7" x2="2.1" y2="-6" layer="51"/>
@@ -1445,7 +1506,8 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12m
 <smd name="98" x="-6.8" y="-4" dx="1.2" dy="0.23" layer="1"/>
 <smd name="99" x="-6.8" y="-4.4" dx="1.2" dy="0.23" layer="1"/>
 <smd name="100" x="-6.8" y="-4.8" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="6" dy="6" layer="1"/><text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="6.2" dy="6.2" layer="1" stop="no" cream="no"/>
+<text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-5.5" y="8" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-5.9" y1="-5.5" x2="-5.5" y2="-5.9" width="0.2032" layer="21"/>
 <wire x1="-5.9" y1="5.9" x2="-5.9" y2="-5.5" width="0.2032" layer="21"/>
@@ -1454,10 +1516,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-120-40P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 120 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 120 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEE, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEE, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-5.9" x2="-7" y2="-5.7" layer="51"/>
 <rectangle x1="-8" y1="-5.5" x2="-7" y2="-5.3" layer="51"/>
@@ -1708,10 +1770,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-120-40P-1400W-1400L-120H-EP">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 120 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 120 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 120 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEE-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEE-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-5.9" x2="-7" y2="-5.7" layer="51"/>
 <rectangle x1="-8" y1="-5.5" x2="-7" y2="-5.3" layer="51"/>
@@ -1756,7 +1818,12 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14m
 <rectangle x1="-3.9" y1="-8" x2="-3.7" y2="-7" layer="51"/>
 <rectangle x1="-3.9" y1="7" x2="-3.7" y2="8" layer="51"/>
 <rectangle x1="-3.5" y1="-8" x2="-3.3" y2="-7" layer="51"/>
+<rectangle x1="-3.5" y1="-3.5" x2="3.5" y2="3.5" layer="29"/>
 <rectangle x1="-3.5" y1="7" x2="-3.3" y2="8" layer="51"/>
+<rectangle x1="-3.3571" y1="-3.3571" x2="-1.8929" y2="-1.8929" layer="31"/>
+<rectangle x1="-3.3571" y1="-1.6071" x2="-1.8929" y2="-0.1429" layer="31"/>
+<rectangle x1="-3.3571" y1="0.1429" x2="-1.8929" y2="1.6071" layer="31"/>
+<rectangle x1="-3.3571" y1="1.8929" x2="-1.8929" y2="3.3571" layer="31"/>
 <rectangle x1="-3.1" y1="-8" x2="-2.9" y2="-7" layer="51"/>
 <rectangle x1="-3.1" y1="7" x2="-2.9" y2="8" layer="51"/>
 <rectangle x1="-2.7" y1="-8" x2="-2.5" y2="-7" layer="51"/>
@@ -1765,6 +1832,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14m
 <rectangle x1="-2.3" y1="7" x2="-2.1" y2="8" layer="51"/>
 <rectangle x1="-1.9" y1="-8" x2="-1.7" y2="-7" layer="51"/>
 <rectangle x1="-1.9" y1="7" x2="-1.7" y2="8" layer="51"/>
+<rectangle x1="-1.6071" y1="-3.3571" x2="-0.1429" y2="-1.8929" layer="31"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
+<rectangle x1="-1.6071" y1="1.8929" x2="-0.1429" y2="3.3571" layer="31"/>
 <rectangle x1="-1.5" y1="-8" x2="-1.3" y2="-7" layer="51"/>
 <rectangle x1="-1.5" y1="7" x2="-1.3" y2="8" layer="51"/>
 <rectangle x1="-1.1" y1="-8" x2="-0.9" y2="-7" layer="51"/>
@@ -1775,6 +1846,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14m
 <rectangle x1="-0.3" y1="7" x2="-0.1" y2="8" layer="51"/>
 <rectangle x1="0.1" y1="-8" x2="0.3" y2="-7" layer="51"/>
 <rectangle x1="0.1" y1="7" x2="0.3" y2="8" layer="51"/>
+<rectangle x1="0.1429" y1="-3.3571" x2="1.6071" y2="-1.8929" layer="31"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
+<rectangle x1="0.1429" y1="1.8929" x2="1.6071" y2="3.3571" layer="31"/>
 <rectangle x1="0.5" y1="-8" x2="0.7" y2="-7" layer="51"/>
 <rectangle x1="0.5" y1="7" x2="0.7" y2="8" layer="51"/>
 <rectangle x1="0.9" y1="-8" x2="1.1" y2="-7" layer="51"/>
@@ -1783,6 +1858,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14m
 <rectangle x1="1.3" y1="7" x2="1.5" y2="8" layer="51"/>
 <rectangle x1="1.7" y1="-8" x2="1.9" y2="-7" layer="51"/>
 <rectangle x1="1.7" y1="7" x2="1.9" y2="8" layer="51"/>
+<rectangle x1="1.8929" y1="-3.3571" x2="3.3571" y2="-1.8929" layer="31"/>
+<rectangle x1="1.8929" y1="-1.6071" x2="3.3571" y2="-0.1429" layer="31"/>
+<rectangle x1="1.8929" y1="0.1429" x2="3.3571" y2="1.6071" layer="31"/>
+<rectangle x1="1.8929" y1="1.8929" x2="3.3571" y2="3.3571" layer="31"/>
 <rectangle x1="2.1" y1="-8" x2="2.3" y2="-7" layer="51"/>
 <rectangle x1="2.1" y1="7" x2="2.3" y2="8" layer="51"/>
 <rectangle x1="2.5" y1="-8" x2="2.7" y2="-7" layer="51"/>
@@ -1953,7 +2032,8 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14m
 <smd name="118" x="-7.8" y="-5" dx="1.2" dy="0.23" layer="1"/>
 <smd name="119" x="-7.8" y="-5.4" dx="1.2" dy="0.23" layer="1"/>
 <smd name="120" x="-7.8" y="-5.8" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="7" dy="7" layer="1"/><text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="7.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-6.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-6.9" y1="-6.5" x2="-6.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-6.9" y1="6.9" x2="-6.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -1962,10 +2042,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-176-40P-2000W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 176 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.7" x2="-10" y2="-8.5" layer="51"/>
 <rectangle x1="-11" y1="-8.3" x2="-10" y2="-8.1" layer="51"/>
@@ -2328,10 +2408,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-176-40P-2000W-2000L-120H-EP">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 176 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFC-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFC-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.7" x2="-10" y2="-8.5" layer="51"/>
 <rectangle x1="-11" y1="-8.3" x2="-10" y2="-8.1" layer="51"/>
@@ -2397,6 +2477,12 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20m
 <rectangle x1="-5.5" y1="10" x2="-5.3" y2="11" layer="51"/>
 <rectangle x1="-5.1" y1="-11" x2="-4.9" y2="-10" layer="51"/>
 <rectangle x1="-5.1" y1="10" x2="-4.9" y2="11" layer="51"/>
+<rectangle x1="-5" y1="-5" x2="5" y2="5" layer="29"/>
+<rectangle x1="-4.8367" y1="-4.8367" x2="-3.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-2.8367" x2="-3.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-0.8367" x2="-3.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="1.1633" x2="-3.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="3.1633" x2="-3.1633" y2="4.8367" layer="31"/>
 <rectangle x1="-4.7" y1="-11" x2="-4.5" y2="-10" layer="51"/>
 <rectangle x1="-4.7" y1="10" x2="-4.5" y2="11" layer="51"/>
 <rectangle x1="-4.3" y1="-11" x2="-4.1" y2="-10" layer="51"/>
@@ -2407,6 +2493,11 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20m
 <rectangle x1="-3.5" y1="10" x2="-3.3" y2="11" layer="51"/>
 <rectangle x1="-3.1" y1="-11" x2="-2.9" y2="-10" layer="51"/>
 <rectangle x1="-3.1" y1="10" x2="-2.9" y2="11" layer="51"/>
+<rectangle x1="-2.8367" y1="-4.8367" x2="-1.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="3.1633" x2="-1.1633" y2="4.8367" layer="31"/>
 <rectangle x1="-2.7" y1="-11" x2="-2.5" y2="-10" layer="51"/>
 <rectangle x1="-2.7" y1="10" x2="-2.5" y2="11" layer="51"/>
 <rectangle x1="-2.3" y1="-11" x2="-2.1" y2="-10" layer="51"/>
@@ -2417,6 +2508,11 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20m
 <rectangle x1="-1.5" y1="10" x2="-1.3" y2="11" layer="51"/>
 <rectangle x1="-1.1" y1="-11" x2="-0.9" y2="-10" layer="51"/>
 <rectangle x1="-1.1" y1="10" x2="-0.9" y2="11" layer="51"/>
+<rectangle x1="-0.8367" y1="-4.8367" x2="0.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="3.1633" x2="0.8367" y2="4.8367" layer="31"/>
 <rectangle x1="-0.7" y1="-11" x2="-0.5" y2="-10" layer="51"/>
 <rectangle x1="-0.7" y1="10" x2="-0.5" y2="11" layer="51"/>
 <rectangle x1="-0.3" y1="-11" x2="-0.1" y2="-10" layer="51"/>
@@ -2427,6 +2523,11 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20m
 <rectangle x1="0.5" y1="10" x2="0.7" y2="11" layer="51"/>
 <rectangle x1="0.9" y1="-11" x2="1.1" y2="-10" layer="51"/>
 <rectangle x1="0.9" y1="10" x2="1.1" y2="11" layer="51"/>
+<rectangle x1="1.1633" y1="-4.8367" x2="2.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
+<rectangle x1="1.1633" y1="3.1633" x2="2.8367" y2="4.8367" layer="31"/>
 <rectangle x1="1.3" y1="-11" x2="1.5" y2="-10" layer="51"/>
 <rectangle x1="1.3" y1="10" x2="1.5" y2="11" layer="51"/>
 <rectangle x1="1.7" y1="-11" x2="1.9" y2="-10" layer="51"/>
@@ -2437,6 +2538,11 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20m
 <rectangle x1="2.5" y1="10" x2="2.7" y2="11" layer="51"/>
 <rectangle x1="2.9" y1="-11" x2="3.1" y2="-10" layer="51"/>
 <rectangle x1="2.9" y1="10" x2="3.1" y2="11" layer="51"/>
+<rectangle x1="3.1633" y1="-4.8367" x2="4.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-2.8367" x2="4.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-0.8367" x2="4.8367" y2="0.8367" layer="31"/>
+<rectangle x1="3.1633" y1="1.1633" x2="4.8367" y2="2.8367" layer="31"/>
+<rectangle x1="3.1633" y1="3.1633" x2="4.8367" y2="4.8367" layer="31"/>
 <rectangle x1="3.3" y1="-11" x2="3.5" y2="-10" layer="51"/>
 <rectangle x1="3.3" y1="10" x2="3.5" y2="11" layer="51"/>
 <rectangle x1="3.7" y1="-11" x2="3.9" y2="-10" layer="51"/>
@@ -2685,7 +2791,8 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20m
 <smd name="174" x="-10.8" y="-7.8" dx="1.2" dy="0.23" layer="1"/>
 <smd name="175" x="-10.8" y="-8.2" dx="1.2" dy="0.23" layer="1"/>
 <smd name="176" x="-10.8" y="-8.6" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="10" dy="10" layer="1"/><text x="-9.5" y="-13" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="10.2" dy="10.2" layer="1" stop="no" cream="no"/>
+<text x="-9.5" y="-13" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-9.5" y="12" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-9.9" y1="-9.5" x2="-9.5" y2="-9.9" width="0.2032" layer="21"/>
 <wire x1="-9.9" y1="9.9" x2="-9.9" y2="-9.5" width="0.2032" layer="21"/>
@@ -2694,10 +2801,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-216-40P-2400W-2400L-120H">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.20mm max height, 216 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.20mm max height, 216 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.20mm max height, 216 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AGB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AGB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-11.1" y="-11.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-13" y1="-10.7" x2="-12" y2="-10.5" layer="51"/>
 <rectangle x1="-13" y1="-10.3" x2="-12" y2="-10.1" layer="51"/>
@@ -3140,10 +3247,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24m
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-216-40P-2400W-2400L-120H-EP">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.20mm max height, 216 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.20mm max height, 216 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.20mm max height, 216 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AGB-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AGB-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-11.1" y="-11.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-13" y1="-10.7" x2="-12" y2="-10.5" layer="51"/>
 <rectangle x1="-13" y1="-10.3" x2="-12" y2="-10.1" layer="51"/>
@@ -3223,8 +3330,15 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24m
 <rectangle x1="-6.7" y1="12" x2="-6.5" y2="13" layer="51"/>
 <rectangle x1="-6.3" y1="-13" x2="-6.1" y2="-12" layer="51"/>
 <rectangle x1="-6.3" y1="12" x2="-6.1" y2="13" layer="51"/>
+<rectangle x1="-6" y1="-6" x2="6" y2="6" layer="29"/>
 <rectangle x1="-5.9" y1="-13" x2="-5.7" y2="-12" layer="51"/>
 <rectangle x1="-5.9" y1="12" x2="-5.7" y2="13" layer="51"/>
+<rectangle x1="-5.8367" y1="-5.8367" x2="-4.1633" y2="-4.1633" layer="31"/>
+<rectangle x1="-5.8367" y1="-3.8367" x2="-4.1633" y2="-2.1633" layer="31"/>
+<rectangle x1="-5.8367" y1="-1.8367" x2="-4.1633" y2="-0.1633" layer="31"/>
+<rectangle x1="-5.8367" y1="0.1633" x2="-4.1633" y2="1.8367" layer="31"/>
+<rectangle x1="-5.8367" y1="2.1633" x2="-4.1633" y2="3.8367" layer="31"/>
+<rectangle x1="-5.8367" y1="4.1633" x2="-4.1633" y2="5.8367" layer="31"/>
 <rectangle x1="-5.5" y1="-13" x2="-5.3" y2="-12" layer="51"/>
 <rectangle x1="-5.5" y1="12" x2="-5.3" y2="13" layer="51"/>
 <rectangle x1="-5.1" y1="-13" x2="-4.9" y2="-12" layer="51"/>
@@ -3235,6 +3349,12 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24m
 <rectangle x1="-4.3" y1="12" x2="-4.1" y2="13" layer="51"/>
 <rectangle x1="-3.9" y1="-13" x2="-3.7" y2="-12" layer="51"/>
 <rectangle x1="-3.9" y1="12" x2="-3.7" y2="13" layer="51"/>
+<rectangle x1="-3.8367" y1="-5.8367" x2="-2.1633" y2="-4.1633" layer="31"/>
+<rectangle x1="-3.8367" y1="-3.8367" x2="-2.1633" y2="-2.1633" layer="31"/>
+<rectangle x1="-3.8367" y1="-1.8367" x2="-2.1633" y2="-0.1633" layer="31"/>
+<rectangle x1="-3.8367" y1="0.1633" x2="-2.1633" y2="1.8367" layer="31"/>
+<rectangle x1="-3.8367" y1="2.1633" x2="-2.1633" y2="3.8367" layer="31"/>
+<rectangle x1="-3.8367" y1="4.1633" x2="-2.1633" y2="5.8367" layer="31"/>
 <rectangle x1="-3.5" y1="-13" x2="-3.3" y2="-12" layer="51"/>
 <rectangle x1="-3.5" y1="12" x2="-3.3" y2="13" layer="51"/>
 <rectangle x1="-3.1" y1="-13" x2="-2.9" y2="-12" layer="51"/>
@@ -3245,6 +3365,12 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24m
 <rectangle x1="-2.3" y1="12" x2="-2.1" y2="13" layer="51"/>
 <rectangle x1="-1.9" y1="-13" x2="-1.7" y2="-12" layer="51"/>
 <rectangle x1="-1.9" y1="12" x2="-1.7" y2="13" layer="51"/>
+<rectangle x1="-1.8367" y1="-5.8367" x2="-0.1633" y2="-4.1633" layer="31"/>
+<rectangle x1="-1.8367" y1="-3.8367" x2="-0.1633" y2="-2.1633" layer="31"/>
+<rectangle x1="-1.8367" y1="-1.8367" x2="-0.1633" y2="-0.1633" layer="31"/>
+<rectangle x1="-1.8367" y1="0.1633" x2="-0.1633" y2="1.8367" layer="31"/>
+<rectangle x1="-1.8367" y1="2.1633" x2="-0.1633" y2="3.8367" layer="31"/>
+<rectangle x1="-1.8367" y1="4.1633" x2="-0.1633" y2="5.8367" layer="31"/>
 <rectangle x1="-1.5" y1="-13" x2="-1.3" y2="-12" layer="51"/>
 <rectangle x1="-1.5" y1="12" x2="-1.3" y2="13" layer="51"/>
 <rectangle x1="-1.1" y1="-13" x2="-0.9" y2="-12" layer="51"/>
@@ -3255,6 +3381,12 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24m
 <rectangle x1="-0.3" y1="12" x2="-0.1" y2="13" layer="51"/>
 <rectangle x1="0.1" y1="-13" x2="0.3" y2="-12" layer="51"/>
 <rectangle x1="0.1" y1="12" x2="0.3" y2="13" layer="51"/>
+<rectangle x1="0.1633" y1="-5.8367" x2="1.8367" y2="-4.1633" layer="31"/>
+<rectangle x1="0.1633" y1="-3.8367" x2="1.8367" y2="-2.1633" layer="31"/>
+<rectangle x1="0.1633" y1="-1.8367" x2="1.8367" y2="-0.1633" layer="31"/>
+<rectangle x1="0.1633" y1="0.1633" x2="1.8367" y2="1.8367" layer="31"/>
+<rectangle x1="0.1633" y1="2.1633" x2="1.8367" y2="3.8367" layer="31"/>
+<rectangle x1="0.1633" y1="4.1633" x2="1.8367" y2="5.8367" layer="31"/>
 <rectangle x1="0.5" y1="-13" x2="0.7" y2="-12" layer="51"/>
 <rectangle x1="0.5" y1="12" x2="0.7" y2="13" layer="51"/>
 <rectangle x1="0.9" y1="-13" x2="1.1" y2="-12" layer="51"/>
@@ -3265,6 +3397,12 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24m
 <rectangle x1="1.7" y1="12" x2="1.9" y2="13" layer="51"/>
 <rectangle x1="2.1" y1="-13" x2="2.3" y2="-12" layer="51"/>
 <rectangle x1="2.1" y1="12" x2="2.3" y2="13" layer="51"/>
+<rectangle x1="2.1633" y1="-5.8367" x2="3.8367" y2="-4.1633" layer="31"/>
+<rectangle x1="2.1633" y1="-3.8367" x2="3.8367" y2="-2.1633" layer="31"/>
+<rectangle x1="2.1633" y1="-1.8367" x2="3.8367" y2="-0.1633" layer="31"/>
+<rectangle x1="2.1633" y1="0.1633" x2="3.8367" y2="1.8367" layer="31"/>
+<rectangle x1="2.1633" y1="2.1633" x2="3.8367" y2="3.8367" layer="31"/>
+<rectangle x1="2.1633" y1="4.1633" x2="3.8367" y2="5.8367" layer="31"/>
 <rectangle x1="2.5" y1="-13" x2="2.7" y2="-12" layer="51"/>
 <rectangle x1="2.5" y1="12" x2="2.7" y2="13" layer="51"/>
 <rectangle x1="2.9" y1="-13" x2="3.1" y2="-12" layer="51"/>
@@ -3275,6 +3413,12 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24m
 <rectangle x1="3.7" y1="12" x2="3.9" y2="13" layer="51"/>
 <rectangle x1="4.1" y1="-13" x2="4.3" y2="-12" layer="51"/>
 <rectangle x1="4.1" y1="12" x2="4.3" y2="13" layer="51"/>
+<rectangle x1="4.1633" y1="-5.8367" x2="5.8367" y2="-4.1633" layer="31"/>
+<rectangle x1="4.1633" y1="-3.8367" x2="5.8367" y2="-2.1633" layer="31"/>
+<rectangle x1="4.1633" y1="-1.8367" x2="5.8367" y2="-0.1633" layer="31"/>
+<rectangle x1="4.1633" y1="0.1633" x2="5.8367" y2="1.8367" layer="31"/>
+<rectangle x1="4.1633" y1="2.1633" x2="5.8367" y2="3.8367" layer="31"/>
+<rectangle x1="4.1633" y1="4.1633" x2="5.8367" y2="5.8367" layer="31"/>
 <rectangle x1="4.5" y1="-13" x2="4.7" y2="-12" layer="51"/>
 <rectangle x1="4.5" y1="12" x2="4.7" y2="13" layer="51"/>
 <rectangle x1="4.9" y1="-13" x2="5.1" y2="-12" layer="51"/>
@@ -3577,7 +3721,8 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24m
 <smd name="214" x="-12.8" y="-9.8" dx="1.2" dy="0.23" layer="1"/>
 <smd name="215" x="-12.8" y="-10.2" dx="1.2" dy="0.23" layer="1"/>
 <smd name="216" x="-12.8" y="-10.6" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="12" dy="12" layer="1"/><text x="-11.5" y="-15" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="12.2" dy="12.2" layer="1" stop="no" cream="no"/>
+<text x="-11.5" y="-15" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-11.5" y="14" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-11.9" y1="-11.5" x2="-11.5" y2="-11.9" width="0.2032" layer="21"/>
 <wire x1="-11.9" y1="11.9" x2="-11.9" y2="-11.5" width="0.2032" layer="21"/>
@@ -3586,10 +3731,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 24mm length, 24m
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-32-40P-400W-400L-120H">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.20mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AKC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AKC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.1" y="-1.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3" y1="-1.5" x2="-2" y2="-1.3" layer="51"/>
 <rectangle x1="-3" y1="-1.1" x2="-2" y2="-0.9" layer="51"/>
@@ -3664,10 +3809,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm 
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-32-40P-400W-400L-120H-EP">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.20mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AKC-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AKC-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.1" y="-1.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3" y1="-1.5" x2="-2" y2="-1.3" layer="51"/>
 <rectangle x1="-3" y1="-1.1" x2="-2" y2="-0.9" layer="51"/>
@@ -3681,6 +3826,8 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm 
 <rectangle x1="-1.5" y1="2" x2="-1.3" y2="3" layer="51"/>
 <rectangle x1="-1.1" y1="-3" x2="-0.9" y2="-2" layer="51"/>
 <rectangle x1="-1.1" y1="2" x2="-0.9" y2="3" layer="51"/>
+<rectangle x1="-1" y1="-1" x2="1" y2="1" layer="29"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
 <rectangle x1="-0.7" y1="-3" x2="-0.5" y2="-2" layer="51"/>
 <rectangle x1="-0.7" y1="2" x2="-0.5" y2="3" layer="51"/>
 <rectangle x1="-0.3" y1="-3" x2="-0.1" y2="-2" layer="51"/>
@@ -3733,7 +3880,8 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm 
 <smd name="30" x="-2.8" y="-0.6" dx="1.2" dy="0.23" layer="1"/>
 <smd name="31" x="-2.8" y="-1" dx="1.2" dy="0.23" layer="1"/>
 <smd name="32" x="-2.8" y="-1.4" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="2" dy="2" layer="1"/><text x="-1.5" y="-5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="2.2" dy="2.2" layer="1" stop="no" cream="no"/>
+<text x="-1.5" y="-5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-1.5" y="4" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-1.9" y1="-1.5" x2="-1.5" y2="-1.9" width="0.2032" layer="21"/>
 <wire x1="-1.9" y1="1.9" x2="-1.9" y2="-1.5" width="0.2032" layer="21"/>
@@ -3742,10 +3890,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 4mm length, 4mm 
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-40-40P-500W-500L-120H">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.20mm max height, 40 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AAB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AAB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.6" y="-1.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3.5" y1="-1.9" x2="-2.5" y2="-1.7" layer="51"/>
 <rectangle x1="-3.5" y1="-1.5" x2="-2.5" y2="-1.3" layer="51"/>
@@ -3836,10 +3984,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm 
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-40-40P-500W-500L-120H-EP">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.20mm max height, 40 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AAB-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AAB-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.6" y="-1.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3.5" y1="-1.9" x2="-2.5" y2="-1.7" layer="51"/>
 <rectangle x1="-3.5" y1="-1.5" x2="-2.5" y2="-1.3" layer="51"/>
@@ -3855,6 +4003,9 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm 
 <rectangle x1="-1.9" y1="2.5" x2="-1.7" y2="3.5" layer="51"/>
 <rectangle x1="-1.5" y1="-3.5" x2="-1.3" y2="-2.5" layer="51"/>
 <rectangle x1="-1.5" y1="2.5" x2="-1.3" y2="3.5" layer="51"/>
+<rectangle x1="-1.25" y1="-1.25" x2="1.25" y2="1.25" layer="29"/>
+<rectangle x1="-1.1479" y1="-1.1479" x2="-0.1021" y2="-0.1021" layer="31"/>
+<rectangle x1="-1.1479" y1="0.1021" x2="-0.1021" y2="1.1479" layer="31"/>
 <rectangle x1="-1.1" y1="-3.5" x2="-0.9" y2="-2.5" layer="51"/>
 <rectangle x1="-1.1" y1="2.5" x2="-0.9" y2="3.5" layer="51"/>
 <rectangle x1="-0.7" y1="-3.5" x2="-0.5" y2="-2.5" layer="51"/>
@@ -3863,6 +4014,8 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm 
 <rectangle x1="-0.3" y1="2.5" x2="-0.1" y2="3.5" layer="51"/>
 <rectangle x1="0.1" y1="-3.5" x2="0.3" y2="-2.5" layer="51"/>
 <rectangle x1="0.1" y1="2.5" x2="0.3" y2="3.5" layer="51"/>
+<rectangle x1="0.1021" y1="-1.1479" x2="1.1479" y2="-0.1021" layer="31"/>
+<rectangle x1="0.1021" y1="0.1021" x2="1.1479" y2="1.1479" layer="31"/>
 <rectangle x1="0.5" y1="-3.5" x2="0.7" y2="-2.5" layer="51"/>
 <rectangle x1="0.5" y1="2.5" x2="0.7" y2="3.5" layer="51"/>
 <rectangle x1="0.9" y1="-3.5" x2="1.1" y2="-2.5" layer="51"/>
@@ -3921,7 +4074,8 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm 
 <smd name="38" x="-3.3" y="-1" dx="1.2" dy="0.23" layer="1"/>
 <smd name="39" x="-3.3" y="-1.4" dx="1.2" dy="0.23" layer="1"/>
 <smd name="40" x="-3.3" y="-1.8" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="2.5" dy="2.5" layer="1"/><text x="-2" y="-5.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="2.7" dy="2.7" layer="1" stop="no" cream="no"/>
+<text x="-2" y="-5.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2" y="4.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-2.4" y1="-2" x2="-2" y2="-2.4" width="0.2032" layer="21"/>
 <wire x1="-2.4" y1="2.4" x2="-2.4" y2="-2" width="0.2032" layer="21"/>
@@ -3930,10 +4084,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 5mm length, 5mm 
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-40P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABD, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABD, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3.1" x2="-3.5" y2="-2.9" layer="51"/>
 <rectangle x1="-4.5" y1="-2.7" x2="-3.5" y2="-2.5" layer="51"/>
@@ -4072,10 +4226,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-40P-700W-700L-120H-EP">
-<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.40mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABD-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABD-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3.1" x2="-3.5" y2="-2.9" layer="51"/>
 <rectangle x1="-4.5" y1="-2.7" x2="-3.5" y2="-2.5" layer="51"/>
@@ -4101,6 +4255,9 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm 
 <rectangle x1="-2.3" y1="3.5" x2="-2.1" y2="4.5" layer="51"/>
 <rectangle x1="-1.9" y1="-4.5" x2="-1.7" y2="-3.5" layer="51"/>
 <rectangle x1="-1.9" y1="3.5" x2="-1.7" y2="4.5" layer="51"/>
+<rectangle x1="-1.75" y1="-1.75" x2="1.75" y2="1.75" layer="29"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
 <rectangle x1="-1.5" y1="-4.5" x2="-1.3" y2="-3.5" layer="51"/>
 <rectangle x1="-1.5" y1="3.5" x2="-1.3" y2="4.5" layer="51"/>
 <rectangle x1="-1.1" y1="-4.5" x2="-0.9" y2="-3.5" layer="51"/>
@@ -4111,6 +4268,8 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm 
 <rectangle x1="-0.3" y1="3.5" x2="-0.1" y2="4.5" layer="51"/>
 <rectangle x1="0.1" y1="-4.5" x2="0.3" y2="-3.5" layer="51"/>
 <rectangle x1="0.1" y1="3.5" x2="0.3" y2="4.5" layer="51"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
 <rectangle x1="0.5" y1="-4.5" x2="0.7" y2="-3.5" layer="51"/>
 <rectangle x1="0.5" y1="3.5" x2="0.7" y2="4.5" layer="51"/>
 <rectangle x1="0.9" y1="-4.5" x2="1.1" y2="-3.5" layer="51"/>
@@ -4205,7 +4364,8 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm 
 <smd name="62" x="-4.3" y="-2.2" dx="1.2" dy="0.23" layer="1"/>
 <smd name="63" x="-4.3" y="-2.6" dx="1.2" dy="0.23" layer="1"/>
 <smd name="64" x="-4.3" y="-3" dx="1.2" dy="0.23" layer="1"/>
-<smd name="EP" x="0" y="0" dx="3.5" dy="3.5" layer="1"/><text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="3.7" dy="3.7" layer="1" stop="no" cream="no"/>
+<text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3" y="5.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-3.4" y1="-3" x2="-3" y2="-3.4" width="0.2032" layer="21"/>
 <wire x1="-3.4" y1="3.4" x2="-3.4" y2="-3" width="0.2032" layer="21"/>
@@ -4214,10 +4374,10 @@ Thin profile Quad Flat Package. 0.40mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-50P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACD, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>
@@ -4356,10 +4516,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-50P-1000W-1000L-120H-EP">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACD-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACD-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>
@@ -4383,20 +4543,30 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <rectangle x1="-3.375" y1="5" x2="-3.125" y2="6" layer="51"/>
 <rectangle x1="-2.875" y1="-6" x2="-2.625" y2="-5" layer="51"/>
 <rectangle x1="-2.875" y1="5" x2="-2.625" y2="6" layer="51"/>
+<rectangle x1="-2.5" y1="-2.5" x2="2.5" y2="2.5" layer="29"/>
 <rectangle x1="-2.375" y1="-6" x2="-2.125" y2="-5" layer="51"/>
 <rectangle x1="-2.375" y1="5" x2="-2.125" y2="6" layer="51"/>
+<rectangle x1="-2.3639" y1="-2.3639" x2="-0.9694" y2="-0.9694" layer="31"/>
+<rectangle x1="-2.3639" y1="-0.6972" x2="-0.9694" y2="0.6972" layer="31"/>
+<rectangle x1="-2.3639" y1="0.9694" x2="-0.9694" y2="2.3639" layer="31"/>
 <rectangle x1="-1.875" y1="-6" x2="-1.625" y2="-5" layer="51"/>
 <rectangle x1="-1.875" y1="5" x2="-1.625" y2="6" layer="51"/>
 <rectangle x1="-1.375" y1="-6" x2="-1.125" y2="-5" layer="51"/>
 <rectangle x1="-1.375" y1="5" x2="-1.125" y2="6" layer="51"/>
 <rectangle x1="-0.875" y1="-6" x2="-0.625" y2="-5" layer="51"/>
 <rectangle x1="-0.875" y1="5" x2="-0.625" y2="6" layer="51"/>
+<rectangle x1="-0.6972" y1="-2.3639" x2="0.6972" y2="-0.9694" layer="31"/>
+<rectangle x1="-0.6972" y1="-0.6972" x2="0.6972" y2="0.6972" layer="31"/>
+<rectangle x1="-0.6972" y1="0.9694" x2="0.6972" y2="2.3639" layer="31"/>
 <rectangle x1="-0.375" y1="-6" x2="-0.125" y2="-5" layer="51"/>
 <rectangle x1="-0.375" y1="5" x2="-0.125" y2="6" layer="51"/>
 <rectangle x1="0.125" y1="-6" x2="0.375" y2="-5" layer="51"/>
 <rectangle x1="0.125" y1="5" x2="0.375" y2="6" layer="51"/>
 <rectangle x1="0.625" y1="-6" x2="0.875" y2="-5" layer="51"/>
 <rectangle x1="0.625" y1="5" x2="0.875" y2="6" layer="51"/>
+<rectangle x1="0.9694" y1="-2.3639" x2="2.3639" y2="-0.9694" layer="31"/>
+<rectangle x1="0.9694" y1="-0.6972" x2="2.3639" y2="0.6972" layer="31"/>
+<rectangle x1="0.9694" y1="0.9694" x2="2.3639" y2="2.3639" layer="31"/>
 <rectangle x1="1.125" y1="-6" x2="1.375" y2="-5" layer="51"/>
 <rectangle x1="1.125" y1="5" x2="1.375" y2="6" layer="51"/>
 <rectangle x1="1.625" y1="-6" x2="1.875" y2="-5" layer="51"/>
@@ -4489,7 +4659,8 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <smd name="62" x="-5.9" y="-2.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="63" x="-5.9" y="-3.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="64" x="-5.9" y="-3.75" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="5" dy="5" layer="1"/><text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="5.2" dy="5.2" layer="1" stop="no" cream="no"/>
+<text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-4.5" y="7" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-4.9" y1="-4.5" x2="-4.5" y2="-4.9" width="0.2032" layer="21"/>
 <wire x1="-4.9" y1="4.9" x2="-4.9" y2="-4.5" width="0.2032" layer="21"/>
@@ -4498,10 +4669,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-80-50P-1200W-1200L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ADD, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ADD, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-4.875" x2="-6" y2="-4.625" layer="51"/>
 <rectangle x1="-7" y1="-4.375" x2="-6" y2="-4.125" layer="51"/>
@@ -4672,10 +4843,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-80-50P-1200W-1200L-120H-EP">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ADD-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ADD-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-4.875" x2="-6" y2="-4.625" layer="51"/>
 <rectangle x1="-7" y1="-4.375" x2="-6" y2="-4.125" layer="51"/>
@@ -4705,8 +4876,12 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12m
 <rectangle x1="-3.875" y1="6" x2="-3.625" y2="7" layer="51"/>
 <rectangle x1="-3.375" y1="-7" x2="-3.125" y2="-6" layer="51"/>
 <rectangle x1="-3.375" y1="6" x2="-3.125" y2="7" layer="51"/>
+<rectangle x1="-3" y1="-3" x2="3" y2="3" layer="29"/>
 <rectangle x1="-2.875" y1="-7" x2="-2.625" y2="-6" layer="51"/>
 <rectangle x1="-2.875" y1="6" x2="-2.625" y2="7" layer="51"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
 <rectangle x1="-2.375" y1="-7" x2="-2.125" y2="-6" layer="51"/>
 <rectangle x1="-2.375" y1="6" x2="-2.125" y2="7" layer="51"/>
 <rectangle x1="-1.875" y1="-7" x2="-1.625" y2="-6" layer="51"/>
@@ -4715,6 +4890,9 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12m
 <rectangle x1="-1.375" y1="6" x2="-1.125" y2="7" layer="51"/>
 <rectangle x1="-0.875" y1="-7" x2="-0.625" y2="-6" layer="51"/>
 <rectangle x1="-0.875" y1="6" x2="-0.625" y2="7" layer="51"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
 <rectangle x1="-0.375" y1="-7" x2="-0.125" y2="-6" layer="51"/>
 <rectangle x1="-0.375" y1="6" x2="-0.125" y2="7" layer="51"/>
 <rectangle x1="0.125" y1="-7" x2="0.375" y2="-6" layer="51"/>
@@ -4723,6 +4901,9 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12m
 <rectangle x1="0.625" y1="6" x2="0.875" y2="7" layer="51"/>
 <rectangle x1="1.125" y1="-7" x2="1.375" y2="-6" layer="51"/>
 <rectangle x1="1.125" y1="6" x2="1.375" y2="7" layer="51"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
 <rectangle x1="1.625" y1="-7" x2="1.875" y2="-6" layer="51"/>
 <rectangle x1="1.625" y1="6" x2="1.875" y2="7" layer="51"/>
 <rectangle x1="2.125" y1="-7" x2="2.375" y2="-6" layer="51"/>
@@ -4837,7 +5018,8 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12m
 <smd name="78" x="-6.9" y="-3.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="79" x="-6.9" y="-4.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="80" x="-6.9" y="-4.75" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="6" dy="6" layer="1"/><text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="6.2" dy="6.2" layer="1" stop="no" cream="no"/>
+<text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-5.5" y="8" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-5.9" y1="-5.5" x2="-5.5" y2="-5.9" width="0.2032" layer="21"/>
 <wire x1="-5.9" y1="5.9" x2="-5.9" y2="-5.5" width="0.2032" layer="21"/>
@@ -4846,10 +5028,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -5060,10 +5242,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-50P-1400W-1400L-120H-EP">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -5102,6 +5284,11 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <rectangle x1="-4.125" y1="7" x2="-3.875" y2="8" layer="51"/>
 <rectangle x1="-3.625" y1="-8" x2="-3.375" y2="-7" layer="51"/>
 <rectangle x1="-3.625" y1="7" x2="-3.375" y2="8" layer="51"/>
+<rectangle x1="-3.5" y1="-3.5" x2="3.5" y2="3.5" layer="29"/>
+<rectangle x1="-3.3571" y1="-3.3571" x2="-1.8929" y2="-1.8929" layer="31"/>
+<rectangle x1="-3.3571" y1="-1.6071" x2="-1.8929" y2="-0.1429" layer="31"/>
+<rectangle x1="-3.3571" y1="0.1429" x2="-1.8929" y2="1.6071" layer="31"/>
+<rectangle x1="-3.3571" y1="1.8929" x2="-1.8929" y2="3.3571" layer="31"/>
 <rectangle x1="-3.125" y1="-8" x2="-2.875" y2="-7" layer="51"/>
 <rectangle x1="-3.125" y1="7" x2="-2.875" y2="8" layer="51"/>
 <rectangle x1="-2.625" y1="-8" x2="-2.375" y2="-7" layer="51"/>
@@ -5110,12 +5297,20 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <rectangle x1="-2.125" y1="7" x2="-1.875" y2="8" layer="51"/>
 <rectangle x1="-1.625" y1="-8" x2="-1.375" y2="-7" layer="51"/>
 <rectangle x1="-1.625" y1="7" x2="-1.375" y2="8" layer="51"/>
+<rectangle x1="-1.6071" y1="-3.3571" x2="-0.1429" y2="-1.8929" layer="31"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
+<rectangle x1="-1.6071" y1="1.8929" x2="-0.1429" y2="3.3571" layer="31"/>
 <rectangle x1="-1.125" y1="-8" x2="-0.875" y2="-7" layer="51"/>
 <rectangle x1="-1.125" y1="7" x2="-0.875" y2="8" layer="51"/>
 <rectangle x1="-0.625" y1="-8" x2="-0.375" y2="-7" layer="51"/>
 <rectangle x1="-0.625" y1="7" x2="-0.375" y2="8" layer="51"/>
 <rectangle x1="-0.125" y1="-8" x2="0.125" y2="-7" layer="51"/>
 <rectangle x1="-0.125" y1="7" x2="0.125" y2="8" layer="51"/>
+<rectangle x1="0.1429" y1="-3.3571" x2="1.6071" y2="-1.8929" layer="31"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
+<rectangle x1="0.1429" y1="1.8929" x2="1.6071" y2="3.3571" layer="31"/>
 <rectangle x1="0.375" y1="-8" x2="0.625" y2="-7" layer="51"/>
 <rectangle x1="0.375" y1="7" x2="0.625" y2="8" layer="51"/>
 <rectangle x1="0.875" y1="-8" x2="1.125" y2="-7" layer="51"/>
@@ -5124,6 +5319,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <rectangle x1="1.375" y1="7" x2="1.625" y2="8" layer="51"/>
 <rectangle x1="1.875" y1="-8" x2="2.125" y2="-7" layer="51"/>
 <rectangle x1="1.875" y1="7" x2="2.125" y2="8" layer="51"/>
+<rectangle x1="1.8929" y1="-3.3571" x2="3.3571" y2="-1.8929" layer="31"/>
+<rectangle x1="1.8929" y1="-1.6071" x2="3.3571" y2="-0.1429" layer="31"/>
+<rectangle x1="1.8929" y1="0.1429" x2="3.3571" y2="1.6071" layer="31"/>
+<rectangle x1="1.8929" y1="1.8929" x2="3.3571" y2="3.3571" layer="31"/>
 <rectangle x1="2.375" y1="-8" x2="2.625" y2="-7" layer="51"/>
 <rectangle x1="2.375" y1="7" x2="2.625" y2="8" layer="51"/>
 <rectangle x1="2.875" y1="-8" x2="3.125" y2="-7" layer="51"/>
@@ -5265,7 +5464,8 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <smd name="98" x="-7.9" y="-5" dx="1.5" dy="0.27" layer="1"/>
 <smd name="99" x="-7.9" y="-5.5" dx="1.5" dy="0.27" layer="1"/>
 <smd name="100" x="-7.9" y="-6" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="7" dy="7" layer="1"/><text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="7.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-6.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-6.9" y1="-6.5" x2="-6.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-6.9" y1="6.9" x2="-6.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -5274,10 +5474,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-128-50P-1400W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.20mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.20mm max height, 128 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.20mm max height, 128 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AHB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AHB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-6.375" x2="-10" y2="-6.125" layer="51"/>
 <rectangle x1="-11" y1="-5.875" x2="-10" y2="-5.625" layer="51"/>
@@ -5544,10 +5744,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14m
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-128-50P-1400W-2000L-120H-EP">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.20mm max height, 128 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.20mm max height, 128 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.20mm max height, 128 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AHB-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AHB-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-6.375" x2="-10" y2="-6.125" layer="51"/>
 <rectangle x1="-11" y1="-5.875" x2="-10" y2="-5.625" layer="51"/>
@@ -5593,8 +5793,13 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14m
 <rectangle x1="-5.875" y1="7" x2="-5.625" y2="8" layer="51"/>
 <rectangle x1="-5.375" y1="-8" x2="-5.125" y2="-7" layer="51"/>
 <rectangle x1="-5.375" y1="7" x2="-5.125" y2="8" layer="51"/>
+<rectangle x1="-5" y1="-3.5" x2="5" y2="3.5" layer="29"/>
 <rectangle x1="-4.875" y1="-8" x2="-4.625" y2="-7" layer="51"/>
 <rectangle x1="-4.875" y1="7" x2="-4.625" y2="8" layer="51"/>
+<rectangle x1="-4.8367" y1="-3.3571" x2="-3.1633" y2="-1.8929" layer="31"/>
+<rectangle x1="-4.8367" y1="-1.6071" x2="-3.1633" y2="-0.1429" layer="31"/>
+<rectangle x1="-4.8367" y1="0.1429" x2="-3.1633" y2="1.6071" layer="31"/>
+<rectangle x1="-4.8367" y1="1.8929" x2="-3.1633" y2="3.3571" layer="31"/>
 <rectangle x1="-4.375" y1="-8" x2="-4.125" y2="-7" layer="51"/>
 <rectangle x1="-4.375" y1="7" x2="-4.125" y2="8" layer="51"/>
 <rectangle x1="-3.875" y1="-8" x2="-3.625" y2="-7" layer="51"/>
@@ -5603,6 +5808,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14m
 <rectangle x1="-3.375" y1="7" x2="-3.125" y2="8" layer="51"/>
 <rectangle x1="-2.875" y1="-8" x2="-2.625" y2="-7" layer="51"/>
 <rectangle x1="-2.875" y1="7" x2="-2.625" y2="8" layer="51"/>
+<rectangle x1="-2.8367" y1="-3.3571" x2="-1.1633" y2="-1.8929" layer="31"/>
+<rectangle x1="-2.8367" y1="-1.6071" x2="-1.1633" y2="-0.1429" layer="31"/>
+<rectangle x1="-2.8367" y1="0.1429" x2="-1.1633" y2="1.6071" layer="31"/>
+<rectangle x1="-2.8367" y1="1.8929" x2="-1.1633" y2="3.3571" layer="31"/>
 <rectangle x1="-2.375" y1="-8" x2="-2.125" y2="-7" layer="51"/>
 <rectangle x1="-2.375" y1="7" x2="-2.125" y2="8" layer="51"/>
 <rectangle x1="-1.875" y1="-8" x2="-1.625" y2="-7" layer="51"/>
@@ -5611,6 +5820,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14m
 <rectangle x1="-1.375" y1="7" x2="-1.125" y2="8" layer="51"/>
 <rectangle x1="-0.875" y1="-8" x2="-0.625" y2="-7" layer="51"/>
 <rectangle x1="-0.875" y1="7" x2="-0.625" y2="8" layer="51"/>
+<rectangle x1="-0.8367" y1="-3.3571" x2="0.8367" y2="-1.8929" layer="31"/>
+<rectangle x1="-0.8367" y1="-1.6071" x2="0.8367" y2="-0.1429" layer="31"/>
+<rectangle x1="-0.8367" y1="0.1429" x2="0.8367" y2="1.6071" layer="31"/>
+<rectangle x1="-0.8367" y1="1.8929" x2="0.8367" y2="3.3571" layer="31"/>
 <rectangle x1="-0.375" y1="-8" x2="-0.125" y2="-7" layer="51"/>
 <rectangle x1="-0.375" y1="7" x2="-0.125" y2="8" layer="51"/>
 <rectangle x1="0.125" y1="-8" x2="0.375" y2="-7" layer="51"/>
@@ -5619,6 +5832,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14m
 <rectangle x1="0.625" y1="7" x2="0.875" y2="8" layer="51"/>
 <rectangle x1="1.125" y1="-8" x2="1.375" y2="-7" layer="51"/>
 <rectangle x1="1.125" y1="7" x2="1.375" y2="8" layer="51"/>
+<rectangle x1="1.1633" y1="-3.3571" x2="2.8367" y2="-1.8929" layer="31"/>
+<rectangle x1="1.1633" y1="-1.6071" x2="2.8367" y2="-0.1429" layer="31"/>
+<rectangle x1="1.1633" y1="0.1429" x2="2.8367" y2="1.6071" layer="31"/>
+<rectangle x1="1.1633" y1="1.8929" x2="2.8367" y2="3.3571" layer="31"/>
 <rectangle x1="1.625" y1="-8" x2="1.875" y2="-7" layer="51"/>
 <rectangle x1="1.625" y1="7" x2="1.875" y2="8" layer="51"/>
 <rectangle x1="2.125" y1="-8" x2="2.375" y2="-7" layer="51"/>
@@ -5627,6 +5844,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14m
 <rectangle x1="2.625" y1="7" x2="2.875" y2="8" layer="51"/>
 <rectangle x1="3.125" y1="-8" x2="3.375" y2="-7" layer="51"/>
 <rectangle x1="3.125" y1="7" x2="3.375" y2="8" layer="51"/>
+<rectangle x1="3.1633" y1="-3.3571" x2="4.8367" y2="-1.8929" layer="31"/>
+<rectangle x1="3.1633" y1="-1.6071" x2="4.8367" y2="-0.1429" layer="31"/>
+<rectangle x1="3.1633" y1="0.1429" x2="4.8367" y2="1.6071" layer="31"/>
+<rectangle x1="3.1633" y1="1.8929" x2="4.8367" y2="3.3571" layer="31"/>
 <rectangle x1="3.625" y1="-8" x2="3.875" y2="-7" layer="51"/>
 <rectangle x1="3.625" y1="7" x2="3.875" y2="8" layer="51"/>
 <rectangle x1="4.125" y1="-8" x2="4.375" y2="-7" layer="51"/>
@@ -5805,7 +6026,8 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14m
 <smd name="126" x="-10.9" y="-5.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="127" x="-10.9" y="-5.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="128" x="-10.9" y="-6.25" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="10" dy="7" layer="1"/><text x="-9.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="10.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-9.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-9.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-9.9" y1="-6.5" x2="-9.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-9.9" y1="6.9" x2="-9.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -5814,10 +6036,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 14m
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-144-50P-2000W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -6116,10 +6338,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-144-50P-2000W-2000L-120H-EP">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFB-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFB-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -6173,8 +6395,14 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <rectangle x1="-5.875" y1="10" x2="-5.625" y2="11" layer="51"/>
 <rectangle x1="-5.375" y1="-11" x2="-5.125" y2="-10" layer="51"/>
 <rectangle x1="-5.375" y1="10" x2="-5.125" y2="11" layer="51"/>
+<rectangle x1="-5" y1="-5" x2="5" y2="5" layer="29"/>
 <rectangle x1="-4.875" y1="-11" x2="-4.625" y2="-10" layer="51"/>
 <rectangle x1="-4.875" y1="10" x2="-4.625" y2="11" layer="51"/>
+<rectangle x1="-4.8367" y1="-4.8367" x2="-3.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-2.8367" x2="-3.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-0.8367" x2="-3.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="1.1633" x2="-3.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="3.1633" x2="-3.1633" y2="4.8367" layer="31"/>
 <rectangle x1="-4.375" y1="-11" x2="-4.125" y2="-10" layer="51"/>
 <rectangle x1="-4.375" y1="10" x2="-4.125" y2="11" layer="51"/>
 <rectangle x1="-3.875" y1="-11" x2="-3.625" y2="-10" layer="51"/>
@@ -6183,6 +6411,11 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <rectangle x1="-3.375" y1="10" x2="-3.125" y2="11" layer="51"/>
 <rectangle x1="-2.875" y1="-11" x2="-2.625" y2="-10" layer="51"/>
 <rectangle x1="-2.875" y1="10" x2="-2.625" y2="11" layer="51"/>
+<rectangle x1="-2.8367" y1="-4.8367" x2="-1.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="3.1633" x2="-1.1633" y2="4.8367" layer="31"/>
 <rectangle x1="-2.375" y1="-11" x2="-2.125" y2="-10" layer="51"/>
 <rectangle x1="-2.375" y1="10" x2="-2.125" y2="11" layer="51"/>
 <rectangle x1="-1.875" y1="-11" x2="-1.625" y2="-10" layer="51"/>
@@ -6191,6 +6424,11 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <rectangle x1="-1.375" y1="10" x2="-1.125" y2="11" layer="51"/>
 <rectangle x1="-0.875" y1="-11" x2="-0.625" y2="-10" layer="51"/>
 <rectangle x1="-0.875" y1="10" x2="-0.625" y2="11" layer="51"/>
+<rectangle x1="-0.8367" y1="-4.8367" x2="0.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="3.1633" x2="0.8367" y2="4.8367" layer="31"/>
 <rectangle x1="-0.375" y1="-11" x2="-0.125" y2="-10" layer="51"/>
 <rectangle x1="-0.375" y1="10" x2="-0.125" y2="11" layer="51"/>
 <rectangle x1="0.125" y1="-11" x2="0.375" y2="-10" layer="51"/>
@@ -6199,6 +6437,11 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <rectangle x1="0.625" y1="10" x2="0.875" y2="11" layer="51"/>
 <rectangle x1="1.125" y1="-11" x2="1.375" y2="-10" layer="51"/>
 <rectangle x1="1.125" y1="10" x2="1.375" y2="11" layer="51"/>
+<rectangle x1="1.1633" y1="-4.8367" x2="2.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
+<rectangle x1="1.1633" y1="3.1633" x2="2.8367" y2="4.8367" layer="31"/>
 <rectangle x1="1.625" y1="-11" x2="1.875" y2="-10" layer="51"/>
 <rectangle x1="1.625" y1="10" x2="1.875" y2="11" layer="51"/>
 <rectangle x1="2.125" y1="-11" x2="2.375" y2="-10" layer="51"/>
@@ -6207,6 +6450,11 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <rectangle x1="2.625" y1="10" x2="2.875" y2="11" layer="51"/>
 <rectangle x1="3.125" y1="-11" x2="3.375" y2="-10" layer="51"/>
 <rectangle x1="3.125" y1="10" x2="3.375" y2="11" layer="51"/>
+<rectangle x1="3.1633" y1="-4.8367" x2="4.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-2.8367" x2="4.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-0.8367" x2="4.8367" y2="0.8367" layer="31"/>
+<rectangle x1="3.1633" y1="1.1633" x2="4.8367" y2="2.8367" layer="31"/>
+<rectangle x1="3.1633" y1="3.1633" x2="4.8367" y2="4.8367" layer="31"/>
 <rectangle x1="3.625" y1="-11" x2="3.875" y2="-10" layer="51"/>
 <rectangle x1="3.625" y1="10" x2="3.875" y2="11" layer="51"/>
 <rectangle x1="4.125" y1="-11" x2="4.375" y2="-10" layer="51"/>
@@ -6409,7 +6657,8 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <smd name="142" x="-10.9" y="-7.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="143" x="-10.9" y="-8.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="144" x="-10.9" y="-8.75" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="10" dy="10" layer="1"/><text x="-9.5" y="-13" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="10.2" dy="10.2" layer="1" stop="no" cream="no"/>
+<text x="-9.5" y="-13" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-9.5" y="12" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-9.9" y1="-9.5" x2="-9.5" y2="-9.9" width="0.2032" layer="21"/>
 <wire x1="-9.9" y1="9.9" x2="-9.9" y2="-9.5" width="0.2032" layer="21"/>
@@ -6418,10 +6667,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-176-50P-2400W-2400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.20mm max height, 176 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AGA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AGA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-11.1" y="-11.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-13" y1="-10.875" x2="-12" y2="-10.625" layer="51"/>
 <rectangle x1="-13" y1="-10.375" x2="-12" y2="-10.125" layer="51"/>
@@ -6784,10 +7033,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24m
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-176-50P-2400W-2400L-120H-EP">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 24mm length, 24mm width, 1.20mm max height, 176 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24mm width, 1.20mm max height, 176 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AGA-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AGA-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-11.1" y="-11.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-13" y1="-10.875" x2="-12" y2="-10.625" layer="51"/>
 <rectangle x1="-13" y1="-10.375" x2="-12" y2="-10.125" layer="51"/>
@@ -6853,8 +7102,15 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24m
 <rectangle x1="-6.875" y1="12" x2="-6.625" y2="13" layer="51"/>
 <rectangle x1="-6.375" y1="-13" x2="-6.125" y2="-12" layer="51"/>
 <rectangle x1="-6.375" y1="12" x2="-6.125" y2="13" layer="51"/>
+<rectangle x1="-6" y1="-6" x2="6" y2="6" layer="29"/>
 <rectangle x1="-5.875" y1="-13" x2="-5.625" y2="-12" layer="51"/>
 <rectangle x1="-5.875" y1="12" x2="-5.625" y2="13" layer="51"/>
+<rectangle x1="-5.8367" y1="-5.8367" x2="-4.1633" y2="-4.1633" layer="31"/>
+<rectangle x1="-5.8367" y1="-3.8367" x2="-4.1633" y2="-2.1633" layer="31"/>
+<rectangle x1="-5.8367" y1="-1.8367" x2="-4.1633" y2="-0.1633" layer="31"/>
+<rectangle x1="-5.8367" y1="0.1633" x2="-4.1633" y2="1.8367" layer="31"/>
+<rectangle x1="-5.8367" y1="2.1633" x2="-4.1633" y2="3.8367" layer="31"/>
+<rectangle x1="-5.8367" y1="4.1633" x2="-4.1633" y2="5.8367" layer="31"/>
 <rectangle x1="-5.375" y1="-13" x2="-5.125" y2="-12" layer="51"/>
 <rectangle x1="-5.375" y1="12" x2="-5.125" y2="13" layer="51"/>
 <rectangle x1="-4.875" y1="-13" x2="-4.625" y2="-12" layer="51"/>
@@ -6863,6 +7119,12 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24m
 <rectangle x1="-4.375" y1="12" x2="-4.125" y2="13" layer="51"/>
 <rectangle x1="-3.875" y1="-13" x2="-3.625" y2="-12" layer="51"/>
 <rectangle x1="-3.875" y1="12" x2="-3.625" y2="13" layer="51"/>
+<rectangle x1="-3.8367" y1="-5.8367" x2="-2.1633" y2="-4.1633" layer="31"/>
+<rectangle x1="-3.8367" y1="-3.8367" x2="-2.1633" y2="-2.1633" layer="31"/>
+<rectangle x1="-3.8367" y1="-1.8367" x2="-2.1633" y2="-0.1633" layer="31"/>
+<rectangle x1="-3.8367" y1="0.1633" x2="-2.1633" y2="1.8367" layer="31"/>
+<rectangle x1="-3.8367" y1="2.1633" x2="-2.1633" y2="3.8367" layer="31"/>
+<rectangle x1="-3.8367" y1="4.1633" x2="-2.1633" y2="5.8367" layer="31"/>
 <rectangle x1="-3.375" y1="-13" x2="-3.125" y2="-12" layer="51"/>
 <rectangle x1="-3.375" y1="12" x2="-3.125" y2="13" layer="51"/>
 <rectangle x1="-2.875" y1="-13" x2="-2.625" y2="-12" layer="51"/>
@@ -6871,6 +7133,12 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24m
 <rectangle x1="-2.375" y1="12" x2="-2.125" y2="13" layer="51"/>
 <rectangle x1="-1.875" y1="-13" x2="-1.625" y2="-12" layer="51"/>
 <rectangle x1="-1.875" y1="12" x2="-1.625" y2="13" layer="51"/>
+<rectangle x1="-1.8367" y1="-5.8367" x2="-0.1633" y2="-4.1633" layer="31"/>
+<rectangle x1="-1.8367" y1="-3.8367" x2="-0.1633" y2="-2.1633" layer="31"/>
+<rectangle x1="-1.8367" y1="-1.8367" x2="-0.1633" y2="-0.1633" layer="31"/>
+<rectangle x1="-1.8367" y1="0.1633" x2="-0.1633" y2="1.8367" layer="31"/>
+<rectangle x1="-1.8367" y1="2.1633" x2="-0.1633" y2="3.8367" layer="31"/>
+<rectangle x1="-1.8367" y1="4.1633" x2="-0.1633" y2="5.8367" layer="31"/>
 <rectangle x1="-1.375" y1="-13" x2="-1.125" y2="-12" layer="51"/>
 <rectangle x1="-1.375" y1="12" x2="-1.125" y2="13" layer="51"/>
 <rectangle x1="-0.875" y1="-13" x2="-0.625" y2="-12" layer="51"/>
@@ -6879,6 +7147,12 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24m
 <rectangle x1="-0.375" y1="12" x2="-0.125" y2="13" layer="51"/>
 <rectangle x1="0.125" y1="-13" x2="0.375" y2="-12" layer="51"/>
 <rectangle x1="0.125" y1="12" x2="0.375" y2="13" layer="51"/>
+<rectangle x1="0.1633" y1="-5.8367" x2="1.8367" y2="-4.1633" layer="31"/>
+<rectangle x1="0.1633" y1="-3.8367" x2="1.8367" y2="-2.1633" layer="31"/>
+<rectangle x1="0.1633" y1="-1.8367" x2="1.8367" y2="-0.1633" layer="31"/>
+<rectangle x1="0.1633" y1="0.1633" x2="1.8367" y2="1.8367" layer="31"/>
+<rectangle x1="0.1633" y1="2.1633" x2="1.8367" y2="3.8367" layer="31"/>
+<rectangle x1="0.1633" y1="4.1633" x2="1.8367" y2="5.8367" layer="31"/>
 <rectangle x1="0.625" y1="-13" x2="0.875" y2="-12" layer="51"/>
 <rectangle x1="0.625" y1="12" x2="0.875" y2="13" layer="51"/>
 <rectangle x1="1.125" y1="-13" x2="1.375" y2="-12" layer="51"/>
@@ -6887,6 +7161,12 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24m
 <rectangle x1="1.625" y1="12" x2="1.875" y2="13" layer="51"/>
 <rectangle x1="2.125" y1="-13" x2="2.375" y2="-12" layer="51"/>
 <rectangle x1="2.125" y1="12" x2="2.375" y2="13" layer="51"/>
+<rectangle x1="2.1633" y1="-5.8367" x2="3.8367" y2="-4.1633" layer="31"/>
+<rectangle x1="2.1633" y1="-3.8367" x2="3.8367" y2="-2.1633" layer="31"/>
+<rectangle x1="2.1633" y1="-1.8367" x2="3.8367" y2="-0.1633" layer="31"/>
+<rectangle x1="2.1633" y1="0.1633" x2="3.8367" y2="1.8367" layer="31"/>
+<rectangle x1="2.1633" y1="2.1633" x2="3.8367" y2="3.8367" layer="31"/>
+<rectangle x1="2.1633" y1="4.1633" x2="3.8367" y2="5.8367" layer="31"/>
 <rectangle x1="2.625" y1="-13" x2="2.875" y2="-12" layer="51"/>
 <rectangle x1="2.625" y1="12" x2="2.875" y2="13" layer="51"/>
 <rectangle x1="3.125" y1="-13" x2="3.375" y2="-12" layer="51"/>
@@ -6895,6 +7175,12 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24m
 <rectangle x1="3.625" y1="12" x2="3.875" y2="13" layer="51"/>
 <rectangle x1="4.125" y1="-13" x2="4.375" y2="-12" layer="51"/>
 <rectangle x1="4.125" y1="12" x2="4.375" y2="13" layer="51"/>
+<rectangle x1="4.1633" y1="-5.8367" x2="5.8367" y2="-4.1633" layer="31"/>
+<rectangle x1="4.1633" y1="-3.8367" x2="5.8367" y2="-2.1633" layer="31"/>
+<rectangle x1="4.1633" y1="-1.8367" x2="5.8367" y2="-0.1633" layer="31"/>
+<rectangle x1="4.1633" y1="0.1633" x2="5.8367" y2="1.8367" layer="31"/>
+<rectangle x1="4.1633" y1="2.1633" x2="5.8367" y2="3.8367" layer="31"/>
+<rectangle x1="4.1633" y1="4.1633" x2="5.8367" y2="5.8367" layer="31"/>
 <rectangle x1="4.625" y1="-13" x2="4.875" y2="-12" layer="51"/>
 <rectangle x1="4.625" y1="12" x2="4.875" y2="13" layer="51"/>
 <rectangle x1="5.125" y1="-13" x2="5.375" y2="-12" layer="51"/>
@@ -7141,7 +7427,8 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24m
 <smd name="174" x="-12.9" y="-9.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="175" x="-12.9" y="-10.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="176" x="-12.9" y="-10.75" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="12" dy="12" layer="1"/><text x="-11.5" y="-15" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="12.2" dy="12.2" layer="1" stop="no" cream="no"/>
+<text x="-11.5" y="-15" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-11.5" y="14" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-11.9" y1="-11.5" x2="-11.5" y2="-11.9" width="0.2032" layer="21"/>
 <wire x1="-11.9" y1="11.9" x2="-11.9" y2="-11.5" width="0.2032" layer="21"/>
@@ -7150,10 +7437,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 24mm length, 24m
 <wire x1="11.9" y1="11.9" x2="-11.9" y2="11.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-24-50P-400W-400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.20mm max height, 24 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AKB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AKB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.1" y="-1.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3" y1="-1.375" x2="-2" y2="-1.125" layer="51"/>
 <rectangle x1="-3" y1="-0.875" x2="-2" y2="-0.625" layer="51"/>
@@ -7212,10 +7499,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm 
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-24-50P-400W-400L-120H-EP">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.20mm max height, 24 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AKB-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AKB-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.1" y="-1.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3" y1="-1.375" x2="-2" y2="-1.125" layer="51"/>
 <rectangle x1="-3" y1="-0.875" x2="-2" y2="-0.625" layer="51"/>
@@ -7225,8 +7512,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm 
 <rectangle x1="-3" y1="1.125" x2="-2" y2="1.375" layer="51"/>
 <rectangle x1="-1.375" y1="-3" x2="-1.125" y2="-2" layer="51"/>
 <rectangle x1="-1.375" y1="2" x2="-1.125" y2="3" layer="51"/>
+<rectangle x1="-1" y1="-1" x2="1" y2="1" layer="29"/>
 <rectangle x1="-0.875" y1="-3" x2="-0.625" y2="-2" layer="51"/>
 <rectangle x1="-0.875" y1="2" x2="-0.625" y2="3" layer="51"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
 <rectangle x1="-0.375" y1="-3" x2="-0.125" y2="-2" layer="51"/>
 <rectangle x1="-0.375" y1="2" x2="-0.125" y2="3" layer="51"/>
 <rectangle x1="0.125" y1="-3" x2="0.375" y2="-2" layer="51"/>
@@ -7265,7 +7554,8 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm 
 <smd name="22" x="-2.9" y="-0.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="23" x="-2.9" y="-0.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="24" x="-2.9" y="-1.25" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="2" dy="2" layer="1"/><text x="-1.5" y="-5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="2.2" dy="2.2" layer="1" stop="no" cream="no"/>
+<text x="-1.5" y="-5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-1.5" y="4" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-1.9" y1="-1.5" x2="-1.5" y2="-1.9" width="0.2032" layer="21"/>
 <wire x1="-1.9" y1="1.9" x2="-1.9" y2="-1.5" width="0.2032" layer="21"/>
@@ -7274,10 +7564,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 4mm length, 4mm 
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-32-50P-500W-500L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.20mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AAA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AAA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.6" y="-1.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3.5" y1="-1.875" x2="-2.5" y2="-1.625" layer="51"/>
 <rectangle x1="-3.5" y1="-1.375" x2="-2.5" y2="-1.125" layer="51"/>
@@ -7352,10 +7642,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm 
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-32-50P-500W-500L-120H-EP">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.20mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AAA-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AAA-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.6" y="-1.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3.5" y1="-1.875" x2="-2.5" y2="-1.625" layer="51"/>
 <rectangle x1="-3.5" y1="-1.375" x2="-2.5" y2="-1.125" layer="51"/>
@@ -7369,10 +7659,15 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm 
 <rectangle x1="-1.875" y1="2.5" x2="-1.625" y2="3.5" layer="51"/>
 <rectangle x1="-1.375" y1="-3.5" x2="-1.125" y2="-2.5" layer="51"/>
 <rectangle x1="-1.375" y1="2.5" x2="-1.125" y2="3.5" layer="51"/>
+<rectangle x1="-1.25" y1="-1.25" x2="1.25" y2="1.25" layer="29"/>
+<rectangle x1="-1.1479" y1="-1.1479" x2="-0.1021" y2="-0.1021" layer="31"/>
+<rectangle x1="-1.1479" y1="0.1021" x2="-0.1021" y2="1.1479" layer="31"/>
 <rectangle x1="-0.875" y1="-3.5" x2="-0.625" y2="-2.5" layer="51"/>
 <rectangle x1="-0.875" y1="2.5" x2="-0.625" y2="3.5" layer="51"/>
 <rectangle x1="-0.375" y1="-3.5" x2="-0.125" y2="-2.5" layer="51"/>
 <rectangle x1="-0.375" y1="2.5" x2="-0.125" y2="3.5" layer="51"/>
+<rectangle x1="0.1021" y1="-1.1479" x2="1.1479" y2="-0.1021" layer="31"/>
+<rectangle x1="0.1021" y1="0.1021" x2="1.1479" y2="1.1479" layer="31"/>
 <rectangle x1="0.125" y1="-3.5" x2="0.375" y2="-2.5" layer="51"/>
 <rectangle x1="0.125" y1="2.5" x2="0.375" y2="3.5" layer="51"/>
 <rectangle x1="0.625" y1="-3.5" x2="0.875" y2="-2.5" layer="51"/>
@@ -7421,7 +7716,8 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm 
 <smd name="30" x="-3.4" y="-0.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="31" x="-3.4" y="-1.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="32" x="-3.4" y="-1.75" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="2.5" dy="2.5" layer="1"/><text x="-2" y="-5.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="2.7" dy="2.7" layer="1" stop="no" cream="no"/>
+<text x="-2" y="-5.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2" y="4.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-2.4" y1="-2" x2="-2" y2="-2.4" width="0.2032" layer="21"/>
 <wire x1="-2.4" y1="2.4" x2="-2.4" y2="-2" width="0.2032" layer="21"/>
@@ -7430,10 +7726,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm 
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-48-50P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -7540,10 +7836,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-48-50P-700W-700L-120H-EP">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABC-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABC-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>
@@ -7563,6 +7859,9 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <rectangle x1="-2.375" y1="3.5" x2="-2.125" y2="4.5" layer="51"/>
 <rectangle x1="-1.875" y1="-4.5" x2="-1.625" y2="-3.5" layer="51"/>
 <rectangle x1="-1.875" y1="3.5" x2="-1.625" y2="4.5" layer="51"/>
+<rectangle x1="-1.75" y1="-1.75" x2="1.75" y2="1.75" layer="29"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
 <rectangle x1="-1.375" y1="-4.5" x2="-1.125" y2="-3.5" layer="51"/>
 <rectangle x1="-1.375" y1="3.5" x2="-1.125" y2="4.5" layer="51"/>
 <rectangle x1="-0.875" y1="-4.5" x2="-0.625" y2="-3.5" layer="51"/>
@@ -7571,6 +7870,8 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <rectangle x1="-0.375" y1="3.5" x2="-0.125" y2="4.5" layer="51"/>
 <rectangle x1="0.125" y1="-4.5" x2="0.375" y2="-3.5" layer="51"/>
 <rectangle x1="0.125" y1="3.5" x2="0.375" y2="4.5" layer="51"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
 <rectangle x1="0.625" y1="-4.5" x2="0.875" y2="-3.5" layer="51"/>
 <rectangle x1="0.625" y1="3.5" x2="0.875" y2="4.5" layer="51"/>
 <rectangle x1="1.125" y1="-4.5" x2="1.375" y2="-3.5" layer="51"/>
@@ -7641,7 +7942,8 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <smd name="46" x="-4.4" y="-1.75" dx="1.5" dy="0.27" layer="1"/>
 <smd name="47" x="-4.4" y="-2.25" dx="1.5" dy="0.27" layer="1"/>
 <smd name="48" x="-4.4" y="-2.75" dx="1.5" dy="0.27" layer="1"/>
-<smd name="EP" x="0" y="0" dx="3.5" dy="3.5" layer="1"/><text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="3.7" dy="3.7" layer="1" stop="no" cream="no"/>
+<text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3" y="5.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-3.4" y1="-3" x2="-3" y2="-3.4" width="0.2032" layer="21"/>
 <wire x1="-3.4" y1="3.4" x2="-3.4" y2="-3" width="0.2032" layer="21"/>
@@ -7650,10 +7952,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-52-65P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.075" x2="-5" y2="-3.725" layer="51"/>
 <rectangle x1="-6" y1="-3.425" x2="-5" y2="-3.075" layer="51"/>
@@ -7768,10 +8070,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-52-65P-1000W-1000L-120H-EP">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACC-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACC-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.075" x2="-5" y2="-3.725" layer="51"/>
 <rectangle x1="-6" y1="-3.425" x2="-5" y2="-3.075" layer="51"/>
@@ -7792,16 +8094,26 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10m
 <rectangle x1="-3.425" y1="5" x2="-3.075" y2="6" layer="51"/>
 <rectangle x1="-2.775" y1="-6" x2="-2.425" y2="-5" layer="51"/>
 <rectangle x1="-2.775" y1="5" x2="-2.425" y2="6" layer="51"/>
+<rectangle x1="-2.5" y1="-2.5" x2="2.5" y2="2.5" layer="29"/>
+<rectangle x1="-2.3639" y1="-2.3639" x2="-0.9694" y2="-0.9694" layer="31"/>
+<rectangle x1="-2.3639" y1="-0.6972" x2="-0.9694" y2="0.6972" layer="31"/>
+<rectangle x1="-2.3639" y1="0.9694" x2="-0.9694" y2="2.3639" layer="31"/>
 <rectangle x1="-2.125" y1="-6" x2="-1.775" y2="-5" layer="51"/>
 <rectangle x1="-2.125" y1="5" x2="-1.775" y2="6" layer="51"/>
 <rectangle x1="-1.475" y1="-6" x2="-1.125" y2="-5" layer="51"/>
 <rectangle x1="-1.475" y1="5" x2="-1.125" y2="6" layer="51"/>
 <rectangle x1="-0.825" y1="-6" x2="-0.475" y2="-5" layer="51"/>
 <rectangle x1="-0.825" y1="5" x2="-0.475" y2="6" layer="51"/>
+<rectangle x1="-0.6972" y1="-2.3639" x2="0.6972" y2="-0.9694" layer="31"/>
+<rectangle x1="-0.6972" y1="-0.6972" x2="0.6972" y2="0.6972" layer="31"/>
+<rectangle x1="-0.6972" y1="0.9694" x2="0.6972" y2="2.3639" layer="31"/>
 <rectangle x1="-0.175" y1="-6" x2="0.175" y2="-5" layer="51"/>
 <rectangle x1="-0.175" y1="5" x2="0.175" y2="6" layer="51"/>
 <rectangle x1="0.475" y1="-6" x2="0.825" y2="-5" layer="51"/>
 <rectangle x1="0.475" y1="5" x2="0.825" y2="6" layer="51"/>
+<rectangle x1="0.9694" y1="-2.3639" x2="2.3639" y2="-0.9694" layer="31"/>
+<rectangle x1="0.9694" y1="-0.6972" x2="2.3639" y2="0.6972" layer="31"/>
+<rectangle x1="0.9694" y1="0.9694" x2="2.3639" y2="2.3639" layer="31"/>
 <rectangle x1="1.125" y1="-6" x2="1.475" y2="-5" layer="51"/>
 <rectangle x1="1.125" y1="5" x2="1.475" y2="6" layer="51"/>
 <rectangle x1="1.775" y1="-6" x2="2.125" y2="-5" layer="51"/>
@@ -7877,7 +8189,8 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10m
 <smd name="50" x="-5.9" y="-2.6" dx="1.5" dy="0.4" layer="1"/>
 <smd name="51" x="-5.9" y="-3.25" dx="1.5" dy="0.4" layer="1"/>
 <smd name="52" x="-5.9" y="-3.9" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="5" dy="5" layer="1"/><text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="5.2" dy="5.2" layer="1" stop="no" cream="no"/>
+<text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-4.5" y="7" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-4.9" y1="-4.5" x2="-4.5" y2="-4.9" width="0.2032" layer="21"/>
 <wire x1="-4.9" y1="4.9" x2="-4.9" y2="-4.5" width="0.2032" layer="21"/>
@@ -7886,10 +8199,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-65P-1200W-1200L-120H">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ADC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ADC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-5.05" x2="-6" y2="-4.7" layer="51"/>
 <rectangle x1="-7" y1="-4.4" x2="-6" y2="-4.05" layer="51"/>
@@ -8028,10 +8341,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-65P-1200W-1200L-120H-EP">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ADC-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ADC-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-5.05" x2="-6" y2="-4.7" layer="51"/>
 <rectangle x1="-7" y1="-4.4" x2="-6" y2="-4.05" layer="51"/>
@@ -8057,18 +8370,28 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12m
 <rectangle x1="-3.75" y1="6" x2="-3.4" y2="7" layer="51"/>
 <rectangle x1="-3.1" y1="-7" x2="-2.75" y2="-6" layer="51"/>
 <rectangle x1="-3.1" y1="6" x2="-2.75" y2="7" layer="51"/>
+<rectangle x1="-3" y1="-3" x2="3" y2="3" layer="29"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
 <rectangle x1="-2.45" y1="-7" x2="-2.1" y2="-6" layer="51"/>
 <rectangle x1="-2.45" y1="6" x2="-2.1" y2="7" layer="51"/>
 <rectangle x1="-1.8" y1="-7" x2="-1.45" y2="-6" layer="51"/>
 <rectangle x1="-1.8" y1="6" x2="-1.45" y2="7" layer="51"/>
 <rectangle x1="-1.15" y1="-7" x2="-0.8" y2="-6" layer="51"/>
 <rectangle x1="-1.15" y1="6" x2="-0.8" y2="7" layer="51"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
 <rectangle x1="-0.5" y1="-7" x2="-0.15" y2="-6" layer="51"/>
 <rectangle x1="-0.5" y1="6" x2="-0.15" y2="7" layer="51"/>
 <rectangle x1="0.15" y1="-7" x2="0.5" y2="-6" layer="51"/>
 <rectangle x1="0.15" y1="6" x2="0.5" y2="7" layer="51"/>
 <rectangle x1="0.8" y1="-7" x2="1.15" y2="-6" layer="51"/>
 <rectangle x1="0.8" y1="6" x2="1.15" y2="7" layer="51"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
 <rectangle x1="1.45" y1="-7" x2="1.8" y2="-6" layer="51"/>
 <rectangle x1="1.45" y1="6" x2="1.8" y2="7" layer="51"/>
 <rectangle x1="2.1" y1="-7" x2="2.45" y2="-6" layer="51"/>
@@ -8161,7 +8484,8 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12m
 <smd name="62" x="-6.9" y="-3.575" dx="1.5" dy="0.4" layer="1"/>
 <smd name="63" x="-6.9" y="-4.225" dx="1.5" dy="0.4" layer="1"/>
 <smd name="64" x="-6.9" y="-4.875" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="6" dy="6" layer="1"/><text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="6.2" dy="6.2" layer="1" stop="no" cream="no"/>
+<text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-5.5" y="8" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-5.9" y1="-5.5" x2="-5.5" y2="-5.9" width="0.2032" layer="21"/>
 <wire x1="-5.9" y1="5.9" x2="-5.9" y2="-5.5" width="0.2032" layer="21"/>
@@ -8170,10 +8494,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-80-65P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEC, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEC, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.35" x2="-7" y2="-6" layer="51"/>
 <rectangle x1="-8" y1="-5.7" x2="-7" y2="-5.35" layer="51"/>
@@ -8344,10 +8668,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-80-65P-1400W-1400L-120H-EP">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEC-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEC-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.35" x2="-7" y2="-6" layer="51"/>
 <rectangle x1="-8" y1="-5.7" x2="-7" y2="-5.35" layer="51"/>
@@ -8379,22 +8703,39 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14m
 <rectangle x1="-4.4" y1="7" x2="-4.05" y2="8" layer="51"/>
 <rectangle x1="-3.75" y1="-8" x2="-3.4" y2="-7" layer="51"/>
 <rectangle x1="-3.75" y1="7" x2="-3.4" y2="8" layer="51"/>
+<rectangle x1="-3.5" y1="-3.5" x2="3.5" y2="3.5" layer="29"/>
+<rectangle x1="-3.3571" y1="-3.3571" x2="-1.8929" y2="-1.8929" layer="31"/>
+<rectangle x1="-3.3571" y1="-1.6071" x2="-1.8929" y2="-0.1429" layer="31"/>
+<rectangle x1="-3.3571" y1="0.1429" x2="-1.8929" y2="1.6071" layer="31"/>
+<rectangle x1="-3.3571" y1="1.8929" x2="-1.8929" y2="3.3571" layer="31"/>
 <rectangle x1="-3.1" y1="-8" x2="-2.75" y2="-7" layer="51"/>
 <rectangle x1="-3.1" y1="7" x2="-2.75" y2="8" layer="51"/>
 <rectangle x1="-2.45" y1="-8" x2="-2.1" y2="-7" layer="51"/>
 <rectangle x1="-2.45" y1="7" x2="-2.1" y2="8" layer="51"/>
 <rectangle x1="-1.8" y1="-8" x2="-1.45" y2="-7" layer="51"/>
 <rectangle x1="-1.8" y1="7" x2="-1.45" y2="8" layer="51"/>
+<rectangle x1="-1.6071" y1="-3.3571" x2="-0.1429" y2="-1.8929" layer="31"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
+<rectangle x1="-1.6071" y1="1.8929" x2="-0.1429" y2="3.3571" layer="31"/>
 <rectangle x1="-1.15" y1="-8" x2="-0.8" y2="-7" layer="51"/>
 <rectangle x1="-1.15" y1="7" x2="-0.8" y2="8" layer="51"/>
 <rectangle x1="-0.5" y1="-8" x2="-0.15" y2="-7" layer="51"/>
 <rectangle x1="-0.5" y1="7" x2="-0.15" y2="8" layer="51"/>
+<rectangle x1="0.1429" y1="-3.3571" x2="1.6071" y2="-1.8929" layer="31"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
+<rectangle x1="0.1429" y1="1.8929" x2="1.6071" y2="3.3571" layer="31"/>
 <rectangle x1="0.15" y1="-8" x2="0.5" y2="-7" layer="51"/>
 <rectangle x1="0.15" y1="7" x2="0.5" y2="8" layer="51"/>
 <rectangle x1="0.8" y1="-8" x2="1.15" y2="-7" layer="51"/>
 <rectangle x1="0.8" y1="7" x2="1.15" y2="8" layer="51"/>
 <rectangle x1="1.45" y1="-8" x2="1.8" y2="-7" layer="51"/>
 <rectangle x1="1.45" y1="7" x2="1.8" y2="8" layer="51"/>
+<rectangle x1="1.8929" y1="-3.3571" x2="3.3571" y2="-1.8929" layer="31"/>
+<rectangle x1="1.8929" y1="-1.6071" x2="3.3571" y2="-0.1429" layer="31"/>
+<rectangle x1="1.8929" y1="0.1429" x2="3.3571" y2="1.6071" layer="31"/>
+<rectangle x1="1.8929" y1="1.8929" x2="3.3571" y2="3.3571" layer="31"/>
 <rectangle x1="2.1" y1="-8" x2="2.45" y2="-7" layer="51"/>
 <rectangle x1="2.1" y1="7" x2="2.45" y2="8" layer="51"/>
 <rectangle x1="2.75" y1="-8" x2="3.1" y2="-7" layer="51"/>
@@ -8509,7 +8850,8 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14m
 <smd name="78" x="-7.9" y="-4.875" dx="1.5" dy="0.4" layer="1"/>
 <smd name="79" x="-7.9" y="-5.525" dx="1.5" dy="0.4" layer="1"/>
 <smd name="80" x="-7.9" y="-6.175" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="7" dy="7" layer="1"/><text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="7.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-6.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-6.9" y1="-6.5" x2="-6.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-6.9" y1="6.9" x2="-6.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -8518,10 +8860,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-65P-1400W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AHA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AHA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-6.35" x2="-10" y2="-6" layer="51"/>
 <rectangle x1="-11" y1="-5.7" x2="-10" y2="-5.35" layer="51"/>
@@ -8732,10 +9074,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14m
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-100-65P-1400W-2000L-120H-EP">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AHA-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AHA-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-6.35" x2="-10" y2="-6" layer="51"/>
 <rectangle x1="-11" y1="-5.7" x2="-10" y2="-5.35" layer="51"/>
@@ -8773,30 +9115,51 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14m
 <rectangle x1="-5.7" y1="7" x2="-5.35" y2="8" layer="51"/>
 <rectangle x1="-5.05" y1="-8" x2="-4.7" y2="-7" layer="51"/>
 <rectangle x1="-5.05" y1="7" x2="-4.7" y2="8" layer="51"/>
+<rectangle x1="-5" y1="-3.5" x2="5" y2="3.5" layer="29"/>
+<rectangle x1="-4.8367" y1="-3.3571" x2="-3.1633" y2="-1.8929" layer="31"/>
+<rectangle x1="-4.8367" y1="-1.6071" x2="-3.1633" y2="-0.1429" layer="31"/>
+<rectangle x1="-4.8367" y1="0.1429" x2="-3.1633" y2="1.6071" layer="31"/>
+<rectangle x1="-4.8367" y1="1.8929" x2="-3.1633" y2="3.3571" layer="31"/>
 <rectangle x1="-4.4" y1="-8" x2="-4.05" y2="-7" layer="51"/>
 <rectangle x1="-4.4" y1="7" x2="-4.05" y2="8" layer="51"/>
 <rectangle x1="-3.75" y1="-8" x2="-3.4" y2="-7" layer="51"/>
 <rectangle x1="-3.75" y1="7" x2="-3.4" y2="8" layer="51"/>
 <rectangle x1="-3.1" y1="-8" x2="-2.75" y2="-7" layer="51"/>
 <rectangle x1="-3.1" y1="7" x2="-2.75" y2="8" layer="51"/>
+<rectangle x1="-2.8367" y1="-3.3571" x2="-1.1633" y2="-1.8929" layer="31"/>
+<rectangle x1="-2.8367" y1="-1.6071" x2="-1.1633" y2="-0.1429" layer="31"/>
+<rectangle x1="-2.8367" y1="0.1429" x2="-1.1633" y2="1.6071" layer="31"/>
+<rectangle x1="-2.8367" y1="1.8929" x2="-1.1633" y2="3.3571" layer="31"/>
 <rectangle x1="-2.45" y1="-8" x2="-2.1" y2="-7" layer="51"/>
 <rectangle x1="-2.45" y1="7" x2="-2.1" y2="8" layer="51"/>
 <rectangle x1="-1.8" y1="-8" x2="-1.45" y2="-7" layer="51"/>
 <rectangle x1="-1.8" y1="7" x2="-1.45" y2="8" layer="51"/>
 <rectangle x1="-1.15" y1="-8" x2="-0.8" y2="-7" layer="51"/>
 <rectangle x1="-1.15" y1="7" x2="-0.8" y2="8" layer="51"/>
+<rectangle x1="-0.8367" y1="-3.3571" x2="0.8367" y2="-1.8929" layer="31"/>
+<rectangle x1="-0.8367" y1="-1.6071" x2="0.8367" y2="-0.1429" layer="31"/>
+<rectangle x1="-0.8367" y1="0.1429" x2="0.8367" y2="1.6071" layer="31"/>
+<rectangle x1="-0.8367" y1="1.8929" x2="0.8367" y2="3.3571" layer="31"/>
 <rectangle x1="-0.5" y1="-8" x2="-0.15" y2="-7" layer="51"/>
 <rectangle x1="-0.5" y1="7" x2="-0.15" y2="8" layer="51"/>
 <rectangle x1="0.15" y1="-8" x2="0.5" y2="-7" layer="51"/>
 <rectangle x1="0.15" y1="7" x2="0.5" y2="8" layer="51"/>
 <rectangle x1="0.8" y1="-8" x2="1.15" y2="-7" layer="51"/>
 <rectangle x1="0.8" y1="7" x2="1.15" y2="8" layer="51"/>
+<rectangle x1="1.1633" y1="-3.3571" x2="2.8367" y2="-1.8929" layer="31"/>
+<rectangle x1="1.1633" y1="-1.6071" x2="2.8367" y2="-0.1429" layer="31"/>
+<rectangle x1="1.1633" y1="0.1429" x2="2.8367" y2="1.6071" layer="31"/>
+<rectangle x1="1.1633" y1="1.8929" x2="2.8367" y2="3.3571" layer="31"/>
 <rectangle x1="1.45" y1="-8" x2="1.8" y2="-7" layer="51"/>
 <rectangle x1="1.45" y1="7" x2="1.8" y2="8" layer="51"/>
 <rectangle x1="2.1" y1="-8" x2="2.45" y2="-7" layer="51"/>
 <rectangle x1="2.1" y1="7" x2="2.45" y2="8" layer="51"/>
 <rectangle x1="2.75" y1="-8" x2="3.1" y2="-7" layer="51"/>
 <rectangle x1="2.75" y1="7" x2="3.1" y2="8" layer="51"/>
+<rectangle x1="3.1633" y1="-3.3571" x2="4.8367" y2="-1.8929" layer="31"/>
+<rectangle x1="3.1633" y1="-1.6071" x2="4.8367" y2="-0.1429" layer="31"/>
+<rectangle x1="3.1633" y1="0.1429" x2="4.8367" y2="1.6071" layer="31"/>
+<rectangle x1="3.1633" y1="1.8929" x2="4.8367" y2="3.3571" layer="31"/>
 <rectangle x1="3.4" y1="-8" x2="3.75" y2="-7" layer="51"/>
 <rectangle x1="3.4" y1="7" x2="3.75" y2="8" layer="51"/>
 <rectangle x1="4.05" y1="-8" x2="4.4" y2="-7" layer="51"/>
@@ -8937,7 +9300,8 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14m
 <smd name="98" x="-10.9" y="-4.875" dx="1.5" dy="0.4" layer="1"/>
 <smd name="99" x="-10.9" y="-5.525" dx="1.5" dy="0.4" layer="1"/>
 <smd name="100" x="-10.9" y="-6.175" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="10" dy="7" layer="1"/><text x="-9.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="10.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-9.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-9.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-9.9" y1="-6.5" x2="-9.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-9.9" y1="6.9" x2="-9.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -8946,10 +9310,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 14m
 <wire x1="9.9" y1="6.9" x2="-9.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-112-65P-2000W-2000L-120H">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 112 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 112 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.95" x2="-10" y2="-8.6" layer="51"/>
 <rectangle x1="-11" y1="-8.3" x2="-10" y2="-7.95" layer="51"/>
@@ -9184,10 +9548,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-112-65P-2000W-2000L-120H-EP">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 112 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.20mm max height, 112 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.20mm max height, 112 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AFA-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AFA-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.95" x2="-10" y2="-8.6" layer="51"/>
 <rectangle x1="-11" y1="-8.3" x2="-10" y2="-7.95" layer="51"/>
@@ -9231,30 +9595,56 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20m
 <rectangle x1="-5.7" y1="10" x2="-5.35" y2="11" layer="51"/>
 <rectangle x1="-5.05" y1="-11" x2="-4.7" y2="-10" layer="51"/>
 <rectangle x1="-5.05" y1="10" x2="-4.7" y2="11" layer="51"/>
+<rectangle x1="-5" y1="-5" x2="5" y2="5" layer="29"/>
+<rectangle x1="-4.8367" y1="-4.8367" x2="-3.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-2.8367" x2="-3.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-4.8367" y1="-0.8367" x2="-3.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="1.1633" x2="-3.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-4.8367" y1="3.1633" x2="-3.1633" y2="4.8367" layer="31"/>
 <rectangle x1="-4.4" y1="-11" x2="-4.05" y2="-10" layer="51"/>
 <rectangle x1="-4.4" y1="10" x2="-4.05" y2="11" layer="51"/>
 <rectangle x1="-3.75" y1="-11" x2="-3.4" y2="-10" layer="51"/>
 <rectangle x1="-3.75" y1="10" x2="-3.4" y2="11" layer="51"/>
 <rectangle x1="-3.1" y1="-11" x2="-2.75" y2="-10" layer="51"/>
 <rectangle x1="-3.1" y1="10" x2="-2.75" y2="11" layer="51"/>
+<rectangle x1="-2.8367" y1="-4.8367" x2="-1.1633" y2="-3.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="3.1633" x2="-1.1633" y2="4.8367" layer="31"/>
 <rectangle x1="-2.45" y1="-11" x2="-2.1" y2="-10" layer="51"/>
 <rectangle x1="-2.45" y1="10" x2="-2.1" y2="11" layer="51"/>
 <rectangle x1="-1.8" y1="-11" x2="-1.45" y2="-10" layer="51"/>
 <rectangle x1="-1.8" y1="10" x2="-1.45" y2="11" layer="51"/>
 <rectangle x1="-1.15" y1="-11" x2="-0.8" y2="-10" layer="51"/>
 <rectangle x1="-1.15" y1="10" x2="-0.8" y2="11" layer="51"/>
+<rectangle x1="-0.8367" y1="-4.8367" x2="0.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="3.1633" x2="0.8367" y2="4.8367" layer="31"/>
 <rectangle x1="-0.5" y1="-11" x2="-0.15" y2="-10" layer="51"/>
 <rectangle x1="-0.5" y1="10" x2="-0.15" y2="11" layer="51"/>
 <rectangle x1="0.15" y1="-11" x2="0.5" y2="-10" layer="51"/>
 <rectangle x1="0.15" y1="10" x2="0.5" y2="11" layer="51"/>
 <rectangle x1="0.8" y1="-11" x2="1.15" y2="-10" layer="51"/>
 <rectangle x1="0.8" y1="10" x2="1.15" y2="11" layer="51"/>
+<rectangle x1="1.1633" y1="-4.8367" x2="2.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
+<rectangle x1="1.1633" y1="3.1633" x2="2.8367" y2="4.8367" layer="31"/>
 <rectangle x1="1.45" y1="-11" x2="1.8" y2="-10" layer="51"/>
 <rectangle x1="1.45" y1="10" x2="1.8" y2="11" layer="51"/>
 <rectangle x1="2.1" y1="-11" x2="2.45" y2="-10" layer="51"/>
 <rectangle x1="2.1" y1="10" x2="2.45" y2="11" layer="51"/>
 <rectangle x1="2.75" y1="-11" x2="3.1" y2="-10" layer="51"/>
 <rectangle x1="2.75" y1="10" x2="3.1" y2="11" layer="51"/>
+<rectangle x1="3.1633" y1="-4.8367" x2="4.8367" y2="-3.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-2.8367" x2="4.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="3.1633" y1="-0.8367" x2="4.8367" y2="0.8367" layer="31"/>
+<rectangle x1="3.1633" y1="1.1633" x2="4.8367" y2="2.8367" layer="31"/>
+<rectangle x1="3.1633" y1="3.1633" x2="4.8367" y2="4.8367" layer="31"/>
 <rectangle x1="3.4" y1="-11" x2="3.75" y2="-10" layer="51"/>
 <rectangle x1="3.4" y1="10" x2="3.75" y2="11" layer="51"/>
 <rectangle x1="4.05" y1="-11" x2="4.4" y2="-10" layer="51"/>
@@ -9413,7 +9803,8 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20m
 <smd name="110" x="-10.9" y="-7.475" dx="1.5" dy="0.4" layer="1"/>
 <smd name="111" x="-10.9" y="-8.125" dx="1.5" dy="0.4" layer="1"/>
 <smd name="112" x="-10.9" y="-8.775" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="10" dy="10" layer="1"/><text x="-9.5" y="-13" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="10.2" dy="10.2" layer="1" stop="no" cream="no"/>
+<text x="-9.5" y="-13" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-9.5" y="12" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-9.9" y1="-9.5" x2="-9.5" y2="-9.9" width="0.2032" layer="21"/>
 <wire x1="-9.9" y1="9.9" x2="-9.9" y2="-9.5" width="0.2032" layer="21"/>
@@ -9422,10 +9813,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-20-65P-400W-400L-120H">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.20mm max height, 20 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AKA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AKA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.1" y="-1.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3" y1="-1.475" x2="-2" y2="-1.125" layer="51"/>
 <rectangle x1="-3" y1="-0.825" x2="-2" y2="-0.475" layer="51"/>
@@ -9476,10 +9867,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm 
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-20-65P-400W-400L-120H-EP">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 4mm length, 4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm width, 1.20mm max height, 20 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AKA-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AKA-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.1" y="-1.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3" y1="-1.475" x2="-2" y2="-1.125" layer="51"/>
 <rectangle x1="-3" y1="-0.825" x2="-2" y2="-0.475" layer="51"/>
@@ -9488,6 +9879,8 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm 
 <rectangle x1="-3" y1="1.125" x2="-2" y2="1.475" layer="51"/>
 <rectangle x1="-1.475" y1="-3" x2="-1.125" y2="-2" layer="51"/>
 <rectangle x1="-1.475" y1="2" x2="-1.125" y2="3" layer="51"/>
+<rectangle x1="-1" y1="-1" x2="1" y2="1" layer="29"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
 <rectangle x1="-0.825" y1="-3" x2="-0.475" y2="-2" layer="51"/>
 <rectangle x1="-0.825" y1="2" x2="-0.475" y2="3" layer="51"/>
 <rectangle x1="-0.175" y1="-3" x2="0.175" y2="-2" layer="51"/>
@@ -9521,7 +9914,8 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm 
 <smd name="18" x="-2.9" y="0" dx="1.5" dy="0.4" layer="1"/>
 <smd name="19" x="-2.9" y="-0.65" dx="1.5" dy="0.4" layer="1"/>
 <smd name="20" x="-2.9" y="-1.3" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="2" dy="2" layer="1"/><text x="-1.5" y="-5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="2.2" dy="2.2" layer="1" stop="no" cream="no"/>
+<text x="-1.5" y="-5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-1.5" y="4" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-1.9" y1="-1.5" x2="-1.5" y2="-1.9" width="0.2032" layer="21"/>
 <wire x1="-1.9" y1="1.9" x2="-1.9" y2="-1.5" width="0.2032" layer="21"/>
@@ -9530,10 +9924,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 4mm length, 4mm 
 <wire x1="1.9" y1="1.9" x2="-1.9" y2="1.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-40-65P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 40 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3.1" x2="-3.5" y2="-2.75" layer="51"/>
 <rectangle x1="-4.5" y1="-2.45" x2="-3.5" y2="-2.1" layer="51"/>
@@ -9624,10 +10018,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-40-65P-700W-700L-120H-EP">
-<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.65mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 40 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 40 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABB-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABB-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3.1" x2="-3.5" y2="-2.75" layer="51"/>
 <rectangle x1="-4.5" y1="-2.45" x2="-3.5" y2="-2.1" layer="51"/>
@@ -9645,10 +10039,15 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm 
 <rectangle x1="-2.45" y1="3.5" x2="-2.1" y2="4.5" layer="51"/>
 <rectangle x1="-1.8" y1="-4.5" x2="-1.45" y2="-3.5" layer="51"/>
 <rectangle x1="-1.8" y1="3.5" x2="-1.45" y2="4.5" layer="51"/>
+<rectangle x1="-1.75" y1="-1.75" x2="1.75" y2="1.75" layer="29"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
 <rectangle x1="-1.15" y1="-4.5" x2="-0.8" y2="-3.5" layer="51"/>
 <rectangle x1="-1.15" y1="3.5" x2="-0.8" y2="4.5" layer="51"/>
 <rectangle x1="-0.5" y1="-4.5" x2="-0.15" y2="-3.5" layer="51"/>
 <rectangle x1="-0.5" y1="3.5" x2="-0.15" y2="4.5" layer="51"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
 <rectangle x1="0.15" y1="-4.5" x2="0.5" y2="-3.5" layer="51"/>
 <rectangle x1="0.15" y1="3.5" x2="0.5" y2="4.5" layer="51"/>
 <rectangle x1="0.8" y1="-4.5" x2="1.15" y2="-3.5" layer="51"/>
@@ -9709,7 +10108,8 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm 
 <smd name="38" x="-4.4" y="-1.625" dx="1.5" dy="0.4" layer="1"/>
 <smd name="39" x="-4.4" y="-2.275" dx="1.5" dy="0.4" layer="1"/>
 <smd name="40" x="-4.4" y="-2.925" dx="1.5" dy="0.4" layer="1"/>
-<smd name="EP" x="0" y="0" dx="3.5" dy="3.5" layer="1"/><text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="3.7" dy="3.7" layer="1" stop="no" cream="no"/>
+<text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3" y="5.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-3.4" y1="-3" x2="-3" y2="-3.4" width="0.2032" layer="21"/>
 <wire x1="-3.4" y1="3.4" x2="-3.4" y2="-3" width="0.2032" layer="21"/>
@@ -9718,10 +10118,10 @@ Thin profile Quad Flat Package. 0.65mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-44-80P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -9820,10 +10220,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-44-80P-1000W-1000L-120H-EP">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACB-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACB-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>
@@ -9842,14 +10242,24 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <rectangle x1="-3.4" y1="5" x2="-3" y2="6" layer="51"/>
 <rectangle x1="-2.6" y1="-6" x2="-2.2" y2="-5" layer="51"/>
 <rectangle x1="-2.6" y1="5" x2="-2.2" y2="6" layer="51"/>
+<rectangle x1="-2.5" y1="-2.5" x2="2.5" y2="2.5" layer="29"/>
+<rectangle x1="-2.3639" y1="-2.3639" x2="-0.9694" y2="-0.9694" layer="31"/>
+<rectangle x1="-2.3639" y1="-0.6972" x2="-0.9694" y2="0.6972" layer="31"/>
+<rectangle x1="-2.3639" y1="0.9694" x2="-0.9694" y2="2.3639" layer="31"/>
 <rectangle x1="-1.8" y1="-6" x2="-1.4" y2="-5" layer="51"/>
 <rectangle x1="-1.8" y1="5" x2="-1.4" y2="6" layer="51"/>
 <rectangle x1="-1" y1="-6" x2="-0.6" y2="-5" layer="51"/>
 <rectangle x1="-1" y1="5" x2="-0.6" y2="6" layer="51"/>
+<rectangle x1="-0.6972" y1="-2.3639" x2="0.6972" y2="-0.9694" layer="31"/>
+<rectangle x1="-0.6972" y1="-0.6972" x2="0.6972" y2="0.6972" layer="31"/>
+<rectangle x1="-0.6972" y1="0.9694" x2="0.6972" y2="2.3639" layer="31"/>
 <rectangle x1="-0.2" y1="-6" x2="0.2" y2="-5" layer="51"/>
 <rectangle x1="-0.2" y1="5" x2="0.2" y2="6" layer="51"/>
 <rectangle x1="0.6" y1="-6" x2="1" y2="-5" layer="51"/>
 <rectangle x1="0.6" y1="5" x2="1" y2="6" layer="51"/>
+<rectangle x1="0.9694" y1="-2.3639" x2="2.3639" y2="-0.9694" layer="31"/>
+<rectangle x1="0.9694" y1="-0.6972" x2="2.3639" y2="0.6972" layer="31"/>
+<rectangle x1="0.9694" y1="0.9694" x2="2.3639" y2="2.3639" layer="31"/>
 <rectangle x1="1.4" y1="-6" x2="1.8" y2="-5" layer="51"/>
 <rectangle x1="1.4" y1="5" x2="1.8" y2="6" layer="51"/>
 <rectangle x1="2.2" y1="-6" x2="2.6" y2="-5" layer="51"/>
@@ -9913,7 +10323,8 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <smd name="42" x="-5.9" y="-2.4" dx="1.5" dy="0.5" layer="1"/>
 <smd name="43" x="-5.9" y="-3.2" dx="1.5" dy="0.5" layer="1"/>
 <smd name="44" x="-5.9" y="-4" dx="1.5" dy="0.5" layer="1"/>
-<smd name="EP" x="0" y="0" dx="5" dy="5" layer="1"/><text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="5.2" dy="5.2" layer="1" stop="no" cream="no"/>
+<text x="-4.5" y="-8" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-4.5" y="7" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-4.9" y1="-4.5" x2="-4.5" y2="-4.9" width="0.2032" layer="21"/>
 <wire x1="-4.9" y1="4.9" x2="-4.9" y2="-4.5" width="0.2032" layer="21"/>
@@ -9922,10 +10333,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-52-80P-1200W-1200L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ADB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ADB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-5" x2="-6" y2="-4.6" layer="51"/>
 <rectangle x1="-7" y1="-4.2" x2="-6" y2="-3.8" layer="51"/>
@@ -10040,10 +10451,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-52-80P-1200W-1200L-120H-EP">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ADB-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ADB-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-5" x2="-6" y2="-4.6" layer="51"/>
 <rectangle x1="-7" y1="-4.2" x2="-6" y2="-3.8" layer="51"/>
@@ -10064,16 +10475,26 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12m
 <rectangle x1="-4.2" y1="6" x2="-3.8" y2="7" layer="51"/>
 <rectangle x1="-3.4" y1="-7" x2="-3" y2="-6" layer="51"/>
 <rectangle x1="-3.4" y1="6" x2="-3" y2="7" layer="51"/>
+<rectangle x1="-3" y1="-3" x2="3" y2="3" layer="29"/>
+<rectangle x1="-2.8367" y1="-2.8367" x2="-1.1633" y2="-1.1633" layer="31"/>
+<rectangle x1="-2.8367" y1="-0.8367" x2="-1.1633" y2="0.8367" layer="31"/>
+<rectangle x1="-2.8367" y1="1.1633" x2="-1.1633" y2="2.8367" layer="31"/>
 <rectangle x1="-2.6" y1="-7" x2="-2.2" y2="-6" layer="51"/>
 <rectangle x1="-2.6" y1="6" x2="-2.2" y2="7" layer="51"/>
 <rectangle x1="-1.8" y1="-7" x2="-1.4" y2="-6" layer="51"/>
 <rectangle x1="-1.8" y1="6" x2="-1.4" y2="7" layer="51"/>
 <rectangle x1="-1" y1="-7" x2="-0.6" y2="-6" layer="51"/>
 <rectangle x1="-1" y1="6" x2="-0.6" y2="7" layer="51"/>
+<rectangle x1="-0.8367" y1="-2.8367" x2="0.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="-0.8367" y1="-0.8367" x2="0.8367" y2="0.8367" layer="31"/>
+<rectangle x1="-0.8367" y1="1.1633" x2="0.8367" y2="2.8367" layer="31"/>
 <rectangle x1="-0.2" y1="-7" x2="0.2" y2="-6" layer="51"/>
 <rectangle x1="-0.2" y1="6" x2="0.2" y2="7" layer="51"/>
 <rectangle x1="0.6" y1="-7" x2="1" y2="-6" layer="51"/>
 <rectangle x1="0.6" y1="6" x2="1" y2="7" layer="51"/>
+<rectangle x1="1.1633" y1="-2.8367" x2="2.8367" y2="-1.1633" layer="31"/>
+<rectangle x1="1.1633" y1="-0.8367" x2="2.8367" y2="0.8367" layer="31"/>
+<rectangle x1="1.1633" y1="1.1633" x2="2.8367" y2="2.8367" layer="31"/>
 <rectangle x1="1.4" y1="-7" x2="1.8" y2="-6" layer="51"/>
 <rectangle x1="1.4" y1="6" x2="1.8" y2="7" layer="51"/>
 <rectangle x1="2.2" y1="-7" x2="2.6" y2="-6" layer="51"/>
@@ -10149,7 +10570,8 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12m
 <smd name="50" x="-6.9" y="-3.2" dx="1.5" dy="0.5" layer="1"/>
 <smd name="51" x="-6.9" y="-4" dx="1.5" dy="0.5" layer="1"/>
 <smd name="52" x="-6.9" y="-4.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="EP" x="0" y="0" dx="6" dy="6" layer="1"/><text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="6.2" dy="6.2" layer="1" stop="no" cream="no"/>
+<text x="-5.5" y="-9" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-5.5" y="8" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-5.9" y1="-5.5" x2="-5.5" y2="-5.9" width="0.2032" layer="21"/>
 <wire x1="-5.9" y1="5.9" x2="-5.9" y2="-5.5" width="0.2032" layer="21"/>
@@ -10158,10 +10580,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 12mm length, 12m
 <wire x1="5.9" y1="5.9" x2="-5.9" y2="5.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-80P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -10300,10 +10722,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-80P-1400W-1400L-120H-EP">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEB-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEB-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -10329,20 +10751,37 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14m
 <rectangle x1="-4.6" y1="7" x2="-4.2" y2="8" layer="51"/>
 <rectangle x1="-3.8" y1="-8" x2="-3.4" y2="-7" layer="51"/>
 <rectangle x1="-3.8" y1="7" x2="-3.4" y2="8" layer="51"/>
+<rectangle x1="-3.5" y1="-3.5" x2="3.5" y2="3.5" layer="29"/>
+<rectangle x1="-3.3571" y1="-3.3571" x2="-1.8929" y2="-1.8929" layer="31"/>
+<rectangle x1="-3.3571" y1="-1.6071" x2="-1.8929" y2="-0.1429" layer="31"/>
+<rectangle x1="-3.3571" y1="0.1429" x2="-1.8929" y2="1.6071" layer="31"/>
+<rectangle x1="-3.3571" y1="1.8929" x2="-1.8929" y2="3.3571" layer="31"/>
 <rectangle x1="-3" y1="-8" x2="-2.6" y2="-7" layer="51"/>
 <rectangle x1="-3" y1="7" x2="-2.6" y2="8" layer="51"/>
 <rectangle x1="-2.2" y1="-8" x2="-1.8" y2="-7" layer="51"/>
 <rectangle x1="-2.2" y1="7" x2="-1.8" y2="8" layer="51"/>
+<rectangle x1="-1.6071" y1="-3.3571" x2="-0.1429" y2="-1.8929" layer="31"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
+<rectangle x1="-1.6071" y1="1.8929" x2="-0.1429" y2="3.3571" layer="31"/>
 <rectangle x1="-1.4" y1="-8" x2="-1" y2="-7" layer="51"/>
 <rectangle x1="-1.4" y1="7" x2="-1" y2="8" layer="51"/>
 <rectangle x1="-0.6" y1="-8" x2="-0.2" y2="-7" layer="51"/>
 <rectangle x1="-0.6" y1="7" x2="-0.2" y2="8" layer="51"/>
+<rectangle x1="0.1429" y1="-3.3571" x2="1.6071" y2="-1.8929" layer="31"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
+<rectangle x1="0.1429" y1="1.8929" x2="1.6071" y2="3.3571" layer="31"/>
 <rectangle x1="0.2" y1="-8" x2="0.6" y2="-7" layer="51"/>
 <rectangle x1="0.2" y1="7" x2="0.6" y2="8" layer="51"/>
 <rectangle x1="1" y1="-8" x2="1.4" y2="-7" layer="51"/>
 <rectangle x1="1" y1="7" x2="1.4" y2="8" layer="51"/>
 <rectangle x1="1.8" y1="-8" x2="2.2" y2="-7" layer="51"/>
 <rectangle x1="1.8" y1="7" x2="2.2" y2="8" layer="51"/>
+<rectangle x1="1.8929" y1="-3.3571" x2="3.3571" y2="-1.8929" layer="31"/>
+<rectangle x1="1.8929" y1="-1.6071" x2="3.3571" y2="-0.1429" layer="31"/>
+<rectangle x1="1.8929" y1="0.1429" x2="3.3571" y2="1.6071" layer="31"/>
+<rectangle x1="1.8929" y1="1.8929" x2="3.3571" y2="3.3571" layer="31"/>
 <rectangle x1="2.6" y1="-8" x2="3" y2="-7" layer="51"/>
 <rectangle x1="2.6" y1="7" x2="3" y2="8" layer="51"/>
 <rectangle x1="3.4" y1="-8" x2="3.8" y2="-7" layer="51"/>
@@ -10433,7 +10872,8 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14m
 <smd name="62" x="-7.9" y="-4.4" dx="1.5" dy="0.5" layer="1"/>
 <smd name="63" x="-7.9" y="-5.2" dx="1.5" dy="0.5" layer="1"/>
 <smd name="64" x="-7.9" y="-6" dx="1.5" dy="0.5" layer="1"/>
-<smd name="EP" x="0" y="0" dx="7" dy="7" layer="1"/><text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="7.2" dy="7.2" layer="1" stop="no" cream="no"/>
+<text x="-6.5" y="-10" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-6.5" y="9" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-6.9" y1="-6.5" x2="-6.5" y2="-6.9" width="0.2032" layer="21"/>
 <wire x1="-6.9" y1="6.9" x2="-6.9" y2="-6.5" width="0.2032" layer="21"/>
@@ -10442,10 +10882,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14m
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-32-80P-700W-700L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABA, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3" x2="-3.5" y2="-2.6" layer="51"/>
 <rectangle x1="-4.5" y1="-2.2" x2="-3.5" y2="-1.8" layer="51"/>
@@ -10520,10 +10960,10 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <wire x1="3.4" y1="3.4" x2="-3.4" y2="3.4" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-32-80P-700W-700L-120H-EP">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.20mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.20mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ABA-HD, HT-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ABA-HD, HT-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3" x2="-3.5" y2="-2.6" layer="51"/>
 <rectangle x1="-4.5" y1="-2.2" x2="-3.5" y2="-1.8" layer="51"/>
@@ -10537,10 +10977,15 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <rectangle x1="-3" y1="3.5" x2="-2.6" y2="4.5" layer="51"/>
 <rectangle x1="-2.2" y1="-4.5" x2="-1.8" y2="-3.5" layer="51"/>
 <rectangle x1="-2.2" y1="3.5" x2="-1.8" y2="4.5" layer="51"/>
+<rectangle x1="-1.75" y1="-1.75" x2="1.75" y2="1.75" layer="29"/>
+<rectangle x1="-1.6071" y1="-1.6071" x2="-0.1429" y2="-0.1429" layer="31"/>
+<rectangle x1="-1.6071" y1="0.1429" x2="-0.1429" y2="1.6071" layer="31"/>
 <rectangle x1="-1.4" y1="-4.5" x2="-1" y2="-3.5" layer="51"/>
 <rectangle x1="-1.4" y1="3.5" x2="-1" y2="4.5" layer="51"/>
 <rectangle x1="-0.6" y1="-4.5" x2="-0.2" y2="-3.5" layer="51"/>
 <rectangle x1="-0.6" y1="3.5" x2="-0.2" y2="4.5" layer="51"/>
+<rectangle x1="0.1429" y1="-1.6071" x2="1.6071" y2="-0.1429" layer="31"/>
+<rectangle x1="0.1429" y1="0.1429" x2="1.6071" y2="1.6071" layer="31"/>
 <rectangle x1="0.2" y1="-4.5" x2="0.6" y2="-3.5" layer="51"/>
 <rectangle x1="0.2" y1="3.5" x2="0.6" y2="4.5" layer="51"/>
 <rectangle x1="1" y1="-4.5" x2="1.4" y2="-3.5" layer="51"/>
@@ -10589,7 +11034,8 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm 
 <smd name="30" x="-4.4" y="-1.2" dx="1.5" dy="0.5" layer="1"/>
 <smd name="31" x="-4.4" y="-2" dx="1.5" dy="0.5" layer="1"/>
 <smd name="32" x="-4.4" y="-2.8" dx="1.5" dy="0.5" layer="1"/>
-<smd name="EP" x="0" y="0" dx="3.5" dy="3.5" layer="1"/><text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<smd name="EP" x="0" y="0" dx="3.7" dy="3.7" layer="1" stop="no" cream="no"/>
+<text x="-3" y="-6.5" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-3" y="5.5" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <wire x1="-3.4" y1="-3" x2="-3" y2="-3.4" width="0.2032" layer="21"/>
 <wire x1="-3.4" y1="3.4" x2="-3.4" y2="-3" width="0.2032" layer="21"/>

--- a/rf-micro-devices.lbr
+++ b/rf-micro-devices.lbr
@@ -79,10 +79,10 @@ http://www.rfmd.com&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
 <package name="LQFP-32-50P-500W-500L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 5mm length, 5mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm width, 1.60mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BAA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BAA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-1.6" y="-1.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-3.5" y1="-1.875" x2="-2.5" y2="-1.625" layer="51"/>
 <rectangle x1="-3.5" y1="-1.375" x2="-2.5" y2="-1.125" layer="51"/>

--- a/silicon-labs.lbr
+++ b/silicon-labs.lbr
@@ -77,10 +77,10 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2008, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
 <package name="TQFP-100-50P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AED, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AED, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -348,10 +348,10 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <rectangle x1="0.75" y1="-1.25" x2="1.25" y2="-0.75" layer="31"/>
 </package>
 <package name="LQFP-32-80P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3" x2="-3.5" y2="-2.6" layer="51"/>
 <rectangle x1="-4.5" y1="-2.2" x2="-3.5" y2="-1.8" layer="51"/>

--- a/st-microelectronics.lbr
+++ b/st-microelectronics.lbr
@@ -518,10 +518,10 @@ http://www.st.com&lt;p&gt;
 </polygon>
 </package>
 <package name="LQFP-144-50P-2000W-2000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>
@@ -918,10 +918,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm
 <rectangle x1="-13.5801" y1="6.54" x2="-13.0899" y2="8.0599" layer="51"/>
 </package>
 <package name="QFP-144-65P-2800W-2800L-410H-160F">
-<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (0.65mm pitch, 1.6mm lead length, 28mm length, 28mm width, 4.10mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 0.65mm pitch, 1.6mm lead length 28mm length, 28mm width, 4.10mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-022B, variation DC-1, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation DC-1, PQFP-G.&lt;/p&gt;</description>
 <circle x="-13.1" y="-13.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-15.6" y1="-11.56" x2="-14" y2="-11.19" layer="51"/>
 <rectangle x1="-15.6" y1="-10.91" x2="-14" y2="-10.54" layer="51"/>
@@ -1702,10 +1702,10 @@ JEDEC MO-142D, variation DD, R-PDSO-G.&lt;/p&gt;
 <wire x1="5.9" y1="9.1" x2="-5.9" y2="9.1" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-44-80P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>

--- a/texas.lbr
+++ b/texas.lbr
@@ -2203,10 +2203,10 @@ body 14x14 mm, pitch 0.8 mm</description>
 <rectangle x1="1" y1="-2" x2="2" y2="-1" layer="31"/>
 </package>
 <package name="TQFP-64-80P-1400W-1400L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.20mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation AEB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.2" x2="-7" y2="-5.8" layer="51"/>
 <rectangle x1="-8" y1="-5.4" x2="-7" y2="-5" layer="51"/>
@@ -3779,10 +3779,10 @@ Quad Flat Package, 0.50 mm Pitch&lt;br&gt;</description>
 <text x="-2.5" y="-4" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="LQFP-32-80P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.80mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 32 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBA, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-3" x2="-3.5" y2="-2.6" layer="51"/>
 <rectangle x1="-4.5" y1="-2.2" x2="-3.5" y2="-1.8" layer="51"/>

--- a/ti-dsp.lbr
+++ b/ti-dsp.lbr
@@ -73,10 +73,10 @@
 <library>
 <packages>
 <package name="LQFP-144-50P-2000W-2000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>

--- a/ti-tiva.lbr
+++ b/ti-tiva.lbr
@@ -107,10 +107,10 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2013, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;&lt;p&gt;</description>
 <packages>
 <package name="LQFP-100-50P-1400W-1400L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 14mm length, 14mm width, 1.60mm max height, 100 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm width, 1.60mm max height, 100 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BED, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BED, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8" y1="-6.125" x2="-7" y2="-5.875" layer="51"/>
 <rectangle x1="-8" y1="-5.625" x2="-7" y2="-5.375" layer="51"/>
@@ -321,10 +321,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-64-50P-1000W-1000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.60mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.60mm max height, 64 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BCD, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-3.875" x2="-5" y2="-3.625" layer="51"/>
 <rectangle x1="-6" y1="-3.375" x2="-5" y2="-3.125" layer="51"/>
@@ -463,10 +463,10 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 10mm length, 10mm
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
 <package name="LQFP-144-50P-2000W-2000L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 20mm length, 20mm width, 1.60mm max height, 144 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20mm width, 1.60mm max height, 144 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BFB, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-9.1" y="-9.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-11" y1="-8.875" x2="-10" y2="-8.625" layer="51"/>
 <rectangle x1="-11" y1="-8.375" x2="-10" y2="-8.125" layer="51"/>

--- a/vlsi-solution.lbr
+++ b/vlsi-solution.lbr
@@ -78,10 +78,10 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2010, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
 <package name="LQFP-48-50P-700W-700L-160H">
-<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;LQFP (0.50mm pitch, 1.0mm lead length, 7mm length, 7mm width, 1.60mm max height, 48 leads)&lt;/b&gt;&lt;p&gt;
 Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm width, 1.60mm max height, 48 leads.
-&lt;p/&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation BBC, L-PQFP-G.&lt;/p&gt;</description>
 <circle x="-2.6" y="-2.6" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.5" y1="-2.875" x2="-3.5" y2="-2.625" layer="51"/>
 <rectangle x1="-4.5" y1="-2.375" x2="-3.5" y2="-2.125" layer="51"/>

--- a/wafer-scale-psd.lbr
+++ b/wafer-scale-psd.lbr
@@ -371,10 +371,10 @@ square</description>
 <text x="-2.54" y="10.541" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
 <package name="QFP-52-100P-1400W-1400L-245H-160F">
-<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;QFP (1.00mm pitch, 1.6mm lead length, 14mm length, 14mm width, 2.45mm max height, 52 leads)&lt;/b&gt;&lt;p&gt;
 Metric quad flat package. 1.00mm pitch, 1.6mm lead length 14mm length, 14mm width, 2.45mm max height, 52 leads.
-&lt;p/&gt;JEDEC MS-022B, variation BA, PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-022B, variation BA, PQFP-G.&lt;/p&gt;</description>
 <circle x="-6.1" y="-6.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-8.6" y1="-6.225" x2="-7" y2="-5.775" layer="21"/>
 <rectangle x1="-8.6" y1="-5.225" x2="-7" y2="-4.775" layer="21"/>
@@ -1352,10 +1352,10 @@ square</description>
 <rectangle x1="9.78" y1="-12.57" x2="10.54" y2="-12.1" layer="51"/>
 </package>
 <package name="TQFP-80-50P-1200W-1200L-120H">
-<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 12mm length, 12mm width, 1.20mm max height, 80 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 12mm length, 12mm width, 1.20mm max height, 80 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ADD, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ADD, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-5.1" y="-5.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7" y1="-4.875" x2="-6" y2="-4.625" layer="51"/>
 <rectangle x1="-7" y1="-4.375" x2="-6" y2="-4.125" layer="51"/>
@@ -1817,10 +1817,10 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 52 leads.
 <wire x1="12.7" y1="12.7" x2="-11.43" y2="12.7" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-44-80P-1000W-1000L-120H">
-<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p/&gt;
+<description>&lt;b&gt;TQFP (0.80mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 44 leads)&lt;/b&gt;&lt;p&gt;
 Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10mm width, 1.20mm max height, 44 leads.
-&lt;p/&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.
-</description>
+&lt;/p&gt;
+&lt;p&gt;JEDEC MS-026D, variation ACB, T-PQFP-G.&lt;/p&gt;</description>
 <circle x="-4.1" y="-4.1" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6" y1="-4.2" x2="-5" y2="-3.8" layer="51"/>
 <rectangle x1="-6" y1="-3.4" x2="-5" y2="-3" layer="51"/>


### PR DESCRIPTION
 - Improved solder paste stencil pattern for exposed pads in QFP packages. The exposed pad is now properly solder mask defined in all cases, the paste pattern is cross-hatch with 70% coverage.
 - Minor changes to description of QFP packages
 - Synchronized all libraries with the QFP reference packages