### PR TITLE
ref-packages-soic: Rename SOP packages to the more common SOIC naming

### DIFF
--- a/40xx.lbr
+++ b/40xx.lbr
@@ -81,9 +81,9 @@ Based on the following sources:
 &lt;/ul&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -106,20 +106,20 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-530W-1030L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-16-127P-530W-1030L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-4.25" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.645" y1="-3.9" x2="-4.245" y2="-2.65" layer="51"/>
 <rectangle x1="-4.645" y1="2.65" x2="-4.245" y2="3.9" layer="51"/>
@@ -428,9 +428,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -465,18 +465,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -539,9 +539,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -580,14 +580,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -2164,7 +2164,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="3"/>
 <connect gate="A" pin="D1" pad="1"/>
@@ -2213,7 +2213,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="1A" pad="3"/>
 <connect gate="A" pin="1DN" pad="5"/>
@@ -2266,7 +2266,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="7"/>
 <connect gate="A" pin="A2" pad="5"/>
@@ -2324,7 +2324,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -2380,7 +2380,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -2432,7 +2432,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="2"/>
 <connect gate="A" pin="CLK" pad="3"/>
@@ -2485,7 +2485,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="10"/>
 <connect gate="A" pin="P/!S" pad="9"/>
@@ -2541,7 +2541,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="D" pad="15"/>
@@ -2597,7 +2597,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -2650,7 +2650,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="14"/>
 <connect gate="A" pin="CO" pad="12"/>
@@ -2705,7 +2705,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="14"/>
 <connect gate="A" pin="D" pad="1"/>
@@ -2760,7 +2760,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="6"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -2815,7 +2815,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="P1" pad="10"/>
 <connect gate="A" pin="Q1" pad="9"/>
@@ -2868,7 +2868,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="14"/>
 <connect gate="A" pin="CLR" pad="13"/>
@@ -2916,7 +2916,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="Q1" pad="12"/>
@@ -2966,7 +2966,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -3022,7 +3022,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="2"/>
 <connect gate="A" pin="CLK" pad="3"/>
@@ -3077,7 +3077,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="13"/>
@@ -3132,7 +3132,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B/!D" pad="9"/>
 <connect gate="A" pin="CI" pad="5"/>
@@ -3180,7 +3180,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="7"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -3228,7 +3228,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="10"/>
 <connect gate="A" pin="A2" pad="13"/>
@@ -3283,7 +3283,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -3346,7 +3346,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A/!B" pad="11"/>
 <connect gate="A" pin="A/!S" pad="14"/>
@@ -3409,7 +3409,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="6"/>
 <connect gate="A" pin="J" pad="4"/>
@@ -3464,7 +3464,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="10"/>
 <connect gate="A" pin="A2" pad="13"/>
@@ -3519,7 +3519,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="P1" pad="10"/>
 <connect gate="A" pin="Q1" pad="9"/>
@@ -3572,7 +3572,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!QA" pad="2"/>
 <connect gate="A" pin="!QB" pad="5"/>
@@ -3625,7 +3625,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q0" pad="3"/>
 <connect gate="A" pin="!Q1" pad="9"/>
@@ -3679,7 +3679,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="EN" pad="5"/>
 <connect gate="A" pin="Q0" pad="2"/>
@@ -3732,7 +3732,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="EN" pad="5"/>
 <connect gate="A" pin="Q0" pad="13"/>
@@ -3786,7 +3786,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CIN" pad="3"/>
 <connect gate="A" pin="CX@1" pad="6"/>
@@ -3839,7 +3839,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!AST" pad="4"/>
 <connect gate="A" pin="!Q" pad="11"/>
@@ -3892,7 +3892,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="14"/>
 <connect gate="A" pin="B" pad="13"/>
@@ -3947,7 +3947,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="M" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -3993,7 +3993,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SJ" package="SOP-16-127P-530W-1030L-210H-125F">
+<device name="SJ" package="SOIC-16-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -4048,7 +4048,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -4103,7 +4103,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -4158,7 +4158,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -4213,7 +4213,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -4268,7 +4268,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!P0" pad="10"/>
 <connect gate="A" pin="P0" pad="9"/>
@@ -4323,7 +4323,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="10"/>
 <connect gate="A" pin="A1" pad="12"/>
@@ -4373,7 +4373,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -4426,7 +4426,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4500,7 +4500,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="CLR" pad="15"/>
@@ -4555,7 +4555,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!OUT" pad="5"/>
 <connect gate="A" pin="15" pad="1"/>
@@ -4610,7 +4610,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="3"/>
 <connect gate="A" pin="D" pad="2"/>
@@ -4662,7 +4662,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -4711,7 +4711,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -4763,7 +4763,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="5"/>
 <connect gate="A" pin="A1" pad="6"/>
@@ -4818,7 +4818,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="10"/>
 <connect gate="A" pin="P/!S" pad="9"/>
@@ -4876,7 +4876,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4953,7 +4953,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="3"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -5028,7 +5028,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -5089,7 +5089,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -5160,7 +5160,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -5224,7 +5224,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5274,7 +5274,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5326,7 +5326,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5376,7 +5376,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5427,7 +5427,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5480,7 +5480,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5534,7 +5534,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5588,7 +5588,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5638,7 +5638,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5689,7 +5689,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5742,7 +5742,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5796,7 +5796,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5844,7 +5844,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5895,7 +5895,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -5945,7 +5945,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -5997,7 +5997,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -6051,7 +6051,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -6107,7 +6107,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -6158,7 +6158,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="3"/>
 <connect gate="A" pin="I1" pad="4"/>
@@ -6209,7 +6209,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLEAR#" pad="1"/>
 <connect gate="G$1" pin="CLK" pad="2"/>
@@ -6264,7 +6264,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLEAR#" pad="1"/>
 <connect gate="G$1" pin="CLK" pad="2"/>
@@ -6319,7 +6319,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLEAR#" pad="1"/>
 <connect gate="G$1" pin="CLK" pad="2"/>
@@ -6374,7 +6374,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLEAR#" pad="1"/>
 <connect gate="G$1" pin="CLK" pad="2"/>
@@ -6429,7 +6429,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="9"/>
 <connect gate="G$1" pin="D0" pad="3"/>
@@ -6484,7 +6484,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!Q0" pad="3"/>
 <connect gate="G$1" pin="!Q01" pad="6"/>
@@ -6539,7 +6539,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="11"/>
 <connect gate="G$1" pin="DP0" pad="3"/>
@@ -6594,7 +6594,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="1"/>
 <connect gate="G$1" pin="DIS#" pad="10"/>
@@ -6649,7 +6649,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="AIN" pad="1"/>
 <connect gate="G$1" pin="AO" pad="15"/>
@@ -6704,7 +6704,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="15"/>
 <connect gate="G$1" pin="B" pad="1"/>
@@ -6762,7 +6762,7 @@ Low-to-High, Quad</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="SOP-16-127P-530W-1030L-210H-125F">
+<device name="NS" package="SOIC-16-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="A" pin="EN" pad="2"/>
 <connect gate="A" pin="I" pad="3"/>
@@ -6878,7 +6878,7 @@ Source: www.standardics.nxp.com/products/hc/datasheet/74hc4059.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CP" pad="1"/>
 <connect gate="G$1" pin="EL" pad="2"/>
@@ -6919,7 +6919,7 @@ Source: www.standardics.nxp.com/products/hc/datasheet/74hc4059.pdf</description>
 <gate name="P" symbol="PWRN" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>

--- a/41xx.lbr
+++ b/41xx.lbr
@@ -102,9 +102,9 @@
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -143,14 +143,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -281,7 +281,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SO" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!CL!" pad="1"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -336,7 +336,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SO" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="D0" pad="3"/>
@@ -391,7 +391,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SO" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q0!" pad="3"/>
 <connect gate="A" pin="!Q1!" pad="6"/>
@@ -446,7 +446,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SO" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="D0" pad="3"/>
@@ -501,7 +501,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SO" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!CL!" pad="1"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -556,7 +556,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SO" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!CL!" pad="1"/>
 <connect gate="A" pin="CLK" pad="2"/>
@@ -611,7 +611,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SO" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!CL!" pad="1"/>
 <connect gate="A" pin="CLK" pad="2"/>

--- a/45xx.lbr
+++ b/45xx.lbr
@@ -200,9 +200,9 @@ Based on the following sources:
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -237,18 +237,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -287,18 +287,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1673,7 +1673,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -1728,7 +1728,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="3"/>
 <connect gate="A" pin="D2" pad="6"/>
@@ -1783,7 +1783,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="DA" pad="1"/>
 <connect gate="A" pin="DB" pad="15"/>
@@ -1838,7 +1838,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="AI" pad="3"/>
 <connect gate="A" pin="AO" pad="2"/>
@@ -1893,7 +1893,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="AA" pad="1"/>
 <connect gate="A" pin="AB" pad="9"/>
@@ -1957,7 +1957,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="D0" pad="4"/>
 <connect gate="A" pin="D1" pad="6"/>
@@ -2020,7 +2020,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CIN" pad="5"/>
 <connect gate="A" pin="CLK" pad="15"/>
@@ -2075,7 +2075,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -2131,7 +2131,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -2228,7 +2228,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="2"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -2299,7 +2299,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="2"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -2362,7 +2362,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CIN" pad="5"/>
 <connect gate="A" pin="CLK" pad="15"/>
@@ -2418,7 +2418,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="4"/>
 <connect gate="A" pin="D" pad="7"/>
@@ -2474,7 +2474,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="EN" pad="2"/>
@@ -2529,7 +2529,7 @@ Inhibit function corrected - 2005.10.04 librarian@cadsoft.de&lt;br&gt;</descript
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -2586,7 +2586,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="01" pad="7"/>
 <connect gate="A" pin="02" pad="4"/>
@@ -2641,7 +2641,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="&quot;0&quot;" pad="12"/>
 <connect gate="A" pin="CF" pad="13"/>
@@ -2696,7 +2696,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!OUT" pad="5"/>
 <connect gate="A" pin="&quot;9&quot;" pad="1"/>
@@ -2751,7 +2751,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="6"/>
 <connect gate="A" pin="B" pad="7"/>
@@ -2807,7 +2807,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -2862,7 +2862,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D0" pad="7"/>
 <connect gate="A" pin="D1" pad="6"/>
@@ -2917,7 +2917,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D0" pad="10"/>
 <connect gate="A" pin="D1" pad="11"/>
@@ -2980,7 +2980,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="3SC" pad="21"/>
 <connect gate="A" pin="3SDC" pad="15"/>
@@ -3043,7 +3043,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="8BYP" pad="6"/>
 <connect gate="A" pin="A" pad="9"/>
@@ -3098,7 +3098,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="14"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -3149,7 +3149,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="12"/>
 <connect gate="A" pin="AR" pad="5"/>
@@ -3200,7 +3200,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="9"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -3287,7 +3287,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -3340,7 +3340,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="D" pad="6"/>
@@ -3395,7 +3395,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CTL" pad="9"/>
 <connect gate="A" pin="W" pad="14"/>
@@ -3450,7 +3450,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CIA" pad="4"/>
 <connect gate="A" pin="CIB" pad="3"/>
@@ -3505,7 +3505,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CO" pad="4"/>
 <connect gate="A" pin="K0" pad="12"/>
@@ -3561,7 +3561,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -3617,7 +3617,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -3672,7 +3672,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!CE" pad="5"/>
 <connect gate="A" pin="!Q" pad="11"/>
@@ -3727,7 +3727,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="13"/>
 <connect gate="A" pin="B" pad="12"/>
@@ -3782,7 +3782,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="D" pad="6"/>
@@ -3837,7 +3837,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="15"/>
 <connect gate="A" pin="A2" pad="1"/>
@@ -3889,7 +3889,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!COM" pad="6"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -3937,7 +3937,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="5"/>
 <connect gate="A" pin="D" pad="12"/>
@@ -3988,7 +3988,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="5/!6" pad="11"/>
 <connect gate="A" pin="A" pad="9"/>
@@ -4043,7 +4043,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="&quot;0&quot;" pad="3"/>
 <connect gate="A" pin="C1" pad="9"/>
@@ -4098,7 +4098,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CF" pad="7"/>
 <connect gate="A" pin="CLK" pad="9"/>
@@ -4158,7 +4158,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="1"/>
@@ -4221,7 +4221,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="3SA" pad="3"/>
 <connect gate="A" pin="3SB" pad="21"/>
@@ -4292,7 +4292,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="2"/>
 <connect gate="A" pin="A1" pad="23"/>
@@ -4355,7 +4355,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CIN" pad="13"/>
 <connect gate="A" pin="CN+X" pad="12"/>
@@ -4410,7 +4410,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A0" pad="11"/>
 <connect gate="A" pin="!B0" pad="12"/>
@@ -4465,7 +4465,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="10"/>
 <connect gate="A" pin="A1" pad="7"/>
@@ -4520,7 +4520,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="3"/>
 <connect gate="A" pin="D0" pad="1"/>
@@ -4643,7 +4643,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="EN" pad="2"/>
@@ -4698,7 +4698,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="&quot;0&quot;" pad="12"/>
 <connect gate="A" pin="CF" pad="13"/>
@@ -4754,7 +4754,7 @@ Source: http://www.standardics.nxp.com/products/hef/datasheet/hef4521b.pdf</desc
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="7"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -4811,7 +4811,7 @@ Dual precision monostable</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="7"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -4869,7 +4869,7 @@ Dual precision monostable</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -4922,7 +4922,7 @@ Dual precision monostable</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="DATA" pad="3"/>
 <connect gate="G$1" pin="FLAGF" pad="9"/>

--- a/65LV.lbr
+++ b/65LV.lbr
@@ -164,9 +164,9 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <text x="1.5" y="-0.75" size="0.4064" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 <rectangle x1="-1" y1="-0.75" x2="-0.75" y2="-0.5" layer="21" rot="R90"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -189,14 +189,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -253,7 +253,7 @@ HIGH-SPEED</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="D" pad="2"/>
 <connect gate="G$1" pin="GND" pad="4"/>

--- a/74CB.lbr
+++ b/74CB.lbr
@@ -79,9 +79,9 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2013, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -363,9 +363,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <wire x1="2.6" y1="-2" x2="2.6" y2="2" width="0.2032" layer="21"/>
 <wire x1="2.6" y1="2" x2="-2.6" y2="2" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -404,14 +404,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -478,7 +478,7 @@ Source: &lt;href&gt;http://www.ti.com/lit/ds/symlink/sn74cb3t3245.pdf</descripti
 <gate name="A" symbol="74CB3T3245" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!OE!" pad="19"/>
 <connect gate="A" pin="A1" pad="2"/>
@@ -617,7 +617,7 @@ Source: &lt;href&gt;http://www.ti.com/lit/ds/symlink/sn74cb3t3245.pdf</descripti
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="15"/>
 <connect gate="G$1" pin="1A" pad="4"/>

--- a/74VHCT.lbr
+++ b/74VHCT.lbr
@@ -76,9 +76,9 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2014, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -113,14 +113,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SSOP-14-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
@@ -215,7 +215,7 @@ LSTTL−Compatible Inputs</description>
 <gate name="P" symbol="PWRN" x="-25.4" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -271,7 +271,7 @@ LSTTL−Compatible Inputs</description>
 <gate name="P" symbol="PWRN" x="-25.4" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="M" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="M" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>

--- a/74ac-logic.lbr
+++ b/74ac-logic.lbr
@@ -390,9 +390,9 @@ Based on the following source:
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -427,18 +427,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -493,9 +493,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -558,9 +558,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -631,9 +631,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -672,14 +672,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -2515,7 +2515,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2573,7 +2573,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2635,7 +2635,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="I" pad="20"/>
 <connect gate="A" pin="O" pad="1"/>
@@ -2695,7 +2695,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2752,7 +2752,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2809,7 +2809,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -2861,7 +2861,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="1"/>
@@ -2909,7 +2909,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="1"/>
@@ -2962,7 +2962,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="16"/>
@@ -3012,7 +3012,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="3"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -3065,7 +3065,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I1" pad="1"/>
 <connect gate="A" pin="I2" pad="16"/>
@@ -3127,7 +3127,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="I" pad="20"/>
 <connect gate="A" pin="O" pad="1"/>
@@ -3183,7 +3183,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="3"/>
 <connect gate="A" pin="CL" pad="12"/>
@@ -3237,7 +3237,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="3"/>
 <connect gate="A" pin="CL" pad="13"/>
@@ -3291,7 +3291,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="3"/>
 <connect gate="A" pin="CL" pad="13"/>
@@ -3344,7 +3344,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -3400,7 +3400,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -3455,7 +3455,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="6"/>
 <connect gate="A" pin="B" pad="7"/>
@@ -3510,7 +3510,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="16"/>
 <connect gate="A" pin="1C1" pad="15"/>
@@ -3569,7 +3569,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="20"/>
@@ -3632,7 +3632,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="20"/>
@@ -3695,7 +3695,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="18"/>
 <connect gate="A" pin="B" pad="17"/>
@@ -3758,7 +3758,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="CLR" pad="20"/>
@@ -3821,7 +3821,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!Q1!" pad="1"/>
 <connect gate="A" pin="!Q2!" pad="3"/>
@@ -3891,7 +3891,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="28"/>
 <connect gate="A" pin="A1" pad="27"/>
@@ -3961,7 +3961,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="18"/>
 <connect gate="A" pin="B" pad="17"/>
@@ -4024,7 +4024,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="18"/>
 <connect gate="A" pin="B" pad="17"/>
@@ -4087,7 +4087,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="18"/>
 <connect gate="A" pin="B" pad="17"/>
@@ -4146,7 +4146,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -4202,7 +4202,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -4266,7 +4266,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="23"/>
 <connect gate="A" pin="A2" pad="22"/>
@@ -4333,7 +4333,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="1A1" pad="23"/>
 <connect gate="A" pin="1A2" pad="22"/>
@@ -4400,7 +4400,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="1A1" pad="23"/>
 <connect gate="A" pin="1A2" pad="22"/>
@@ -4471,7 +4471,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A2" pad="2"/>
@@ -4534,7 +4534,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="6"/>
 <connect gate="A" pin="B" pad="7"/>
@@ -4589,7 +4589,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="16"/>
 <connect gate="A" pin="1C1" pad="15"/>
@@ -4648,7 +4648,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="20"/>
@@ -4711,7 +4711,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="20"/>
@@ -4767,7 +4767,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="P" pin="GND" pad="4"/>
 <connect gate="P" pin="VCC" pad="11"/>
@@ -4817,7 +4817,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -4878,7 +4878,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A/QA" pad="1"/>
 <connect gate="A" pin="B/QB" pad="2"/>
@@ -4941,7 +4941,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="16"/>
 <connect gate="A" pin="1C1" pad="15"/>
@@ -4996,7 +4996,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="16"/>
 <connect gate="A" pin="1C1" pad="15"/>
@@ -5059,7 +5059,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="D0" pad="23"/>
 <connect gate="A" pin="D1" pad="22"/>
@@ -5130,7 +5130,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="13"/>
 <connect gate="A" pin="D0" pad="23"/>
@@ -5197,7 +5197,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!Q1!" pad="1"/>
 <connect gate="A" pin="!Q2!" pad="3"/>
@@ -5260,7 +5260,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="G" pad="20"/>
 <connect gate="A" pin="P0" pad="4"/>
@@ -5327,7 +5327,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="C" pad="13"/>
 <connect gate="A" pin="D1" pad="23"/>
@@ -5398,7 +5398,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="13"/>
 <connect gate="A" pin="D1" pad="23"/>
@@ -5469,7 +5469,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A2" pad="2"/>
@@ -5544,7 +5544,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -5623,7 +5623,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -5702,7 +5702,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="15"/>
 <connect gate="A" pin="CLKEN" pad="16"/>
@@ -5781,7 +5781,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="15"/>
 <connect gate="A" pin="CLKEN" pad="16"/>
@@ -5860,7 +5860,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="15"/>
 <connect gate="A" pin="CLKEN" pad="16"/>
@@ -5939,7 +5939,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="27"/>
 <connect gate="A" pin="A10" pad="16"/>
@@ -6018,7 +6018,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -6097,7 +6097,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="1"/>
 <connect gate="A" pin="A10" pad="14"/>
@@ -6175,7 +6175,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="CN" pad="3"/>
 <connect gate="A" pin="CN+16" pad="5"/>
@@ -6253,7 +6253,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="P" pin="GND@1" pad="6"/>
 <connect gate="P" pin="GND@2" pad="7"/>
@@ -6332,7 +6332,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -6411,7 +6411,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -6491,7 +6491,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="C" pad="1"/>
 <connect gate="A" pin="CLR" pad="27"/>
@@ -6571,7 +6571,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="1"/>
 <connect gate="A" pin="CLR" pad="27"/>
@@ -6650,7 +6650,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="28"/>
 <connect gate="G$1" pin="A1" pad="27"/>

--- a/74xx-eu.lbr
+++ b/74xx-eu.lbr
@@ -675,9 +675,9 @@ Thin shrink small outline transistor package (SSOT). 0.95mm pitch, 1.6mm body wi
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -712,18 +712,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -778,9 +778,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -843,9 +843,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -884,14 +884,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -8472,7 +8472,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -8567,7 +8567,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -8653,7 +8653,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -8711,7 +8711,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -8797,7 +8797,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -8975,7 +8975,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="1A" pad="1"/>
 <connect gate="A" pin="1B" pad="12"/>
@@ -9048,7 +9048,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -9204,7 +9204,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="11"/>
@@ -9366,7 +9366,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="13"/>
 <connect gate="A" pin="CL" pad="2"/>
@@ -9423,7 +9423,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="3"/>
@@ -9510,7 +9510,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q1" pad="1"/>
 <connect gate="A" pin="!Q2" pad="14"/>
@@ -9570,7 +9570,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="14"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -9623,7 +9623,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="12C" pad="12"/>
 <connect gate="A" pin="1D" pad="1"/>
@@ -9768,7 +9768,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="10"/>
 <connect gate="A" pin="A1" pad="12"/>
@@ -9849,7 +9849,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -9918,7 +9918,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -9963,7 +9963,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -10045,7 +10045,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -10100,7 +10100,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B0" pad="4"/>
 <connect gate="A" pin="B1" pad="1"/>
@@ -10194,7 +10194,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="2"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -10255,7 +10255,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="7"/>
 <connect gate="A" pin="CLK" pad="4"/>
@@ -10380,7 +10380,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -10470,7 +10470,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -10625,7 +10625,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="1"/>
 <connect gate="A" pin="A1" pad="3"/>
@@ -10670,7 +10670,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="6"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -10723,7 +10723,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="4"/>
 <connect gate="A" pin="A" pad="1"/>
@@ -10804,7 +10804,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CX@1" pad="4"/>
 <connect gate="A" pin="CX@2" pad="5"/>
@@ -10883,7 +10883,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -10940,7 +10940,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -11027,7 +11027,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -11121,7 +11121,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -11250,7 +11250,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -11331,7 +11331,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1" pad="11"/>
 <connect gate="A" pin="2" pad="12"/>
@@ -11388,7 +11388,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="11"/>
@@ -11516,7 +11516,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -11641,7 +11641,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -11739,7 +11739,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -11806,7 +11806,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C" pad="1"/>
 <connect gate="A" pin="1G" pad="2"/>
@@ -11889,7 +11889,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C" pad="1"/>
 <connect gate="A" pin="1G" pad="2"/>
@@ -11974,7 +11974,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -12069,7 +12069,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -12201,7 +12201,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -12261,7 +12261,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -12348,7 +12348,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH" pad="7"/>
 <connect gate="A" pin="A" pad="11"/>
@@ -12435,7 +12435,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -12582,7 +12582,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="15"/>
 <connect gate="A" pin="D2" pad="1"/>
@@ -12695,7 +12695,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="CLR" pad="15"/>
@@ -12783,7 +12783,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -12879,7 +12879,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q1" pad="3"/>
 <connect gate="A" pin="!Q2" pad="6"/>
@@ -13101,7 +13101,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="2"/>
 <connect gate="A" pin="A1" pad="23"/>
@@ -13203,7 +13203,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CN" pad="13"/>
 <connect gate="A" pin="CN+X" pad="12"/>
@@ -13282,7 +13282,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -13368,7 +13368,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -13427,7 +13427,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -13488,7 +13488,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -13579,7 +13579,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QD" pad="11"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -13751,7 +13751,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -13857,7 +13857,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -13951,7 +13951,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14013,7 +14013,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14117,7 +14117,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -14256,7 +14256,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -14349,7 +14349,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -14441,7 +14441,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -14534,7 +14534,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -14627,7 +14627,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLR" pad="15"/>
 <connect gate="A" pin="D" pad="13"/>
@@ -14726,7 +14726,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -14889,7 +14889,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="Q" pad="4"/>
 <connect gate="A" pin="R" pad="1"/>
@@ -14970,7 +14970,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="8"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -15057,7 +15057,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="5"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -15311,7 +15311,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -15436,7 +15436,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="2"/>
@@ -15524,7 +15524,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!QA!" pad="8"/>
 <connect gate="A" pin="!QH!" pad="17"/>
@@ -15714,7 +15714,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="11"/>
@@ -15795,7 +15795,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -15855,7 +15855,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -15918,7 +15918,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="D0" pad="8"/>
 <connect gate="A" pin="D1" pad="7"/>
@@ -16019,7 +16019,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="D0" pad="8"/>
@@ -16117,7 +16117,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -16201,7 +16201,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -16285,7 +16285,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1A1" pad="2"/>
 <connect gate="A" pin="1A2" pad="4"/>
@@ -16369,7 +16369,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1A1" pad="2"/>
 <connect gate="A" pin="1A2" pad="4"/>
@@ -16460,7 +16460,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16563,7 +16563,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16659,7 +16659,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!1Q" pad="2"/>
 <connect gate="A" pin="!2Q" pad="6"/>
@@ -16737,7 +16737,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1J" pad="2"/>
 <connect gate="A" pin="1K" pad="3"/>
@@ -16800,7 +16800,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16895,7 +16895,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -16976,7 +16976,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!1Q" pad="3"/>
 <connect gate="A" pin="!2Q" pad="6"/>
@@ -17059,7 +17059,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17150,7 +17150,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17281,7 +17281,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -17366,7 +17366,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="CLR" pad="2"/>
@@ -17444,7 +17444,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QD!" pad="11"/>
 <connect gate="A" pin="A" pad="3"/>
@@ -17522,7 +17522,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1Q1" pad="2"/>
 <connect gate="A" pin="1Q2" pad="5"/>
@@ -17636,7 +17636,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -17954,7 +17954,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18124,7 +18124,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="J" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18187,7 +18187,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="J" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18250,7 +18250,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="J" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18379,7 +18379,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18459,7 +18459,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -18583,7 +18583,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -18678,7 +18678,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -18769,7 +18769,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -18864,7 +18864,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -18954,7 +18954,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19045,7 +19045,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19129,7 +19129,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19226,7 +19226,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19347,7 +19347,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19435,7 +19435,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19516,7 +19516,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19569,7 +19569,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="G" pad="3"/>
 <connect gate="A" pin="I0" pad="1"/>
@@ -19630,7 +19630,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19719,7 +19719,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19809,7 +19809,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19896,7 +19896,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20040,7 +20040,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20130,7 +20130,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -20193,7 +20193,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -20276,7 +20276,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20389,7 +20389,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1A" pad="1"/>
 <connect gate="A" pin="1B" pad="2"/>
@@ -20541,7 +20541,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20617,7 +20617,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20695,7 +20695,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20756,7 +20756,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="13"/>
 <connect gate="A" pin="O" pad="12"/>
@@ -20843,7 +20843,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20928,7 +20928,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21056,7 +21056,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="ALS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="G1" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -21264,7 +21264,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21365,7 +21365,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21532,7 +21532,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="A" pad="15"/>
@@ -21590,7 +21590,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CCKEN" pad="12"/>
 <connect gate="A" pin="CCLR" pad="10"/>
@@ -21705,7 +21705,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -21791,7 +21791,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!CCKEN" pad="14"/>
 <connect gate="A" pin="!G" pad="18"/>
@@ -21881,7 +21881,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="QA" pad="15"/>
@@ -21940,7 +21940,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="G" pad="13"/>
@@ -22021,7 +22021,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="G" pad="13"/>
@@ -22078,7 +22078,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="A" pad="15"/>
@@ -22162,7 +22162,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="11"/>
 <connect gate="A" pin="A/QA" pad="1"/>
@@ -22248,7 +22248,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="QA" pad="15"/>
@@ -22429,7 +22429,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -22600,7 +22600,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="15"/>
 <connect gate="A" pin="D2" pad="1"/>
@@ -22724,7 +22724,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="CS" pad="1"/>
 <connect gate="A" pin="M/SCLK" pad="5"/>
@@ -22825,7 +22825,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="2"/>
 <connect gate="A" pin="CS" pad="1"/>
@@ -23070,7 +23070,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="P0" pad="2"/>
 <connect gate="A" pin="P1" pad="4"/>
@@ -23199,7 +23199,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="G1" pad="2"/>
 <connect gate="A" pin="G2" pad="23"/>
@@ -23333,7 +23333,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -24651,7 +24651,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -24745,7 +24745,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -24815,7 +24815,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -24885,7 +24885,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -24955,7 +24955,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25025,7 +25025,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25095,7 +25095,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25818,7 +25818,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="8"/>
 <connect gate="A" pin="EN" pad="5"/>
@@ -25872,7 +25872,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -25957,7 +25957,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -26014,7 +26014,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -26251,7 +26251,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="J" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="8"/>
 <connect gate="A" pin="CLR" pad="10"/>
@@ -26368,7 +26368,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="J" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="9"/>
@@ -26463,7 +26463,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="J" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -26526,7 +26526,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="J" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="AN" pad="1"/>
 <connect gate="A" pin="AN1" pad="2"/>
@@ -26589,7 +26589,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="J" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="2N+0" pad="9"/>
 <connect gate="A" pin="2N+1" pad="11"/>
@@ -26688,7 +26688,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="J" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -26998,7 +26998,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -27054,7 +27054,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -27112,7 +27112,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="13"/>
 <connect gate="A" pin="O" pad="12"/>
@@ -27182,7 +27182,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1A" pad="1"/>
 <connect gate="G$1" pin="1B" pad="13"/>
@@ -27237,7 +27237,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="4"/>
 <connect gate="A" pin="A" pad="1"/>
@@ -27323,7 +27323,7 @@ Philips Semiconductor</description>
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1Y0" pad="12"/>
 <connect gate="G$1" pin="1Y1" pad="13"/>
@@ -27378,7 +27378,7 @@ Philips Semiconductor</description>
 <technology name="T"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q" pad="13"/>
 <connect gate="A" pin="CP" pad="1"/>

--- a/74xx-us.lbr
+++ b/74xx-us.lbr
@@ -1059,9 +1059,9 @@ Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 12.5m
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -1096,18 +1096,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1162,9 +1162,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1227,9 +1227,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -1268,20 +1268,20 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-530W-1030L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-16-127P-530W-1030L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-4.25" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.645" y1="-3.9" x2="-4.245" y2="-2.65" layer="51"/>
 <rectangle x1="-4.645" y1="2.65" x2="-4.245" y2="3.9" layer="51"/>
@@ -1385,11 +1385,11 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <wire x1="4.45" y1="-2.6" x2="4.45" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="4.45" y1="2.6" x2="-4.4" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-20-127P-530W-1280L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 12.80mm length, 5.30mm width, 2.10mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 12.80mm length, 5.30mm width, 2.10mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-20-127P-530W-1280L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 12.80mm length, 5.30mm width, 2.10mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 12.80mm length, 5.30mm width, 2.10mm max height, 20 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-5.5" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-5.915" y1="-3.9" x2="-5.515" y2="-2.65" layer="51"/>
 <rectangle x1="-5.915" y1="2.65" x2="-5.515" y2="3.9" layer="51"/>
@@ -9592,7 +9592,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -9701,7 +9701,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -9786,7 +9786,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LVC"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -9863,7 +9863,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -9941,7 +9941,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="14"/>
@@ -10118,7 +10118,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="1A" pad="1"/>
 <connect gate="A" pin="1B" pad="12"/>
@@ -10189,7 +10189,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -10345,7 +10345,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="11"/>
@@ -10507,7 +10507,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="13"/>
 <connect gate="A" pin="CL" pad="2"/>
@@ -10560,7 +10560,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="CLK" pad="3"/>
@@ -10637,7 +10637,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q1!" pad="1"/>
 <connect gate="A" pin="!Q2!" pad="14"/>
@@ -10694,7 +10694,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="14"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -10868,7 +10868,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="10"/>
 <connect gate="A" pin="A1" pad="12"/>
@@ -10945,7 +10945,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -11014,7 +11014,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -11057,7 +11057,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CKA" pad="14"/>
 <connect gate="A" pin="CKB" pad="1"/>
@@ -11137,7 +11137,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -11192,7 +11192,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B0" pad="4"/>
 <connect gate="A" pin="B1" pad="1"/>
@@ -11284,7 +11284,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="2"/>
 <connect gate="A" pin="CLK" pad="12"/>
@@ -11339,7 +11339,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="7"/>
 <connect gate="A" pin="CLK" pad="4"/>
@@ -11452,7 +11452,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="CLK" pad="1"/>
@@ -11663,7 +11663,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="1"/>
 <connect gate="A" pin="A1" pad="3"/>
@@ -11708,7 +11708,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="6"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -11761,7 +11761,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="4"/>
 <connect gate="A" pin="A" pad="1"/>
@@ -11842,7 +11842,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CX@1" pad="4"/>
 <connect gate="A" pin="CX@2" pad="5"/>
@@ -11952,7 +11952,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -12031,7 +12031,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -12126,7 +12126,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="SOP-16-127P-530W-1030L-210H-125F">
+<device name="NS" package="SOIC-16-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -12186,7 +12186,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -12311,7 +12311,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -12423,7 +12423,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="11"/>
@@ -12545,7 +12545,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -12658,7 +12658,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -12746,7 +12746,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="0" pad="1"/>
 <connect gate="A" pin="1" pad="2"/>
@@ -12810,7 +12810,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C" pad="1"/>
 <connect gate="A" pin="1G" pad="2"/>
@@ -12891,7 +12891,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C" pad="1"/>
 <connect gate="A" pin="1G" pad="2"/>
@@ -12972,7 +12972,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -13055,7 +13055,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -13206,7 +13206,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -13283,7 +13283,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="7"/>
 <connect gate="A" pin="A" pad="11"/>
@@ -13362,7 +13362,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -13505,7 +13505,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="15"/>
 <connect gate="A" pin="D2" pad="1"/>
@@ -13616,7 +13616,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="7"/>
 <connect gate="A" pin="CLR" pad="15"/>
@@ -13696,7 +13696,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="9"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -13780,7 +13780,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q1!" pad="3"/>
 <connect gate="A" pin="!Q2!" pad="6"/>
@@ -13992,7 +13992,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="2"/>
 <connect gate="A" pin="A1" pad="23"/>
@@ -14088,7 +14088,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CN" pad="13"/>
 <connect gate="A" pin="CN+X" pad="12"/>
@@ -14163,7 +14163,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="3"/>
@@ -14313,7 +14313,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -14394,7 +14394,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QD!" pad="11"/>
 <connect gate="A" pin="A" pad="4"/>
@@ -14560,7 +14560,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14683,7 +14683,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14805,7 +14805,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -14925,7 +14925,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -15079,7 +15079,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="11"/>
 <connect gate="A" pin="B" pad="10"/>
@@ -15160,7 +15160,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -15240,7 +15240,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -15367,7 +15367,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!A!/B" pad="1"/>
 <connect gate="A" pin="1A" pad="2"/>
@@ -15450,7 +15450,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="13"/>
 <connect gate="A" pin="LE" pad="14"/>
@@ -15543,7 +15543,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="11"/>
 <connect gate="A" pin="CLR" pad="1"/>
@@ -15698,7 +15698,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="Q" pad="4"/>
 <connect gate="A" pin="R" pad="1"/>
@@ -15775,7 +15775,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="8"/>
 <connect gate="A" pin="B" pad="9"/>
@@ -15850,7 +15850,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="5"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -16096,7 +16096,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="10"/>
 <connect gate="A" pin="B" pad="11"/>
@@ -16220,7 +16220,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="2"/>
@@ -16303,7 +16303,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!QA!" pad="8"/>
 <connect gate="A" pin="!QH!" pad="17"/>
@@ -16485,7 +16485,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="11"/>
@@ -16563,7 +16563,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1C0" pad="6"/>
 <connect gate="A" pin="1C1" pad="5"/>
@@ -16794,7 +16794,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -16872,7 +16872,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -16950,7 +16950,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1A1" pad="2"/>
 <connect gate="A" pin="1A2" pad="4"/>
@@ -17028,7 +17028,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1A1" pad="2"/>
 <connect gate="A" pin="1A2" pad="4"/>
@@ -17113,7 +17113,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17230,7 +17230,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="SOP-20-127P-530W-1280L-210H-125F">
+<device name="NS" package="SOIC-20-127P-530W-1280L-210H-125F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17294,7 +17294,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17382,7 +17382,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!1Q!" pad="2"/>
 <connect gate="A" pin="!2Q!" pad="6"/>
@@ -17460,7 +17460,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1J" pad="2"/>
 <connect gate="A" pin="1K" pad="3"/>
@@ -17519,7 +17519,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17605,7 +17605,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="3"/>
 <connect gate="A" pin="1Q" pad="2"/>
@@ -17683,7 +17683,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!1Q!" pad="3"/>
 <connect gate="A" pin="!2Q!" pad="6"/>
@@ -17766,7 +17766,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17857,7 +17857,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="3"/>
 <connect gate="A" pin="A1" pad="1"/>
@@ -17985,7 +17985,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -18064,7 +18064,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="CLR" pad="2"/>
@@ -18163,7 +18163,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QD!" pad="11"/>
 <connect gate="A" pin="A" pad="3"/>
@@ -18241,7 +18241,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1Q1" pad="2"/>
 <connect gate="A" pin="1Q2" pad="5"/>
@@ -18355,7 +18355,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18673,7 +18673,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -18843,7 +18843,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="J" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18906,7 +18906,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="J" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -18969,7 +18969,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="J" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="16"/>
 <connect gate="A" pin="A2" pad="15"/>
@@ -19096,7 +19096,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -19170,7 +19170,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -19290,7 +19290,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19375,7 +19375,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19454,7 +19454,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -19539,7 +19539,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19621,7 +19621,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19725,7 +19725,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19805,7 +19805,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -19890,7 +19890,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20064,7 +20064,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20168,7 +20168,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="G" pad="3"/>
 <connect gate="A" pin="I0" pad="1"/>
@@ -20223,7 +20223,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20300,7 +20300,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20378,7 +20378,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20457,7 +20457,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="2"/>
 <connect gate="A" pin="I1" pad="3"/>
@@ -20598,7 +20598,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20699,7 +20699,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>
@@ -20773,7 +20773,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -20884,7 +20884,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1A" pad="1"/>
 <connect gate="A" pin="1B" pad="2"/>
@@ -21036,7 +21036,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21111,7 +21111,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21224,7 +21224,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="13"/>
 <connect gate="A" pin="O" pad="12"/>
@@ -21325,7 +21325,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21405,7 +21405,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -21749,7 +21749,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -21839,7 +21839,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="3"/>
@@ -22029,7 +22029,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CCKEN" pad="12"/>
 <connect gate="A" pin="CCLR" pad="10"/>
@@ -22139,7 +22139,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="15"/>
 <connect gate="A" pin="B" pad="1"/>
@@ -22221,7 +22221,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!CCKEN!" pad="14"/>
 <connect gate="A" pin="!G!" pad="18"/>
@@ -22307,7 +22307,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="QA" pad="15"/>
@@ -22362,7 +22362,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="G" pad="13"/>
@@ -22440,7 +22440,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="G" pad="13"/>
@@ -22495,7 +22495,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="A" pad="15"/>
@@ -22577,7 +22577,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="11"/>
 <connect gate="A" pin="A/QA" pad="1"/>
@@ -22663,7 +22663,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!QH!" pad="9"/>
 <connect gate="A" pin="QA" pad="15"/>
@@ -22983,7 +22983,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="15"/>
 <connect gate="A" pin="D2" pad="1"/>
@@ -23105,7 +23105,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="CS" pad="1"/>
 <connect gate="A" pin="M/SCLK" pad="5"/>
@@ -23206,7 +23206,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="2"/>
 <connect gate="A" pin="CS" pad="1"/>
@@ -23450,7 +23450,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="P0" pad="2"/>
 <connect gate="A" pin="P1" pad="4"/>
@@ -23578,7 +23578,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="G1" pad="2"/>
 <connect gate="A" pin="G2" pad="23"/>
@@ -23710,7 +23710,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="G" pad="1"/>
 <connect gate="A" pin="P0" pad="2"/>
@@ -25024,7 +25024,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="3"/>
 <connect gate="A" pin="B" pad="4"/>
@@ -25262,7 +25262,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -25976,7 +25976,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="8"/>
 <connect gate="A" pin="EN" pad="5"/>
@@ -26026,7 +26026,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -26103,7 +26103,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -26160,7 +26160,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I0" pad="1"/>
 <connect gate="A" pin="I1" pad="2"/>
@@ -26397,7 +26397,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="J" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CLK" pad="8"/>
 <connect gate="A" pin="CLR" pad="10"/>
@@ -26514,7 +26514,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="J" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="0" pad="10"/>
 <connect gate="A" pin="1" pad="9"/>
@@ -26609,7 +26609,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="J" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="3"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -26668,7 +26668,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="J" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="AN" pad="1"/>
 <connect gate="A" pin="AN1" pad="2"/>
@@ -26727,7 +26727,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="J" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="2N+0" pad="9"/>
 <connect gate="A" pin="2N+1" pad="11"/>
@@ -26826,7 +26826,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="S"/>
 </technologies>
 </device>
-<device name="J" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="J" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="A1" pad="2"/>
 <connect gate="A" pin="A2" pad="4"/>
@@ -27136,7 +27136,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -27192,7 +27192,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -27248,7 +27248,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="13"/>
 <connect gate="A" pin="O" pad="12"/>
@@ -27316,7 +27316,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1A" pad="1"/>
 <connect gate="G$1" pin="1B" pad="13"/>
@@ -27367,7 +27367,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="T"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="!Q!" pad="13"/>
 <connect gate="A" pin="CP" pad="1"/>
@@ -27429,7 +27429,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="HCT"/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="1D" pad="2"/>
 <connect gate="A" pin="1Q" pad="19"/>
@@ -27468,7 +27468,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OEBA!" pad="21"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -27508,7 +27508,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <gate name="P" symbol="PWRN" x="-22.86" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="M" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="M" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="COM" pad="1"/>
 <connect gate="A" pin="E" pad="15"/>
@@ -27714,7 +27714,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name="LS"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="2"/>
 <connect gate="A" pin="O" pad="3"/>

--- a/751xx.lbr
+++ b/751xx.lbr
@@ -75,9 +75,9 @@
 
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -132,9 +132,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -327,9 +327,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <text x="-15.24" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.795" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -368,14 +368,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -714,7 +714,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SO" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!G" pad="12"/>
 <connect gate="G$1" pin="1A" pad="1"/>
@@ -769,7 +769,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SO" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1,2G" pad="4"/>
 <connect gate="G$1" pin="1A" pad="3"/>
@@ -824,7 +824,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SO" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1A" pad="3"/>
 <connect gate="G$1" pin="1W" pad="2"/>
@@ -883,7 +883,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="SO" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="B1" pad="2"/>
 <connect gate="G$1" pin="B2" pad="3"/>
@@ -946,7 +946,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="SO" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="ATN" pad="13"/>
 <connect gate="G$1" pin="ATN2" pad="8"/>
@@ -1047,7 +1047,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="SO" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="B1" pad="2"/>
 <connect gate="G$1" pin="B2" pad="3"/>
@@ -1112,7 +1112,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="SO" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="ATN" pad="14"/>
 <connect gate="G$1" pin="ATN+EOI" pad="21"/>
@@ -1173,7 +1173,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SO" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!G" pad="12"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -1228,7 +1228,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SO" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1,2EN" pad="4"/>
 <connect gate="G$1" pin="1A" pad="1"/>
@@ -1283,7 +1283,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SO" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1,2EN" pad="4"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -1346,7 +1346,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="SO" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="ATN" pad="9"/>
 <connect gate="G$1" pin="ATN2" pad="16"/>

--- a/akm.lbr
+++ b/akm.lbr
@@ -729,9 +729,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <text x="-2.6475" y="-1.3575" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.3175" y="-1.405" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2797,7 +2797,7 @@ Super High Performance, 192kHz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5394" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="22"/>
 <connect gate="G$1" pin="AINL+" pad="4"/>
@@ -2841,7 +2841,7 @@ Enhanced Dual Bit, 96kHz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5393" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="22"/>
 <connect gate="G$1" pin="AINL+" pad="4"/>
@@ -2885,7 +2885,7 @@ Enhanced Dual Bit, 48Hz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5392" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="22"/>
 <connect gate="G$1" pin="AINL+" pad="4"/>
@@ -2929,7 +2929,7 @@ Enhanced Dual Bit, 48Hz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5385" x="0" y="0"/>
 </gates>
 <devices>
-<device name="AVS" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="AVS" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AVDD" pad="23"/>
 <connect gate="G$1" pin="AVSS" pad="2"/>
@@ -3008,7 +3008,7 @@ Enhanced Dual Bit, 48Hz, 24-Bit, 2ch, Delta Sigma</description>
 <gate name="G$1" symbol="AK5383" x="0" y="0"/>
 </gates>
 <devices>
-<device name="VS" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="VS" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="22"/>
 <connect gate="G$1" pin="AINL+" pad="4"/>

--- a/allegro-micro.lbr
+++ b/allegro-micro.lbr
@@ -318,9 +318,9 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -343,18 +343,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -494,7 +494,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="LB" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="LB" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="EN1" pad="3"/>
 <connect gate="G$1" pin="EN2" pad="14"/>
@@ -527,7 +527,7 @@ Fully Integrated, Hall Effect-Based&lt;br&gt;
 <gate name="G$1" symbol="ACS712/ACS713" x="0" y="0"/>
 </gates>
 <devices>
-<device name="LC" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="LC" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FILTER" pad="6"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -584,7 +584,7 @@ Fully Integrated, Hall Effect-Based&lt;br&gt;
 <gate name="G$1" symbol="ACS712/ACS713" x="0" y="0"/>
 </gates>
 <devices>
-<device name="LC" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="LC" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FILTER" pad="6"/>
 <connect gate="G$1" pin="GND" pad="5"/>

--- a/ams.lbr
+++ b/ams.lbr
@@ -188,9 +188,9 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 16 leads. JED
 <wire x1="3.15" y1="-2.6" x2="3.15" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="3.15" y1="2.6" x2="-3.1" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -213,14 +213,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -414,7 +414,7 @@ For High Ambient Temperatures</description>
 <gate name="G$1" symbol="AS5601" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="5"/>

--- a/analog-devices.lbr
+++ b/analog-devices.lbr
@@ -2268,9 +2268,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -2293,18 +2293,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2351,9 +2351,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -2392,14 +2392,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SSOP-20-65P-440W-650L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 6.5mm length, 4.4mm width, 1.20mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
@@ -2458,9 +2458,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 6.5mm
 <wire x1="3.35" y1="-2" x2="3.35" y2="2" width="0.2032" layer="21"/>
 <wire x1="3.35" y1="2" x2="-3.35" y2="2" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2588,9 +2588,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm
 <wire x1="4" y1="-2" x2="4" y2="2" width="0.2032" layer="21"/>
 <wire x1="4" y1="2" x2="-4" y2="2" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -8330,7 +8330,7 @@ body 4 x 4 mm, 20-WFQFN Exposed Pad, CSP</description>
 <gate name="G$1" symbol="AD736" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+VS" pad="7"/>
 <connect gate="G$1" pin="-VS" pad="4"/>
@@ -8537,7 +8537,7 @@ body 4 x 4 mm, 20-WFQFN Exposed Pad, CSP</description>
 <gate name="G$1" symbol="AD8801" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CLK!" pad="9"/>
 <connect gate="G$1" pin="!CS!" pad="7"/>
@@ -8568,7 +8568,7 @@ body 4 x 4 mm, 20-WFQFN Exposed Pad, CSP</description>
 <gate name="G$1" symbol="AD8803" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CLK!" pad="10"/>
 <connect gate="G$1" pin="!CS!" pad="7"/>
@@ -8618,7 +8618,7 @@ body 4 x 4 mm, 20-WFQFN Exposed Pad, CSP</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="1" pin="NC" pad="1"/>
 <connect gate="5" pin="NC" pad="5"/>
@@ -9308,7 +9308,7 @@ single-chip microcomputer optimized for digital signal processing (DSP)</descrip
 <technology name=""/>
 </technologies>
 </device>
-<device name="AR" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="AR" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -9347,7 +9347,7 @@ single-chip microcomputer optimized for digital signal processing (DSP)</descrip
 <gate name="P" symbol="PWR+-" x="2.54" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="AR" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="AR" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="IN+" pad="3"/>
 <connect gate="A" pin="IN-" pad="2"/>
@@ -9380,7 +9380,7 @@ Low Cost, Low Power 12-Bit</description>
 <gate name="G$1" symbol="AD8137" x="2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="-IN" pad="1"/>
@@ -9403,7 +9403,7 @@ Low Cost, Low Power 12-Bit</description>
 <gate name="G$1" symbol="AD421" x="0" y="0"/>
 </gates>
 <devices>
-<device name="R" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="R" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="BOOST" pad="15"/>
 <connect gate="G$1" pin="C1" pad="12"/>
@@ -9480,7 +9480,7 @@ Low Cost, Low Power 12-Bit</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="R" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="9"/>
 <connect gate="G$1" pin="!LDAC!" pad="7"/>
@@ -9569,7 +9569,7 @@ Low Power 20 mW 2.3 V to 5.5 V</description>
 <gate name="G$1" symbol="SSM2141" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -9591,7 +9591,7 @@ Low Power 20 mW 2.3 V to 5.5 V</description>
 <gate name="G$1" symbol="SSM2142" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="S" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="FORCE+" pad="14"/>
 <connect gate="G$1" pin="FORCE-" pad="3"/>
@@ -9687,7 +9687,7 @@ CMOS, Low-Voltage, 3-Wire Serially-Controlled</description>
 <gate name="G$1" symbol="ADUM1200" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND1" pad="4"/>
 <connect gate="G$1" pin="GND2" pad="5"/>
@@ -9710,7 +9710,7 @@ CMOS, Low-Voltage, 3-Wire Serially-Controlled</description>
 <gate name="G$1" symbol="ADUM1201" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND1" pad="4"/>
 <connect gate="G$1" pin="GND2" pad="5"/>
@@ -9762,7 +9762,7 @@ Low Cost, Low Power CMOS General Purpose Analog Front End</description>
 <technology name="L"/>
 </technologies>
 </device>
-<device name="AR" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="AR" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="13"/>
 <connect gate="G$1" pin="AGND@10" pad="10"/>
@@ -9904,7 +9904,7 @@ Single-Channel, 12-/16-Bit, Serial Input,&lt;br&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="BR" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="BR" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="-1" pin="A" pad="18"/>
 <connect gate="-1" pin="B" pad="16"/>
@@ -9975,7 +9975,7 @@ Single-Channel, 12-/16-Bit, Serial Input,&lt;br&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="BR" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="BR" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="-1" pin="A" pad="18"/>
 <connect gate="-1" pin="B" pad="16"/>
@@ -10051,7 +10051,7 @@ Single-Channel, 12-/16-Bit, Serial Input,&lt;br&gt;
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="TRIM" pad="5"/>
@@ -10091,7 +10091,7 @@ Micropower, Low Noise with Shutdown</description>
 <gate name="G$1" symbol="ADM3483E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -10281,7 +10281,7 @@ adjustable output LDO regulator</description>
 <gate name="G$1" symbol="ADP3334" x="0" y="0"/>
 </gates>
 <devices>
-<device name="AR" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="AR" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FB" pad="7"/>
 <connect gate="G$1" pin="GND" pad="1"/>
@@ -10372,7 +10372,7 @@ SPI Interface, 2.7 V to 5.5 V, &lt;100 ?A, 8-/10-/12-Bit</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="R" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -10450,7 +10450,7 @@ Rail-to-Rail, Very Fast, 2.5 V to 5.5 V, Single-Supply</description>
 <gate name="G$1" symbol="AD8132" x="0" y="0"/>
 </gates>
 <devices>
-<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="R" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="-IN" pad="1"/>
@@ -10501,7 +10501,7 @@ Rail-to-Rail, Very Fast, 2.5 V to 5.5 V, Single-Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="R" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="1"/>
 <connect gate="G$1" pin="-IN" pad="8"/>
@@ -11027,7 +11027,7 @@ Dual 12 Bit, 250 MSPS</description>
 <gate name="G$1" symbol="ADUM4160" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="DD+" pad="10"/>
 <connect gate="G$1" pin="DD-" pad="11"/>
@@ -11387,7 +11387,7 @@ Single Channel, 12-/16-Bit, Serial Input, HART Connectivity</description>
 <gate name="G$1" symbol="ADR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="R" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="TEMP" pad="3"/>
@@ -11426,7 +11426,7 @@ Single Channel, 12-/16-Bit, Serial Input, HART Connectivity</description>
 <gate name="G$1" symbol="ADR42" x="0" y="0"/>
 </gates>
 <devices>
-<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="R" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="TRIM" pad="5"/>
@@ -11525,7 +11525,7 @@ Low Power, Wide Supply Range, Unity-Gain Difference Amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="R" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="3"/>
 <connect gate="G$1" pin="IN-" pad="2"/>
@@ -11622,7 +11622,7 @@ TXRX DUAL RS232 3.3V</description>
 <gate name="G$2" symbol="ADM3202" x="33.02" y="-12.7"/>
 </gates>
 <devices>
-<device name="R" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="R" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="C1+" pad="1"/>
 <connect gate="G$2" pin="C1-" pad="3"/>
@@ -11645,7 +11645,7 @@ TXRX DUAL RS232 3.3V</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="RW" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="RW" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$2" pin="C1+" pad="1"/>
 <connect gate="G$2" pin="C1-" pad="3"/>
@@ -11764,7 +11764,7 @@ TXRX DUAL RS232 3.3V</description>
 <gate name="G$1" symbol="ADM708S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="R" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="1"/>
 <connect gate="G$1" pin="!PFO!" pad="5"/>
@@ -12167,7 +12167,7 @@ TXRX DUAL RS232 3.3V</description>
 <gate name="P" symbol="PWRN_VDDVSSVLGND" x="-33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>

--- a/atmel-avr.lbr
+++ b/atmel-avr.lbr
@@ -1745,9 +1745,9 @@ Quad flat no-lead package. 0.50mm pitch, 0.40mm lead length 9mm length, 9mm widt
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -1770,20 +1770,20 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-530W-530L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-8-127P-530W-530L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-1.75" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-2.105" y1="-3.9" x2="-1.705" y2="-2.65" layer="51"/>
 <rectangle x1="-2.105" y1="2.65" x2="-1.705" y2="3.9" layer="51"/>
@@ -5781,7 +5781,7 @@ Quad flat no-lead package. 0.50mm pitch, 0.50mm lead length 9mm length, 9mm widt
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S2" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="-8S2" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="(PCINT0/OC0A/AIN0/MOSI)PB0" pad="5"/>
 <connect gate="G$1" pin="(PCINT1/INT0/OC0B/AIN1/MISO)PB1" pad="6"/>
@@ -5796,7 +5796,7 @@ Quad flat no-lead package. 0.50mm pitch, 0.50mm lead length 9mm length, 9mm widt
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S1" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="-8S1" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(PCINT0/OC0A/AIN0/MOSI)PB0" pad="5"/>
 <connect gate="G$1" pin="(PCINT1/INT0/OC0B/AIN1/MISO)PB1" pad="6"/>

--- a/atmel.lbr
+++ b/atmel.lbr
@@ -2315,9 +2315,9 @@ Quad flat no-lead package. 0.65mm pitch, 0.55mm lead length 7mm length, 7mm widt
 <text x="-18.415" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-8.255" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -2340,18 +2340,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2497,9 +2497,9 @@ Quad flat no-lead package. 0.50mm pitch, 0.50mm lead length 5mm length, 5mm widt
 <wire x1="2.7" y1="-2.7" x2="2.1" y2="-2.7" width="0.2032" layer="21"/>
 <wire x1="2.7" y1="2.1" x2="2.7" y2="2.7" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -2534,14 +2534,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -6972,7 +6972,7 @@ UART&lt;p&gt;
 <technology name="S"/>
 </technologies>
 </device>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(MISO)PB1" pad="6"/>
 <connect gate="G$1" pin="(MOSI)PB0" pad="5"/>
@@ -6999,7 +6999,7 @@ UART&lt;p&gt;
 <gate name="G$1" symbol="5-I/O-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(CLOCK)PB3" pad="2"/>
 <connect gate="G$1" pin="(MISO)PB1" pad="6"/>
@@ -7070,7 +7070,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="S" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="(AIN0)PB0" pad="12"/>
 <connect gate="G$1" pin="(AIN1)PB1" pad="13"/>
@@ -7134,7 +7134,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="S" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="(AIN0)PB0" pad="12"/>
 <connect gate="G$1" pin="(AIN1)PB1" pad="13"/>
@@ -7212,7 +7212,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(AIN0)PB0" pad="5"/>
 <connect gate="G$1" pin="(AIN1)PB1" pad="6"/>
@@ -7252,7 +7252,7 @@ UART</description>
 <technology name="L"/>
 </technologies>
 </device>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(AIN0)PB0" pad="5"/>
 <connect gate="G$1" pin="(AIN1)PB1" pad="6"/>
@@ -7293,7 +7293,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(MISO)PB1" pad="6"/>
 <connect gate="G$1" pin="(MOSI)PB0" pad="5"/>
@@ -7334,7 +7334,7 @@ UART</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(CLOCK)PB3" pad="2"/>
 <connect gate="G$1" pin="(MISO)PB1" pad="6"/>
@@ -7810,7 +7810,7 @@ hardware multiplier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(ADC0)PB5" pad="1"/>
 <connect gate="G$1" pin="(ADC1)PB2" pad="7"/>
@@ -9794,7 +9794,7 @@ USART&lt;p&gt;
 <gate name="G$1" symbol="TINY26" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="(ADC0)PA0" pad="20"/>
 <connect gate="G$1" pin="(ADC1)PA1" pad="19"/>
@@ -10649,7 +10649,7 @@ Low Power Transceiver  for ZigBee, IEEE 802.15.4,&lt;br&gt;
 <gate name="G$1" symbol="TINY24A-14S1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="(PCINT0/AREF/ADC0)PA0" pad="13"/>
 <connect gate="G$1" pin="(PCINT1/AIN0/ADC1)PA1" pad="12"/>

--- a/burr-brown.lbr
+++ b/burr-brown.lbr
@@ -123,9 +123,9 @@
 <rectangle x1="1.016" y1="3.175" x2="1.524" y2="4.826" layer="51"/>
 <rectangle x1="3.556" y1="3.175" x2="4.064" y2="4.826" layer="51"/>
 </package>
-<package name="SOP-28-127P-890W-1790L-265H-155F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 17.90mm length, 8.90mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body length,
+<package name="SOIC-28-127P-890W-1790L-265H-155F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.55mm lead length, 17.90mm length, 8.90mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body length,
 8.90mm body width, 2.65mm max height, 28 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-120B, variation AB.&lt;/p&gt;</description>
@@ -188,14 +188,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <smd name="28" x="-8.255" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-9.45" y="-4.45" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="9.95" y="-4.45" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-9.05" y1="-4.05" x2="9.05" y2="-4.05" width="0.2032" layer="21"/>
+<wire x1="-9.05" y1="4.05" x2="-9.05" y2="-4.05" width="0.2032" layer="21"/>
 <wire x1="-8.925" y1="4.425" x2="-8.925" y2="-4.425" width="0.0508" layer="51"/>
-<wire x1="-8.85" y1="-4.05" x2="8.85" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="-8.85" y1="4.05" x2="-8.85" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="-4.05" x2="8.85" y2="4.05" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="4.05" x2="-8.85" y2="4.05" width="0.2032" layer="21"/>
 <wire x1="8.925" y1="-4.425" x2="8.925" y2="4.425" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="-4.425" x2="-8.925" y2="-4.425" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="4.425" x2="-8.925" y2="4.425" width="0.0508" layer="51"/>
+<wire x1="9.05" y1="-4.05" x2="9.05" y2="4.05" width="0.2032" layer="21"/>
+<wire x1="9.05" y1="4.05" x2="-9.05" y2="4.05" width="0.2032" layer="21"/>
 </package>
 <package name="SO16-1/8">
 <description>&lt;b&gt;Small Outline Package&lt;/b&gt;</description>
@@ -794,9 +794,9 @@ Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body wid
 <rectangle x1="-3.5941" y1="-4.5085" x2="-3.3909" y2="-3.6703" layer="51"/>
 <rectangle x1="-4.2291" y1="-4.5085" x2="-4.0259" y2="-3.6703" layer="51"/>
 </package>
-<package name="SOP-18-127P-750W-1155L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
+<package name="SOIC-18-127P-750W-1155L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.875" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -847,9 +847,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2320,9 +2320,9 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-11.43" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.35" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -2345,18 +2345,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -2391,18 +2391,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2449,9 +2449,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -9186,7 +9186,7 @@ Low Power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="INA+" pad="2"/>
 <connect gate="G$1" pin="INA-" pad="1"/>
@@ -9241,7 +9241,7 @@ Dual, Low Power, G = 10, 100</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="INA+" pad="2"/>
 <connect gate="G$1" pin="INA-" pad="1"/>
@@ -9346,7 +9346,7 @@ Precision, Lowest Cost</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="26"/>
 <connect gate="G$1" pin="!CS" pad="25"/>
@@ -9424,7 +9424,7 @@ Precision, Lowest Cost</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="26"/>
 <connect gate="G$1" pin="!CS" pad="25"/>
@@ -9490,7 +9490,7 @@ Precision, Lowest Cost</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="14"/>
 <connect gate="G$1" pin="!CONV" pad="12"/>
@@ -9556,7 +9556,7 @@ Precision, Lowest Cost</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="26"/>
 <connect gate="G$1" pin="!CS" pad="25"/>
@@ -9600,7 +9600,7 @@ Precision Switched Integrator Transimpedance</description>
 <gate name="G$1" symbol="IVC102" x="-5.08" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="-IN" pad="3"/>
 <connect gate="G$1" pin="AGND" pad="1"/>
@@ -9743,7 +9743,7 @@ Single-Ended 16-Channel/Differential 8-Channel</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="+V" pad="1"/>
 <connect gate="G$1" pin="-V" pad="27"/>
@@ -9822,7 +9822,7 @@ Single-Ended 16-Channel/Differential 8-Channel</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="+V" pad="1"/>
 <connect gate="G$1" pin="-V" pad="27"/>
@@ -9889,7 +9889,7 @@ Single-Ended 8-Channel/Differential 4-Channell</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+V" pad="13"/>
 <connect gate="G$1" pin="-V" pad="3"/>
@@ -9944,7 +9944,7 @@ Single-Ended 8-Channel/Differential 4-Channel</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+V" pad="14"/>
 <connect gate="G$1" pin="-V" pad="3"/>
@@ -10384,7 +10384,7 @@ Serial Interface</description>
 <gate name="G$1" symbol="ADS7819" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="25"/>
 <connect gate="G$1" pin="!CS" pad="24"/>
@@ -10462,7 +10462,7 @@ Serial Interface</description>
 <gate name="G$1" symbol="ADS7824" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="24"/>
 <connect gate="G$1" pin="!CS" pad="23"/>
@@ -10540,7 +10540,7 @@ Serial Interface</description>
 <gate name="G$1" symbol="ADS7824" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="24"/>
 <connect gate="G$1" pin="!CS" pad="23"/>
@@ -10618,7 +10618,7 @@ Serial Interface</description>
 <gate name="G$1" symbol="ADS7819" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="25"/>
 <connect gate="G$1" pin="!CS" pad="24"/>
@@ -10815,7 +10815,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -10858,7 +10858,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7819" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="25"/>
 <connect gate="G$1" pin="!CS" pad="24"/>
@@ -11042,7 +11042,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7806" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="24"/>
 <connect gate="G$1" pin="!CS" pad="23"/>
@@ -11120,7 +11120,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7806" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="24"/>
 <connect gate="G$1" pin="!CS" pad="23"/>
@@ -11225,7 +11225,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="U" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="17"/>
 <connect gate="G$1" pin="!CS" pad="16"/>
@@ -11283,7 +11283,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="14"/>
 <connect gate="G$1" pin="!CONV" pad="12"/>
@@ -11314,7 +11314,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <gate name="G$1" symbol="ADS7815" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="26"/>
 <connect gate="G$1" pin="!CS" pad="25"/>
@@ -11382,7 +11382,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="U" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="5"/>
 <connect gate="G$1" pin="!DRDY" pad="14"/>
@@ -11477,7 +11477,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="U" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="8"/>
 <connect gate="G$1" pin="!DRDY" pad="17"/>
@@ -11541,7 +11541,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="U" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="5"/>
 <connect gate="G$1" pin="!DRDY" pad="14"/>
@@ -11636,7 +11636,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="U" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="8"/>
 <connect gate="G$1" pin="!DRDY" pad="17"/>
@@ -11690,7 +11690,7 @@ three synchronized A/D converters and seven S/H amplifiers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!/SHDN" pad="5"/>
 <connect gate="G$1" pin="+IN" pad="2"/>
@@ -11923,7 +11923,7 @@ Int Reference and Adjustable Fullscale Range</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -12001,7 +12001,7 @@ Int Reference and Adjustable Fullscale Range</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -12080,7 +12080,7 @@ with Int References and 9.5 bit ENOB</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -12159,7 +12159,7 @@ with Int References and 9.3 bit ENOB</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!IN" pad="27"/>
 <connect gate="G$1" pin="!OE" pad="18"/>
@@ -12383,7 +12383,7 @@ MicroAmplifier(TM) Series; Product Folder:OPA2340</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12451,7 +12451,7 @@ MicroAmplifier(TM) Series; Product Folder:OPA2340</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="U" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12505,7 +12505,7 @@ Single-Supply, MicroAmplifier(TM) Series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12539,7 +12539,7 @@ Single-Supply, MicroAmplifier(TM) Series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="+VS1" pad="7"/>
@@ -12581,7 +12581,7 @@ Single-Supply, MicroAmplifier(TM) Series</description>
 <gate name="G$1" symbol="SUBS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12617,7 +12617,7 @@ Single-Supply, MicroPower</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12654,7 +12654,7 @@ Single-Supply, MicroPower</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12690,7 +12690,7 @@ Ultra-Low Bias Current</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12726,7 +12726,7 @@ High Speed FET-Input</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12750,7 +12750,7 @@ Product Folder:OPA2132</description>
 <gate name="B" symbol="OP-AMP" x="10.16" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12791,7 +12791,7 @@ Product Folder:OPA2132</description>
 <gate name="D" symbol="OP-AMP" x="10.16" y="-12.7"/>
 </gates>
 <devices>
-<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="U" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12856,7 +12856,7 @@ General Purpose FET-Input</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -12880,7 +12880,7 @@ Product Folder:OPA2131</description>
 <gate name="B" symbol="OP-AMP" x="10.16" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12921,7 +12921,7 @@ Product Folder:OPA2131</description>
 <gate name="D" symbol="OP-AMP" x="10.16" y="-7.62"/>
 </gates>
 <devices>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12963,7 +12963,7 @@ Product Folder:OPA2131</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="N" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13007,7 +13007,7 @@ Low Power, Precision FET-Input</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13030,7 +13030,7 @@ Low Power, Precision FET-Input</description>
 <gate name="A" symbol="OP-AMP+-" x="-10.16" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13092,7 +13092,7 @@ Low Power, Precision FET-Input</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="U" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13136,7 +13136,7 @@ SoundPlus(TM) High Performance Audio</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13159,7 +13159,7 @@ SoundPlus(TM) High Performance Audio</description>
 <gate name="B" symbol="OP-AMP" x="12.7" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13211,7 +13211,7 @@ SoundPlus(TM) High Performance Audio</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13270,7 +13270,7 @@ Low Power, Precision, Single-Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13293,7 +13293,7 @@ Low Power, Precision, Single-Supply</description>
 <gate name="B" symbol="OP-AMP" x="15.24" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13355,7 +13355,7 @@ Low Power, Precision, Single-Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="U" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13397,7 +13397,7 @@ Single-Supply, MicroAmplifier(TM) Series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13434,7 +13434,7 @@ MicroAmplifier(TM) Series; Product Folder:OPA2237</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13503,7 +13503,7 @@ Single-Supply, MicroPower, MicroAmplifier(TM) Series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13567,7 +13567,7 @@ MicroAmplifier Series; Product Folder:OPA2336,</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13636,7 +13636,7 @@ MicroAmplifier (TM) Series</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="U" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13680,7 +13680,7 @@ Precision, High-Speed</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13741,7 +13741,7 @@ Precision, High-Speed</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13810,7 +13810,7 @@ Wideband, Low Distortion</description>
 <gate name="G$1" symbol="2+2-" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="+VS1" pad="7"/>
@@ -13856,7 +13856,7 @@ Wideband, Low Distortion</description>
 <gate name="D" symbol="OP-AMP" x="10.16" y="-12.7"/>
 </gates>
 <devices>
-<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="U" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13909,7 +13909,7 @@ Wideband, Low Distortion</description>
 <gate name="D" symbol="OP-AMP" x="10.16" y="-12.7"/>
 </gates>
 <devices>
-<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="U" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13990,7 +13990,7 @@ Wideband, Low Distortion</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14038,7 +14038,7 @@ Wideband, Low Power, Current Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14089,7 +14089,7 @@ Wideband, Low Power, Current Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14136,7 +14136,7 @@ Wideband, Switched-Input</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CHA" pad="12"/>
 <connect gate="G$1" pin="+INA" pad="1"/>
@@ -14182,7 +14182,7 @@ Wideband, FET-Input</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="+VS1" pad="7"/>
@@ -14229,7 +14229,7 @@ Wideband, Low Power, Voltage Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14274,7 +14274,7 @@ Wideband, Low Power, Voltage Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14372,7 +14372,7 @@ with Programmable Dual PLL</description>
 <gate name="P" symbol="PWRN" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BCKIN" pad="3"/>
 <connect gate="G$1" pin="CAP" pad="5"/>
@@ -14704,7 +14704,7 @@ MPEG2/AC-3 Compatible</description>
 <gate name="G$1" symbol="PCM1702U" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+VCC" pad="11"/>
 <connect gate="G$1" pin="+VDD" pad="4"/>
@@ -14740,7 +14740,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="PCM1710" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="AGND1" pad="14"/>
 <connect gate="G$1" pin="AGND2L" pad="19"/>
@@ -14910,7 +14910,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="PCM1712" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="AGND1" pad="14"/>
 <connect gate="G$1" pin="AGND2L" pad="19"/>
@@ -14953,7 +14953,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="PGA206" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="5"/>
 <connect gate="G$1" pin="-IN" pad="4"/>
@@ -15030,7 +15030,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="5"/>
 <connect gate="G$1" pin="-IN" pad="4"/>
@@ -15091,7 +15091,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COM" pad="4"/>
 <connect gate="G$1" pin="NC" pad="1"/>
@@ -15129,7 +15129,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="I1H" pad="8"/>
 <connect gate="G$1" pin="I1L" pad="1"/>
@@ -15152,7 +15152,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="REF1004" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="4"/>
 <connect gate="G$1" pin="C" pad="6"/>
@@ -15204,7 +15204,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="XTR101U" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="4"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -15235,7 +15235,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="DAC712" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CLR" pad="9"/>
 <connect gate="G$1" pin="!WR" pad="10"/>
@@ -15336,7 +15336,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLK" pad="1"/>
 <connect gate="G$1" pin="!CLR" pad="16"/>
@@ -15367,7 +15367,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="DAC712" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CLR" pad="9"/>
 <connect gate="G$1" pin="!WR" pad="10"/>
@@ -15488,7 +15488,7 @@ with On-Chip Digital Filter</description>
 <gate name="G$1" symbol="DAC813" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!LDAC" pad="12"/>
 <connect gate="G$1" pin="!LLSB" pad="15"/>
@@ -15633,7 +15633,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR" pad="11"/>
 <connect gate="G$1" pin="!CS" pad="8"/>
@@ -15695,7 +15695,7 @@ with On-Chip Digital Filter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="U" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR" pad="17"/>
 <connect gate="G$1" pin="!CS" pad="5"/>
@@ -15766,7 +15766,7 @@ Multiplying</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="U" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CSA" pad="5"/>
 <connect gate="G$1" pin="!CSB" pad="20"/>
@@ -15821,7 +15821,7 @@ Precision, Low Power, G = 10, 100</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -15960,7 +15960,7 @@ with RTD Excitation And Linearization</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="4"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -15992,7 +15992,7 @@ with Bridge Excitation And Linearization</description>
 <gate name="G$1" symbol="XTR104" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="1"/>
 <connect gate="G$1" pin="+LIN" pad="3"/>
@@ -16068,7 +16068,7 @@ with Sensor Excitation and Linearization</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="U" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="13"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16177,7 +16177,7 @@ Microprocessor-Compatible</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="3"/>
 <connect gate="G$1" pin="10VR" pad="13"/>
@@ -16291,7 +16291,7 @@ Microprocessor Compatible</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="3"/>
 <connect gate="G$1" pin="10VR" pad="13"/>
@@ -16369,7 +16369,7 @@ Microprocessor Compatible</description>
 <gate name="G$1" symbol="ADS7800" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="U" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!BUSY" pad="21"/>
 <connect gate="G$1" pin="!CS" pad="20"/>
@@ -16470,7 +16470,7 @@ Microprocessor Compatible</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="U" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CAPA" pad="22"/>
 <connect gate="G$1" pin="CAPB" pad="3"/>
@@ -16572,7 +16572,7 @@ Microprocessor Compatible</description>
 <gate name="G$1" symbol="DDC101U" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="U" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="U" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!DTR" pad="18"/>
 <connect gate="G$1" pin="!DVAL" pad="15"/>
@@ -16771,7 +16771,7 @@ Precision, Low Power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16810,7 +16810,7 @@ Precision, Low Power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16849,7 +16849,7 @@ Precision, Low Power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16894,7 +16894,7 @@ Precision, Low Power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="U" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+INA" pad="3"/>
 <connect gate="G$1" pin="+INB" pad="5"/>
@@ -16939,7 +16939,7 @@ Single Supply, MicroPower</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -16978,7 +16978,7 @@ Low Power, Single-Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17017,7 +17017,7 @@ Precision, Low Power</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17064,7 +17064,7 @@ with Precision Voltage Reference</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!SLEEP" pad="2"/>
 <connect gate="G$1" pin="+IN" pad="6"/>
@@ -17126,7 +17126,7 @@ High Common-Mode Voltage</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17173,7 +17173,7 @@ Ultra Low Input Bias Current</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="6"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -17227,7 +17227,7 @@ Ultra Low Input Bias Current</description>
 <gate name="G$1" symbol="INA114U" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="5"/>
 <connect gate="G$1" pin="-IN" pad="4"/>
@@ -17282,7 +17282,7 @@ High Speed FET-Input</description>
 <gate name="G$1" symbol="INA114U" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="5"/>
 <connect gate="G$1" pin="-IN" pad="4"/>
@@ -17337,7 +17337,7 @@ Low Distortion, Low Noise</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+GD" pad="5"/>
 <connect gate="G$1" pin="+GS" pad="2"/>
@@ -17384,7 +17384,7 @@ Low Distortion, Low Noise</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17429,7 +17429,7 @@ Low Distortion, Low Noise</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="U" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+INA" pad="3"/>
 <connect gate="G$1" pin="+INB" pad="5"/>
@@ -17488,7 +17488,7 @@ Low Distortion, Low Noise</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17558,7 +17558,7 @@ Micropower, Single and Dual Versions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+INA" pad="2"/>
 <connect gate="G$1" pin="+INB" pad="15"/>
@@ -17620,7 +17620,7 @@ Micropower, Single and Dual Versions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -17696,7 +17696,7 @@ Micropower, Single and Dual Versions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BW" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -17739,7 +17739,7 @@ Micropower, Single and Dual Versions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+VL" pad="3"/>
 <connect gate="G$1" pin="+VS" pad="16"/>
@@ -18253,7 +18253,7 @@ Fast-Settling FET-Input</description>
 <technology name="K"/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!10!" pad="13"/>
 <connect gate="G$1" pin="!100!" pad="12"/>
@@ -18306,7 +18306,7 @@ Fast-Settling FET-Input</description>
 <gate name="G$1" symbol="BUF634F" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BW" pad="1"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -18436,7 +18436,7 @@ High-Side, Bidirectional</description>
 <gate name="G$1" symbol="XTR115" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="B" pad="6"/>
 <connect gate="G$1" pin="E" pad="5"/>
@@ -18460,7 +18460,7 @@ Quad, Serial Input, 12-Bit, Voltage Output</description>
 <gate name="G$1" symbol="DAC7715" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="12"/>
 <connect gate="G$1" pin="!LOADDACS!" pad="13"/>

--- a/cirrus.lbr
+++ b/cirrus.lbr
@@ -632,9 +632,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 9.7mm
 <wire x1="4.95" y1="-2" x2="4.95" y2="2" width="0.2032" layer="21"/>
 <wire x1="4.95" y1="2" x2="-4.95" y2="2" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -697,9 +697,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -770,9 +770,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -811,14 +811,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SSOP-10-50P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads)&lt;/b&gt;&lt;p&gt;
@@ -2426,7 +2426,7 @@ Stereo 114 dB, 192 kHz, Multi-Bit Audio A/D Converter</description>
 <gate name="G$1" symbol="CS5361" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-KSZ" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="-KSZ" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!HPF!" pad="11"/>
 <connect gate="G$1" pin="!OVFL!" pad="15"/>
@@ -2497,7 +2497,7 @@ Stereo 114 dB, 192 kHz, Multi-Bit Audio A/D Converter</description>
 <gate name="G$1" symbol="CS8406_SW" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-CSS" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="-CSS" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="9"/>
 <connect gate="G$1" pin="AD0/!CS!" pad="2"/>
@@ -2576,7 +2576,7 @@ Stereo 114 dB, 192 kHz, Multi-Bit Audio A/D Converter</description>
 <gate name="G$1" symbol="CS8406_HW" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-CSS" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="-CSS" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!AUDIO!" pad="19"/>
 <connect gate="G$1" pin="!EMPH!" pad="3"/>
@@ -2699,7 +2699,7 @@ Stereo 108 dB, 192 kHz, Multi-Bit Audio A/D Converter</description>
 <gate name="G$1" symbol="CS5351" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-KSZ" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="-KSZ" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!HPF!" pad="11"/>
 <connect gate="G$1" pin="!OVFL!" pad="15"/>
@@ -2886,7 +2886,7 @@ CrystalLAN 100BASE-X and 10BASE-T Transceiver</description>
 <gate name="G$1" symbol="CS3310" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!MUTE!" pad="8"/>
@@ -3076,7 +3076,7 @@ Low Power, Stereo CODEC with Headphone Amp</description>
 <gate name="IC1" symbol="CS4340" x="5.08" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="IC1" pin="!RST!" pad="1"/>
 <connect gate="IC1" pin="AGND" pad="13"/>

--- a/cml-micro.lbr
+++ b/cml-micro.lbr
@@ -372,9 +372,9 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <wire x1="5.1" y1="-2.6" x2="5.1" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="5.1" y1="2.6" x2="-5.05" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -421,9 +421,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1061,7 +1061,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="DW" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="A" pin="!TX_EN_L!" pad="14"/>
 <connect gate="A" pin="D0" pad="4"/>
@@ -1121,7 +1121,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="!RX_TONE_DEC!" pad="13"/>
 <connect gate="A" pin="D0" pad="10"/>
@@ -1193,7 +1193,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <gate name="P" symbol="VDDVSS" x="-35.56" y="17.78"/>
 </gates>
 <devices>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="!CS!" pad="6"/>
 <connect gate="A" pin="!IRQ!" pad="7"/>
@@ -1326,7 +1326,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="A" pin="!CS!" pad="6"/>
 <connect gate="A" pin="!IRQ!" pad="7"/>
@@ -1396,7 +1396,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <gate name="G$1" symbol="CMX639D4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!POWERSAVE!" pad="10"/>
 <connect gate="G$1" pin="ALGORITHM" pad="13"/>
@@ -1458,7 +1458,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D2" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D2" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RXHOLD!" pad="5"/>
 <connect gate="G$1" pin="BT" pad="15"/>
@@ -1560,7 +1560,7 @@ Digitally Controlled</description>
 <gate name="G$1" symbol="FX019" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="DW" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!LOAD!/LATCH" pad="3"/>
 <connect gate="G$1" pin="CS" pad="14"/>

--- a/crystal.lbr
+++ b/crystal.lbr
@@ -2371,11 +2371,11 @@ ABS10 Series, 4.9 x 1.8mm</description>
 <text x="-2.8575" y="1.5875" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2.8575" y="-2.2225" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-14-127P-530W-1030L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-14-127P-530W-1030L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-4.25" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.01" y1="-3.9" x2="-3.61" y2="-2.65" layer="51"/>
 <rectangle x1="-4.01" y1="2.65" x2="-3.61" y2="3.9" layer="51"/>
@@ -5219,7 +5219,7 @@ ABM3 Series</description>
 <gate name="G$1" symbol="QG" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-14-127P-530W-1030L-210H-125F">
+<device name="" package="SOIC-14-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="G$1" pin="GND" pad="14"/>
 <connect gate="G$1" pin="OUT" pad="2"/>

--- a/cypressmicro.lbr
+++ b/cypressmicro.lbr
@@ -2102,9 +2102,9 @@ Thin profile Quad Flat Package. 0.80mm pitch, 1.0mm lead length 10mm length, 10m
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2159,9 +2159,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2842,7 +2842,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SI" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SI" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="P0(0)" pad="24"/>
 <connect gate="G$1" pin="P0(1)" pad="4"/>
@@ -3067,7 +3067,7 @@ a range of convinient pinouts and memory size on one single chip.</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SI" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="SI" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="P0(0)" pad="16"/>
 <connect gate="G$1" pin="P0(1)" pad="4"/>

--- a/diode.lbr
+++ b/diode.lbr
@@ -5349,9 +5349,9 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <rectangle x1="0.4318" y1="-0.4318" x2="0.8382" y2="0.4318" layer="51"/>
 <rectangle x1="-0.8382" y1="-0.4318" x2="-0.4318" y2="0.4318" layer="51"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -5374,14 +5374,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SOD123F">
 <description>SOD123F - NXP Semiconductor</description>
@@ -16764,7 +16764,7 @@ Semtech</description>
 <gate name="G$1" symbol="SLVU2.8-4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
@@ -16787,7 +16787,7 @@ Semtech</description>
 <gate name="G$1" symbol="CDNBS08-SLVU2.8-4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
@@ -17589,7 +17589,7 @@ Semtech</description>
 <gate name="G$1" symbol="SLVU2.8-4_S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>

--- a/diodes-inc.lbr
+++ b/diodes-inc.lbr
@@ -94,9 +94,9 @@
 </layers>
 <library>
 <packages>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -119,14 +119,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SSOP-8-65P-300W-300L-110H-95F-170EW-170EL">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
@@ -336,7 +336,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="G$1" symbol="AP2176" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!FLAGA!" pad="2"/>
 <connect gate="G$1" pin="!FLAGB" pad="3"/>
@@ -375,7 +375,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="G$1" symbol="AP2166" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!ENA!" pad="1"/>
 <connect gate="G$1" pin="!ENB!" pad="4"/>
@@ -414,7 +414,7 @@ Small outline package. 0.95mm pitch, 1.3mm body width, 3 leads. JEDEC TO-236H, v
 <gate name="G$1" symbol="AP2192A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!FLAGA!" pad="8"/>
 <connect gate="G$1" pin="!FLAGB" pad="5"/>

--- a/exar.lbr
+++ b/exar.lbr
@@ -283,11 +283,11 @@ Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body wid
 <wire x1="8.2931" y1="7.015" x2="8.2931" y2="8.2931" width="0.2032" layer="21"/>
 <wire x1="8.2931" y1="8.2931" x2="7.015" y2="8.2931" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-530W-530L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-8-127P-530W-530L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-1.75" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-2.105" y1="-3.9" x2="-1.705" y2="-2.65" layer="51"/>
 <rectangle x1="-2.105" y1="2.65" x2="-1.705" y2="3.9" layer="51"/>
@@ -316,9 +316,9 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="2.625" y1="-2.625" x2="-2.625" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="2.625" x2="-2.625" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -357,14 +357,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="PLCC-20-127P-896W-896L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 8.97mm length, 8.97mm width, 4.57mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
@@ -428,9 +428,9 @@ Plastic leaded chip carrier. 1.27mm pitch, 8.97mm body length, 8.97mm body width
 <wire x1="4.4831" y1="3.205" x2="4.4831" y2="4.4831" width="0.2032" layer="21"/>
 <wire x1="4.4831" y1="4.4831" x2="3.205" y2="4.4831" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-24-127P-840W-1540L-254H-180F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 15.40mm length, 8.40mm width, 2.54mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body length,
+<package name="SOIC-24-127P-840W-1540L-254H-180F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.8mm lead length, 15.40mm length, 8.40mm width, 2.54mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body length,
 8.40mm body width, 2.54mm max height, 24 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-059B, variation AA.&lt;/p&gt;</description>
@@ -485,10 +485,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body l
 <smd name="24" x="-6.985" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-8.2" y="-4.2" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="8.7" y="-4.2" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<wire x1="-7.6" y1="-4.1" x2="7.6" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="-7.6" y1="4.1" x2="-7.6" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="7.6" y1="-4.1" x2="7.6" y2="4.1" width="0.2032" layer="21"/>
-<wire x1="7.6" y1="4.1" x2="-7.6" y2="4.1" width="0.2032" layer="21"/>&gt;
+<wire x1="-7.8" y1="-4.1" x2="7.8" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-7.8" y1="4.1" x2="-7.8" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-7.675" y1="-4.175" x2="-7.675" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="-7.675" y1="4.175" x2="7.675" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="7.675" y1="-4.175" x2="-7.675" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="7.675" y1="4.175" x2="7.675" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="7.8" y1="-4.1" x2="7.8" y2="4.1" width="0.2032" layer="21"/>
+<wire x1="7.8" y1="4.1" x2="-7.8" y2="4.1" width="0.2032" layer="21"/>
 </package>
 <package name="PLCC-68-127P-2423W-2423L-457H">
 <description>&lt;b&gt;PLCC (1.27mm pitch, 24.23mm length, 24.23mm width, 4.57mm max height, 68 leads)&lt;/b&gt;&lt;p&gt;
@@ -1123,11 +1127,11 @@ Plastic leaded chip carrier. 1.27mm pitch, 19.13mm body length, 19.13mm body wid
 <rectangle x1="-5.15" y1="2.25" x2="-3.15" y2="2.55" layer="51"/>
 <rectangle x1="-5.15" y1="3.05" x2="-3.15" y2="3.35" layer="51"/>
 </package>
-<package name="SOP-16-127P-530W-1030L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-16-127P-530W-1030L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-4.25" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.645" y1="-3.9" x2="-4.245" y2="-2.65" layer="51"/>
 <rectangle x1="-4.645" y1="2.65" x2="-4.245" y2="3.9" layer="51"/>
@@ -1172,9 +1176,9 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="5.125" y1="-2.625" x2="-5.125" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="2.625" x2="-5.125" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-20-127P-840W-1280L-254H-180F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 12.80mm length, 8.40mm width, 2.54mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body length,
+<package name="SOIC-20-127P-840W-1280L-254H-180F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.8mm lead length, 12.80mm length, 8.40mm width, 2.54mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body length,
 8.40mm body width, 2.54mm max height, 20 leads.
 &lt;/p&gt;
 &lt;p&gt;Non-standard, based on JEDEC MO-059B.&lt;/p&gt;</description>
@@ -1221,10 +1225,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <smd name="20" x="-5.715" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-6.9" y="-4.2" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="7.4" y="-4.2" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<wire x1="-6.3" y1="-4.1" x2="6.3" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="-6.3" y1="4.1" x2="-6.3" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="6.3" y1="-4.1" x2="6.3" y2="4.1" width="0.2032" layer="21"/>
-<wire x1="6.3" y1="4.1" x2="-6.3" y2="4.1" width="0.2032" layer="21"/>&gt;
+<wire x1="-6.5" y1="-4.1" x2="6.5" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-6.5" y1="4.1" x2="-6.5" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-6.375" y1="-4.175" x2="-6.375" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="-6.375" y1="4.175" x2="6.375" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="6.375" y1="-4.175" x2="-6.375" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="6.375" y1="4.175" x2="6.375" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="6.5" y1="-4.1" x2="6.5" y2="4.1" width="0.2032" layer="21"/>
+<wire x1="6.5" y1="4.1" x2="-6.5" y2="4.1" width="0.2032" layer="21"/>
 </package>
 <package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
@@ -1682,9 +1690,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <text x="-28.575" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-22.225" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -1707,18 +1715,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1765,9 +1773,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1822,9 +1830,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -5430,7 +5438,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="P" symbol="PWRN" x="-35.56" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="D" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AMSI" pad="1"/>
 <connect gate="G$1" pin="BIAS" pad="10"/>
@@ -5714,7 +5722,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <technology name=""/>
 </technologies>
 </device>
-<device name="MD" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="MD" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CSO" pad="1"/>
 <connect gate="G$1" pin="IN_V" pad="7"/>
@@ -6576,7 +6584,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="P" symbol="PWR+/-" x="-33.02" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-530W-1030L-210H-125F">
+<device name="" package="SOIC-16-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="G$1" pin="C1" pad="13"/>
 <connect gate="G$1" pin="C2" pad="14"/>
@@ -6632,7 +6640,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="P" symbol="PWRN" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="C" pad="5"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -6882,7 +6890,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="G$1" symbol="XR-2321D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-840W-1540L-254H-180F">
+<device name="" package="SOIC-24-127P-840W-1540L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="10"/>
 <connect gate="G$1" pin="!RD" pad="9"/>
@@ -9260,7 +9268,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="G$1" symbol="XR-532AD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!AMD" pad="19"/>
 <connect gate="G$1" pin="!RD" pad="4"/>
@@ -9453,7 +9461,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="G$1" symbol="4610R4CD" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-840W-1280L-254H-180F">
+<device name="" package="SOIC-20-127P-840W-1280L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="20"/>
 <connect gate="G$1" pin="!WDI" pad="12"/>
@@ -9488,7 +9496,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="G$1" symbol="4610R2CD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-530W-1030L-210H-125F">
+<device name="" package="SOIC-16-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="16"/>
 <connect gate="G$1" pin="!WDI" pad="9"/>
@@ -9519,7 +9527,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="G$1" symbol="4610R4CD" x="0" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-840W-1280L-254H-180F">
+<device name="" package="SOIC-20-127P-840W-1280L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="20"/>
 <connect gate="G$1" pin="!WDI" pad="12"/>
@@ -9554,7 +9562,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="G$1" symbol="4610R2CD" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-530W-1030L-210H-125F">
+<device name="" package="SOIC-16-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="16"/>
 <connect gate="G$1" pin="!WDI" pad="9"/>
@@ -9628,7 +9636,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="G$1" symbol="XR-9050" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!AMD" pad="14"/>
 <connect gate="G$1" pin="!DRD" pad="22"/>
@@ -9738,7 +9746,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="G$1" symbol="XR-1001" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="5"/>
 <connect gate="G$1" pin="CLKIN" pad="1"/>
@@ -9796,7 +9804,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="G$1" symbol="XR-1010" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="50/100/PD" pad="12"/>
 <connect gate="G$1" pin="AGND" pad="15"/>
@@ -9883,7 +9891,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="G$1" symbol="XR-1016D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="5/10" pad="1"/>
 <connect gate="G$1" pin="A+IN" pad="8"/>
@@ -10280,7 +10288,7 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <gate name="P" symbol="VCC-GND" x="27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="CN" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="CN" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>

--- a/fairchild-semi.lbr
+++ b/fairchild-semi.lbr
@@ -238,9 +238,9 @@ body 3x3mm, pitch 0.95mm</description>
 <rectangle x1="-1.125" y1="-0.625" x2="1.125" y2="0.625" layer="31"/>
 <rectangle x1="-2.125" y1="-1.625" x2="-1.75" y2="-1.25" layer="21"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -263,14 +263,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="UFQFN12">
 <description>&lt;b&gt;12-UFQFN&lt;/b&gt;&lt;p&gt;
@@ -1376,7 +1376,7 @@ Non-Inverting with Open Drain</description>
 <gate name="G$1" symbol="FAN8303" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BS" pad="1"/>
 <connect gate="G$1" pin="COMP" pad="6"/>

--- a/honeywell.lbr
+++ b/honeywell.lbr
@@ -135,9 +135,9 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <text x="-1.905" y="6.08" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-1.905" y="-6" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -160,14 +160,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="LPCC20">
 <description>&lt;b&gt;LPCC 20&lt;/b&gt;&lt;p&gt;
@@ -509,7 +509,7 @@ body 4x4mm</description>
 <gate name="G$1" symbol="HCM1501" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND1" pad="2"/>
 <connect gate="G$1" pin="GND2" pad="7"/>
@@ -529,7 +529,7 @@ body 4x4mm</description>
 <gate name="G$1" symbol="HCM1512" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND-A" pad="8"/>
 <connect gate="G$1" pin="GND-B" pad="7"/>

--- a/intersil.lbr
+++ b/intersil.lbr
@@ -132,9 +132,9 @@ Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0m
 <wire x1="1.6" y1="-1.4" x2="1.6" y2="1.4" width="0.2032" layer="21"/>
 <wire x1="1.6" y1="1.4" x2="-1.6" y2="1.4" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -157,14 +157,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SSOP-10-50P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.50mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 10 leads)&lt;/b&gt;&lt;p&gt;
@@ -609,7 +609,7 @@ body 3.9 mm/JEDEC MS-012AC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="IB" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="IB" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!IRQ!" pad="7"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -695,7 +695,7 @@ body 3.9 mm/JEDEC MS-012AC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="FBZ" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="FBZ" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A/Y" pad="6"/>
@@ -758,7 +758,7 @@ body 3.9 mm/JEDEC MS-012AC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="IBZ" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="IBZ" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -781,7 +781,7 @@ body 3.9 mm/JEDEC MS-012AC</description>
 <gate name="G$1" symbol="ISL12022" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!IRQ!/FOUT" pad="7"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -804,7 +804,7 @@ body 3.9 mm/JEDEC MS-012AC</description>
 <gate name="G$1" symbol="ISL83485" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="AY" pad="6"/>
@@ -827,7 +827,7 @@ body 3.9 mm/JEDEC MS-012AC</description>
 <gate name="G$1" symbol="ISL83490" x="0" y="0"/>
 </gates>
 <devices>
-<device name="B" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="B" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>

--- a/isd-new.lbr
+++ b/isd-new.lbr
@@ -197,9 +197,9 @@ Winbond Electronics, Corp.&lt;p&gt;
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -631,7 +631,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$5" symbol="NC-LEFT" x="15.24" y="20.32" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -713,7 +713,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="90"/>
 </technologies>
 </device>
-<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="IC1" pin="A0" pad="1"/>
 <connect gate="IC1" pin="A1" pad="2"/>
@@ -846,7 +846,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="16"/>
 </technologies>
 </device>
-<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="22"/>
@@ -884,7 +884,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="16"/>
 </technologies>
 </device>
-<device name="SI" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SI" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="22"/>
@@ -1094,7 +1094,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="08"/>
 </technologies>
 </device>
-<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="21"/>
@@ -1132,7 +1132,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="08"/>
 </technologies>
 </device>
-<device name="SI" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SI" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="21"/>
@@ -1342,7 +1342,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="240"/>
 </technologies>
 </device>
-<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="21"/>
@@ -1380,7 +1380,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <technology name="240"/>
 </technologies>
 </device>
-<device name="SI" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SI" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="5"/>
 <connect gate="G$10" pin="NC" pad="21"/>
@@ -1576,7 +1576,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="02S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="02S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$2" pin="NC" pad="7"/>
 <connect gate="G$3" pin="NC" pad="21"/>
@@ -1611,7 +1611,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="04S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="04S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$2" pin="NC" pad="7"/>
 <connect gate="G$3" pin="NC" pad="21"/>
@@ -1646,7 +1646,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="08S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="08S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$2" pin="NC" pad="7"/>
 <connect gate="G$3" pin="NC" pad="21"/>
@@ -1681,7 +1681,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="16S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="16S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$2" pin="NC" pad="7"/>
 <connect gate="G$3" pin="NC" pad="21"/>
@@ -1901,7 +1901,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="32S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="32S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="8"/>
 <connect gate="IC" pin="A0" pad="1"/>
@@ -2006,7 +2006,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="40S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="40S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="8"/>
 <connect gate="IC" pin="A0" pad="1"/>
@@ -2111,7 +2111,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="48S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="48S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="8"/>
 <connect gate="IC" pin="A0" pad="1"/>
@@ -2216,7 +2216,7 @@ devices with digital storage capability.&lt;/b&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="64S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="64S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="NC" pad="8"/>
 <connect gate="IC" pin="A0" pad="1"/>

--- a/isd.lbr
+++ b/isd.lbr
@@ -116,9 +116,9 @@
 <text x="-18.415" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.16" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -634,7 +634,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="!CE!" pad="23"/>
 <connect gate="A" pin="!EOM!" pad="25"/>
@@ -702,7 +702,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT!" pad="25"/>
 <connect gate="G$1" pin="!SS!" pad="1"/>
@@ -735,7 +735,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="G$1" symbol="ISD51XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT!" pad="25"/>
 <connect gate="G$1" pin="A0" pad="4"/>
@@ -849,7 +849,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="G$1" symbol="ISD17XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="S" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!ERASE!" pad="25"/>
 <connect gate="G$1" pin="!FT!" pad="22"/>

--- a/linear-technology.lbr
+++ b/linear-technology.lbr
@@ -742,9 +742,9 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -767,18 +767,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -813,18 +813,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -871,9 +871,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -912,14 +912,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="DFN12-3X3">
 <description>DFN 3x3mm, 12 lead</description>
@@ -3911,7 +3911,7 @@ with shutdown</description>
 <gate name="G$2" symbol="NC" x="35.56" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="5"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -3976,7 +3976,7 @@ with shutdown</description>
 <gate name="G$1" symbol="LT1016" x="0" y="0"/>
 </gates>
 <devices>
-<device name="CS8" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="CS8" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!OUT" pad="8"/>
 <connect gate="G$1" pin="+IN" pad="2"/>
@@ -4060,7 +4060,7 @@ with shutdown</description>
 <gate name="P" symbol="PWRN" x="20.32" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4123,7 +4123,7 @@ Linear Technology, Digikey part #: LT1716IS5-ND</description>
 <gate name="G$1" symbol="LT1512" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FB" pad="2"/>
 <connect gate="G$1" pin="GND1@2" pad="7"/>
@@ -4223,7 +4223,7 @@ Switched Capacitor Regulated</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="CS8" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="CS8" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="5"/>
 <connect gate="G$1" pin="C1+" pad="2"/>
@@ -4261,7 +4261,7 @@ Switched Capacitor Regulated</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="CS8" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="CS8" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4316,7 +4316,7 @@ Switched Capacitor Regulated</description>
 <gate name="G$1" symbol="LT1910" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!FAULT!" pad="3"/>
 <connect gate="G$1" pin="GATE" pad="5"/>
@@ -4356,7 +4356,7 @@ Switched Capacitor Regulated</description>
 <gate name="G$1" symbol="ITC137P" x="-15.24" y="20.32"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="B" pad="14"/>
 <connect gate="G$1" pin="BRG" pad="11"/>
@@ -4531,7 +4531,7 @@ fixed output with shutdown control</description>
 <gate name="G$1" symbol="LTC1155" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="DS1" pad="1"/>
 <connect gate="G$1" pin="DS2" pad="8"/>
@@ -4577,7 +4577,7 @@ fixed output with shutdown control</description>
 <gate name="G$1" symbol="LT1735" x="0" y="-22.86"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BG" pad="11"/>
 <connect gate="G$1" pin="BOOST" pad="15"/>
@@ -4607,7 +4607,7 @@ fixed output with shutdown control</description>
 <gate name="G$1" symbol="LTC1877" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="ITH" pad="2"/>
@@ -4655,7 +4655,7 @@ fixed output with shutdown control</description>
 <gate name="G$1" symbol="LT1620IS8" x="0" y="-10.16"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="AVG" pad="8"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -4737,7 +4737,7 @@ High-Voltage Synchronous Current Mode</description>
 <gate name="G$1" symbol="LT1676" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FB" pad="7"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -4914,7 +4914,7 @@ adjustable output with shutdown control</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="S" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="3"/>
 <connect gate="G$1" pin="A" pad="12"/>
@@ -4943,7 +4943,7 @@ adjustable output with shutdown control</description>
 <gate name="P" symbol="PWR+-" x="7.62" y="-7.62"/>
 </gates>
 <devices>
-<device name="S8" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S8" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5186,7 +5186,7 @@ Switched Capacitor Voltage Convertor</description>
 <gate name="G$1" symbol="LT1054" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S8" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S8" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CAP+" pad="2"/>
 <connect gate="G$1" pin="CAP-" pad="4"/>
@@ -5240,7 +5240,7 @@ Ultralow Power with Shutdown</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S8" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S8" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -5420,7 +5420,7 @@ Power Tracking 2A for Solar Power</description>
 <gate name="G$1" symbol="LT1763" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="5"/>
 <connect gate="G$1" pin="BYP" pad="4"/>
@@ -5478,7 +5478,7 @@ Positive High Voltage Ideal Diode Controller</description>
 <gate name="G$1" symbol="LTC485" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S8" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S8" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>

--- a/linear.lbr
+++ b/linear.lbr
@@ -802,9 +802,9 @@ National Semiconductor</description>
 <text x="-1.905" y="-3.175" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-1.27" y="1.27" size="0.254" layer="250">NS Z03A</text>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1599,9 +1599,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <rectangle x1="3" y1="-10.995" x2="3.8" y2="-7.045" layer="21"/>
 <hole x="0" y="5.455" drill="3.175"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -1624,18 +1624,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -1670,18 +1670,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-14-127P-750W-900L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads.&lt;/p&gt;
+<package name="SOIC-14-127P-750W-900L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AF, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-3.6" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1724,9 +1724,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length,
 <wire x1="4.475" y1="-3.725" x2="-4.475" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="4.475" y1="3.725" x2="-4.475" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1781,9 +1781,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1846,9 +1846,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1919,9 +1919,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-18-127P-750W-1155L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
+<package name="SOIC-18-127P-750W-1155L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.875" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1972,9 +1972,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -2013,14 +2013,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -4507,7 +4507,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4544,7 +4544,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4582,7 +4582,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4620,7 +4620,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4655,7 +4655,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4692,7 +4692,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4740,7 +4740,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4794,7 +4794,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -4848,7 +4848,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -4891,7 +4891,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4941,7 +4941,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5000,7 +5000,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5038,7 +5038,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5077,7 +5077,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="UA"/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5116,7 +5116,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5154,7 +5154,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5192,7 +5192,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5245,7 +5245,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5298,7 +5298,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5336,7 +5336,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5374,7 +5374,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5412,7 +5412,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5454,7 +5454,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="E"/>
 </technologies>
 </device>
-<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="R" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5530,7 +5530,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5583,7 +5583,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5621,7 +5621,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5674,7 +5674,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5712,7 +5712,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5750,7 +5750,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LM"/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5788,7 +5788,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5826,7 +5826,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5865,7 +5865,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="UA"/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5904,7 +5904,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5942,7 +5942,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5980,7 +5980,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6018,7 +6018,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6056,7 +6056,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6094,7 +6094,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6155,7 +6155,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6193,7 +6193,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6231,7 +6231,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6269,7 +6269,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6307,7 +6307,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6345,7 +6345,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6383,7 +6383,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6421,7 +6421,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6459,7 +6459,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6497,7 +6497,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6535,7 +6535,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6573,7 +6573,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6611,7 +6611,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6651,7 +6651,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6691,7 +6691,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6731,7 +6731,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6771,7 +6771,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6811,7 +6811,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6851,7 +6851,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6891,7 +6891,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6931,7 +6931,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -6971,7 +6971,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7011,7 +7011,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7051,7 +7051,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7091,7 +7091,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7131,7 +7131,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LM"/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7171,7 +7171,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7211,7 +7211,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7251,7 +7251,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7291,7 +7291,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7331,7 +7331,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7396,7 +7396,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7436,7 +7436,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7476,7 +7476,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7516,7 +7516,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7556,7 +7556,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7596,7 +7596,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7636,7 +7636,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name="LM"/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7684,7 +7684,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -7738,7 +7738,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -7773,7 +7773,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <gate name="P" symbol="PWR+-" x="15.24" y="10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7890,7 +7890,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7944,7 +7944,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -7998,7 +7998,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8052,7 +8052,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8106,7 +8106,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8160,7 +8160,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8214,7 +8214,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8268,7 +8268,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8322,7 +8322,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8376,7 +8376,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8430,7 +8430,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8484,7 +8484,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8538,7 +8538,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="1"/>
@@ -8592,7 +8592,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8646,7 +8646,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8700,7 +8700,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8754,7 +8754,7 @@ source  http://products.analog.com/products/info.asp?product=OP400</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -8809,7 +8809,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -8884,7 +8884,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -8938,7 +8938,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -8992,7 +8992,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -9112,7 +9112,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name="UA"/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="CV" pad="5"/>
 <connect gate="A" pin="DIS" pad="7"/>
@@ -9377,7 +9377,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="1"/>
 <connect gate="A" pin="-IN" pad="6"/>
@@ -9535,7 +9535,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -9579,7 +9579,7 @@ current output</description>
 <technology name="SE"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="CV" pad="3"/>
 <connect gate="A" pin="DIS" pad="1"/>
@@ -9652,7 +9652,7 @@ current output</description>
 <technology name="NE"/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="CT" pad="6"/>
 <connect gate="A" pin="GND" pad="7"/>
@@ -9774,7 +9774,7 @@ current output</description>
 <technology name="LM"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="+CL" pad="4"/>
 <connect gate="A" pin="+IN" pad="2"/>
@@ -9831,7 +9831,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -9887,7 +9887,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -9943,7 +9943,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10001,7 +10001,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10060,7 +10060,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10119,7 +10119,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10178,7 +10178,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10235,7 +10235,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10291,7 +10291,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10349,7 +10349,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10408,7 +10408,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10467,7 +10467,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10522,7 +10522,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="1"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -10575,7 +10575,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="1"/>
 <connect gate="A" pin="D2" pad="3"/>
@@ -10622,7 +10622,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="9"/>
 <connect gate="A" pin="IN" pad="14"/>
@@ -10666,7 +10666,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="9"/>
 <connect gate="A" pin="IN" pad="14"/>
@@ -10719,7 +10719,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10767,7 +10767,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="1"/>
 <connect gate="A" pin="IN" pad="6"/>
@@ -10813,7 +10813,7 @@ current output</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!RS!" pad="7"/>
 <connect gate="A" pin="!WR!" pad="2"/>
@@ -10906,7 +10906,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="16"/>
 <connect gate="A" pin="IN" pad="1"/>
@@ -10961,7 +10961,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="1"/>
 <connect gate="A" pin="G" pad="3"/>
@@ -11004,7 +11004,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="3"/>
 <connect gate="A" pin="GND@2" pad="4"/>
@@ -11095,7 +11095,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="GND" pad="4"/>
 <connect gate="A" pin="OPT" pad="3"/>
@@ -11139,7 +11139,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="GND" pad="4"/>
 <connect gate="A" pin="OPT" pad="3"/>
@@ -11204,7 +11204,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="2"/>
 <connect gate="A" pin="-IN" pad="3"/>
@@ -11452,7 +11452,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="1"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -11492,7 +11492,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="1"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -11532,7 +11532,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="7"/>
 <connect gate="A" pin="-IN" pad="8"/>
@@ -11572,7 +11572,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="7"/>
 <connect gate="A" pin="-IN" pad="8"/>
@@ -11618,7 +11618,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!IO!" pad="2"/>
 <connect gate="A" pin="+VR" pad="14"/>
@@ -11713,7 +11713,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -11748,7 +11748,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="1"/>
 <connect gate="A" pin="-IN" pad="14"/>
@@ -11786,7 +11786,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="G1A" pad="7"/>
 <connect gate="A" pin="G1B" pad="2"/>
@@ -11872,7 +11872,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -11933,7 +11933,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="GND" pad="4"/>
 <connect gate="A" pin="OPT" pad="3"/>
@@ -11980,7 +11980,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="AGC" pad="5"/>
 <connect gate="A" pin="BS" pad="10"/>
@@ -12090,7 +12090,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name="UA"/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -12189,7 +12189,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="D" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="A0" pad="25"/>
 <connect gate="A" pin="A1" pad="24"/>
@@ -12255,7 +12255,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!IOUT!" pad="2"/>
 <connect gate="A" pin="+V" pad="13"/>
@@ -12309,7 +12309,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="P" pin="GND" pad="2"/>
 <connect gate="P" pin="VCC" pad="13"/>
@@ -12390,7 +12390,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12428,7 +12428,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12466,7 +12466,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12505,7 +12505,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name="2"/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12544,7 +12544,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12584,7 +12584,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12624,7 +12624,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -12679,7 +12679,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name="02"/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+VCC" pad="23"/>
 <connect gate="G$1" pin="-VCC" pad="19"/>
@@ -12750,7 +12750,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name="3"/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="+VCC" pad="23"/>
 <connect gate="G$1" pin="-VCC" pad="19"/>
@@ -12895,7 +12895,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="2"/>
 <connect gate="G$1" pin="-IN" pad="1"/>
@@ -12950,7 +12950,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWR+-GR" x="0" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="S" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="S" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="A" pin="CTL" pad="2"/>
 <connect gate="A" pin="IN" pad="4"/>
@@ -13027,7 +13027,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13065,7 +13065,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -13190,7 +13190,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="R" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="+VS" pad="6"/>
@@ -13230,7 +13230,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13270,7 +13270,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13297,7 +13297,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="PWR+-" x="-10.16" y="10.16" addlevel="always"/>
 </gates>
 <devices>
-<device name="GS" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="GS" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -13436,7 +13436,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!SH!" pad="8"/>
 <connect gate="G$1" pin="CHOLD" pad="6"/>
@@ -13484,7 +13484,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="NC5" symbol="NC" x="30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND@1" pad="2"/>
 <connect gate="G$1" pin="GND@2" pad="3"/>
@@ -13528,7 +13528,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="7"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13578,7 +13578,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="11"/>
 <connect gate="G$1" pin="CH0" pad="1"/>
@@ -13634,7 +13634,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="8"/>
 <connect gate="G$1" pin="CH0" pad="3"/>
@@ -13678,7 +13678,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CH0" pad="2"/>
 <connect gate="G$1" pin="CH1" pad="3"/>
@@ -13693,7 +13693,7 @@ latched 4/8-channel analog multiplexer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-14-127P-750W-900L-265H-140F">
+<device name="S" package="SOIC-14-127P-750W-900L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CH0" pad="3"/>
 <connect gate="G$1" pin="CH1" pad="5"/>
@@ -13753,7 +13753,7 @@ latched 4/8-channel analog multiplexer</description>
 <gate name="P" symbol="VCCVSS" x="27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="T" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="T" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="-(B-Y)" pad="3"/>
 <connect gate="G$1" pin="-(R-Y)" pad="1"/>
@@ -13825,7 +13825,7 @@ Philips Semiconductors</description>
 <gate name="P" symbol="VDDVSS" x="22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="T" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="T" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="BK" pad="16"/>
 <connect gate="G$1" pin="CB" pad="17"/>
@@ -13903,7 +13903,7 @@ Philips Semiconductors</description>
 <gate name="G$1" symbol="MC34119" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CD" pad="1"/>
 <connect gate="G$1" pin="FC1" pad="3"/>
@@ -13981,7 +13981,7 @@ Philips Semiconductors</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14126,7 +14126,7 @@ http://onsemi.com tl494-d.pdf</description>
 <technology name="I"/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+I1" pad="1"/>
 <connect gate="G$1" pin="+I2" pad="16"/>
@@ -14181,7 +14181,7 @@ http://onsemi.com tl494-d.pdf</description>
 <gate name="G$1" symbol="IR4426" x="-2.54" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="INA" pad="2"/>
@@ -14310,7 +14310,7 @@ cm8870.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="S" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="A" pin="EST" pad="16"/>
 <connect gate="A" pin="GS" pad="3"/>
@@ -14376,7 +14376,7 @@ Microchip</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14440,7 +14440,7 @@ Microchip</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="SN" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14509,7 +14509,7 @@ Microchip</description>
 <gate name="G$1" symbol="MIC4429" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="GND2" pad="5"/>
@@ -14570,7 +14570,7 @@ National Overture Series&lt;p&gt;High-Performance 68W Audio Power Amplifier w/Mu
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14611,7 +14611,7 @@ dual with linearizing diodes and buffers</description>
 <gate name="P" symbol="PWR+-" x="-38.1" y="15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="M" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -14665,7 +14665,7 @@ dual with linearizing diodes and buffers</description>
 <gate name="G$1" symbol="LMH6551" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="-IN" pad="1"/>
@@ -14714,7 +14714,7 @@ dual with linearizing diodes and buffers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -14746,7 +14746,7 @@ dual with linearizing diodes and buffers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14766,7 +14766,7 @@ dual with linearizing diodes and buffers</description>
 <gate name="G$1" symbol="TLE2426" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COM" pad="2"/>
 <connect gate="G$1" pin="IN" pad="3"/>
@@ -14804,7 +14804,7 @@ dual with linearizing diodes and buffers</description>
 <gate name="G$1" symbol="IRS2011" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COM" pad="7"/>
 <connect gate="G$1" pin="HIN" pad="5"/>
@@ -14841,7 +14841,7 @@ dual with linearizing diodes and buffers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -14878,7 +14878,7 @@ dual with linearizing diodes and buffers</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>

--- a/luminary-arm.lbr
+++ b/luminary-arm.lbr
@@ -463,9 +463,9 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14mm
 <wire x1="6.9" y1="-6.9" x2="6.9" y2="6.9" width="0.2032" layer="21"/>
 <wire x1="6.9" y1="6.9" x2="-6.9" y2="6.9" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2792,7 +2792,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S102" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="32KHZ/PB1" pad="20"/>
@@ -3654,7 +3654,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="LM3S101" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RST!" pad="5"/>
 <connect gate="G$1" pin="32KHZ/PB1" pad="20"/>

--- a/maxim.lbr
+++ b/maxim.lbr
@@ -233,9 +233,9 @@ Plastic leaded chip carrier. 1.27mm pitch, 16.59mm body length, 16.59mm body wid
 <text x="-2.54" y="3.175" size="1.016" layer="25" ratio="18">&gt;NAME</text>
 <text x="-2.032" y="-4.572" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1366,9 +1366,9 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 5mm length, 5mm 
 <wire x1="2.4" y1="-2.4" x2="2.4" y2="2.4" width="0.2032" layer="21"/>
 <wire x1="2.4" y1="2.4" x2="-2.4" y2="2.4" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1415,9 +1415,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1472,9 +1472,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-18-127P-750W-1155L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
+<package name="SOIC-18-127P-750W-1155L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.875" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1525,9 +1525,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1883,9 +1883,9 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <rectangle x1="-2.3725" y1="1.8" x2="-2.0725" y2="3.1" layer="51"/>
 <rectangle x1="-3.0075" y1="1.8" x2="-2.7075" y2="3.1" layer="51"/>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -1920,18 +1920,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -1970,14 +1970,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SSOP-16-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
@@ -2085,9 +2085,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 6.5mm
 <wire x1="3.35" y1="-2" x2="3.35" y2="2" width="0.2032" layer="21"/>
 <wire x1="3.35" y1="2" x2="-3.35" y2="2" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -2110,14 +2110,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
@@ -14750,7 +14750,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MX580CS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+2,5V" pad="1"/>
 <connect gate="G$1" pin="+VS" pad="8"/>
@@ -14895,7 +14895,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="REF02" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="NC" pad="1"/>
@@ -15149,7 +15149,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX454" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="-IN" pad="13"/>
 <connect gate="G$1" pin="A0" pad="2"/>
@@ -15412,7 +15412,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX630" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+VS" pad="5"/>
 <connect gate="G$1" pin="CX" pad="2"/>
@@ -15481,7 +15481,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX634" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+VS" pad="6"/>
 <connect gate="G$1" pin="CX" pad="3"/>
@@ -15527,7 +15527,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX635" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+VS" pad="6"/>
 <connect gate="G$1" pin="-VOUT" pad="1"/>
@@ -15573,7 +15573,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX638" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+VS" pad="6"/>
 <connect gate="G$1" pin="COMP" pad="8"/>
@@ -15619,7 +15619,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX641" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COMP" pad="8"/>
 <connect gate="G$1" pin="EXT" pad="6"/>
@@ -15665,7 +15665,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX663" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SENSE" pad="1"/>
@@ -15711,7 +15711,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX664" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="8"/>
 <connect gate="G$1" pin="SENSE" pad="2"/>
@@ -15757,7 +15757,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX666" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="LBI" pad="3"/>
@@ -15805,7 +15805,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="7"/>
 <connect gate="G$1" pin="C1-" pad="1"/>
@@ -15971,7 +15971,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX8211" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="5"/>
 <connect gate="G$1" pin="HYSTER" pad="2"/>
@@ -16017,7 +16017,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7660" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CAP+" pad="2"/>
 <connect gate="G$1" pin="CAP-" pad="4"/>
@@ -16063,7 +16063,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7663" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="OUT1" pad="3"/>
@@ -16109,7 +16109,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7664" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="8"/>
 <connect gate="G$1" pin="OUT1" pad="7"/>
@@ -16155,7 +16155,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="ICL7665" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="HYST1" pad="2"/>
@@ -17796,7 +17796,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -17819,7 +17819,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="DW" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -19064,7 +19064,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="22.86" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="PFI" pad="4"/>
 <connect gate="G$1" pin="PFO" pad="5"/>
@@ -19088,7 +19088,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="27.94" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BATT-ON" pad="5"/>
 <connect gate="G$1" pin="CE-IN" pad="13"/>
@@ -21231,7 +21231,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="SA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="1" pin="C1+" pad="2"/>
 <connect gate="1" pin="C1-" pad="1"/>
@@ -22472,7 +22472,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX201" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C+" pad="1"/>
 <connect gate="G$1" pin="C-" pad="2"/>
@@ -22769,7 +22769,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX318" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COM" pad="1"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -22792,7 +22792,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX317" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COM" pad="1"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -22815,7 +22815,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX306" x="2.54" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -22901,7 +22901,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$3" symbol="MAX307" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$3" pin="A0" pad="17"/>
 <connect gate="G$3" pin="A1" pad="16"/>
@@ -22944,7 +22944,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX308" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="A0" pad="1"/>
 <connect gate="G$4" pin="A1" pad="16"/>
@@ -22975,7 +22975,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX309" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -23006,7 +23006,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX333" x="2.54" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="COM1" pad="3"/>
 <connect gate="G$1" pin="COM2" pad="8"/>
@@ -23080,7 +23080,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX335" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="24"/>
 <connect gate="G$1" pin="COM0" pad="6"/>
@@ -23150,7 +23150,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX338" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="A0" pad="1"/>
 <connect gate="G$2" pin="A1" pad="16"/>
@@ -23212,7 +23212,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX339" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="A0" pad="1"/>
 <connect gate="G$4" pin="A1" pad="16"/>
@@ -23274,7 +23274,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX351" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="COM1" pad="2"/>
 <connect gate="G$2" pin="COM2" pad="15"/>
@@ -23336,7 +23336,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX352" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="COM1" pad="2"/>
 <connect gate="G$4" pin="COM2" pad="15"/>
@@ -23398,7 +23398,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$6" symbol="MAX353" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$6" pin="COM1" pad="2"/>
 <connect gate="G$6" pin="COM2" pad="15"/>
@@ -23460,7 +23460,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX361" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="COM1" pad="2"/>
 <connect gate="G$2" pin="COM2" pad="15"/>
@@ -23522,7 +23522,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX362" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="COM1" pad="2"/>
 <connect gate="G$2" pin="COM2" pad="15"/>
@@ -23584,7 +23584,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX351" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="COM1" pad="2"/>
 <connect gate="G$2" pin="COM2" pad="15"/>
@@ -23646,7 +23646,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX352" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="COM1" pad="2"/>
 <connect gate="G$4" pin="COM2" pad="15"/>
@@ -23700,7 +23700,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX366" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$2" pin="IN1" pad="1"/>
 <connect gate="G$2" pin="IN2" pad="2"/>
@@ -23756,7 +23756,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX367" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$2" pin="IN1" pad="1"/>
 <connect gate="G$2" pin="IN2" pad="2"/>
@@ -23820,7 +23820,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX381" x="2.54" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="COM1" pad="1"/>
 <connect gate="G$2" pin="COM2" pad="8"/>
@@ -23882,7 +23882,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX383" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="COM1" pad="1"/>
 <connect gate="G$4" pin="COM2" pad="8"/>
@@ -23913,7 +23913,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$6" symbol="MAX385" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$6" pin="COM1" pad="1"/>
 <connect gate="G$6" pin="COM2" pad="8"/>
@@ -23975,7 +23975,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX391" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="COM1" pad="2"/>
 <connect gate="G$2" pin="COM2" pad="15"/>
@@ -24037,7 +24037,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX392" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="COM1" pad="2"/>
 <connect gate="G$4" pin="COM2" pad="15"/>
@@ -24099,7 +24099,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$6" symbol="MAX393" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$6" pin="COM1" pad="2"/>
 <connect gate="G$6" pin="COM2" pad="15"/>
@@ -24161,7 +24161,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="MAX398" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="A0" pad="1"/>
 <connect gate="G$2" pin="A1" pad="16"/>
@@ -24223,7 +24223,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$4" symbol="MAX399" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$4" pin="A0" pad="1"/>
 <connect gate="G$4" pin="A1" pad="16"/>
@@ -24254,7 +24254,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG401" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="D1" pad="1"/>
 <connect gate="G$1" pin="D2" pad="8"/>
@@ -24308,7 +24308,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$3" symbol="DG403" x="0" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$3" pin="D1" pad="1"/>
 <connect gate="G$3" pin="D2" pad="8"/>
@@ -24366,7 +24366,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$5" symbol="DG403" x="0" y="-7.62"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$5" pin="D1" pad="1"/>
 <connect gate="G$5" pin="D2" pad="8"/>
@@ -24395,7 +24395,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="DG406" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="16"/>
@@ -24435,7 +24435,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="DG408" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="A0" pad="1"/>
 <connect gate="G$2" pin="A1" pad="16"/>
@@ -24497,7 +24497,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="DG409" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="A0" pad="1"/>
 <connect gate="G$2" pin="A1" pad="16"/>
@@ -24528,7 +24528,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="DG411" x="0" y="7.62"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$2" pin="D1" pad="2"/>
 <connect gate="G$2" pin="D2" pad="15"/>
@@ -24707,7 +24707,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name="6E"/>
 </technologies>
 </device>
-<device name="SA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FB" pad="2"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -24760,7 +24760,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$2" symbol="VCC-GND" x="33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN" pad="1"/>
 <connect gate="G$1" pin="TAP1" pad="7"/>
@@ -24828,7 +24828,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="15" symbol="NC" x="45.72" y="-12.7" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="10" pin="NC" pad="10"/>
 <connect gate="12" pin="NC" pad="12"/>
@@ -24982,7 +24982,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="30.48" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="WE" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="WE" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -25054,7 +25054,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name="E"/>
 </technologies>
 </device>
-<device name="SE" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SE" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -25111,7 +25111,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -25159,7 +25159,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="CSA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="CSA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -25216,7 +25216,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="PWR2GND" x="27.94" y="-15.24" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="1" pin="NC" pad="1"/>
 <connect gate="13" pin="NC" pad="13"/>
@@ -25293,7 +25293,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX705" x="0" y="0"/>
 </gates>
 <devices>
-<device name="CSA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="CSA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="MR" pad="1"/>
@@ -25354,7 +25354,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX705" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="MR" pad="1"/>
@@ -25393,7 +25393,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -25453,7 +25453,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="NC3" symbol="NC" x="30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -25496,7 +25496,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gates>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <technologies>
 <technology name=""/>
 </technologies>
@@ -25509,7 +25509,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="NC1" symbol="MAX4137" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="NC1" pin="!SEL1!" pad="23"/>
 <connect gate="NC1" pin="!SEL2!" pad="22"/>
@@ -25548,7 +25548,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="NC1" symbol="MAX4138" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="NC1" pin="!SEL1!" pad="23"/>
 <connect gate="NC1" pin="!SEL2!" pad="22"/>
@@ -25588,7 +25588,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="25.4" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -25620,7 +25620,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="35.56" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -25652,7 +25652,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="PWR2GND" x="33.02" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="13"/>
 <connect gate="G$1" pin="C1-" pad="14"/>
@@ -25688,7 +25688,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX236" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="10"/>
 <connect gate="G$1" pin="C1-" pad="12"/>
@@ -25768,7 +25768,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="33.02" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="10"/>
 <connect gate="G$1" pin="C1-" pad="12"/>
@@ -25808,7 +25808,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="27.94" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="10"/>
 <connect gate="G$1" pin="C1-" pad="12"/>
@@ -25848,7 +25848,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="30.48" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="12"/>
 <connect gate="G$1" pin="C1-" pad="14"/>
@@ -25892,7 +25892,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="12"/>
 <connect gate="G$1" pin="C1-" pad="14"/>
@@ -25936,7 +25936,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="33.02" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="12"/>
 <connect gate="G$1" pin="C1-" pad="14"/>
@@ -25982,7 +25982,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="2" symbol="BUFF3P" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="1" pin="NC" pad="1"/>
 <connect gate="2" pin="GND" pad="2"/>
@@ -26054,7 +26054,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="8" symbol="NC" x="22.86" y="-10.16" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="1" pin="NC" pad="1"/>
 <connect gate="5" pin="NC" pad="5"/>
@@ -26124,7 +26124,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!LOWLINE!" pad="7"/>
 <connect gate="G$1" pin="!MR!" pad="6"/>
@@ -26156,7 +26156,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="PWR2GND" x="25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="13"/>
 <connect gate="G$1" pin="C1-" pad="14"/>
@@ -26192,7 +26192,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="P" symbol="VCC-GND" x="30.48" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="BATT-ON" pad="5"/>
 <connect gate="G$1" pin="CE-IN" pad="13"/>
@@ -26223,7 +26223,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <gate name="G$1" symbol="MAX038" x="0" y="0"/>
 </gates>
 <devices>
-<device name="WP" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="WP" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="3"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -26369,7 +26369,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 28 leads. JED
 <technology name="3E"/>
 </technologies>
 </device>
-<device name="SE" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="SE" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!FASTCHG!" pad="8"/>
 <connect gate="G$1" pin="BATT+" pad="2"/>
@@ -26653,7 +26653,7 @@ High-Speed, Low-Power, Single-Supply, Multichannel</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="ESA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="ESA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="N1" pin="!SHDN!" pad="2"/>
 <connect gate="N1" pin="A0" pad="1"/>
@@ -26692,7 +26692,7 @@ High-Speed, Low-Power, Single-Supply, Multichannel</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="EUA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="EUA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="N1" pin="!SHDN!" pad="2"/>
 <connect gate="N1" pin="A0" pad="1"/>
@@ -26716,7 +26716,7 @@ High-Speed, Low-Power, Single-Supply, Multichannel</description>
 <gate name="N1" symbol="MAX4311" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="ESD" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="ESD" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="N1" pin="!SHDN!" pad="12"/>
 <connect gate="N1" pin="A0" pad="2"/>
@@ -26761,7 +26761,7 @@ High-Speed, Low-Power, Single-Supply, Multichannel</description>
 <gate name="N1" symbol="MAX4312" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="ESE" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="ESE" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="N1" pin="!SHDN!" pad="14"/>
 <connect gate="N1" pin="A0" pad="3"/>
@@ -26816,7 +26816,7 @@ High-Speed, Low-Power, Single-Supply, Multichannel</description>
 <gate name="N1" symbol="MAX4314" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="ESD" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="ESD" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="N1" pin="!SHDN!" pad="12"/>
 <connect gate="N1" pin="A0" pad="3"/>
@@ -26863,7 +26863,7 @@ High-Speed, Low-Power, Single-Supply, Multichannel</description>
 <gate name="N1" symbol="MAX4315" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="ESE" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="ESE" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="N1" pin="!SHDN!" pad="14"/>
 <connect gate="N1" pin="A0" pad="3"/>
@@ -27058,7 +27058,7 @@ http://dbserv.maxim-ic.com/</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!EN!" pad="1"/>
 <connect gate="G$1" pin="!FORCEOFF!" pad="20"/>
@@ -27131,7 +27131,7 @@ http://dbserv.maxim-ic.com/</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="DW" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!FORCEOFF!" pad="22"/>
 <connect gate="G$1" pin="!INVALID!" pad="21"/>
@@ -27225,7 +27225,7 @@ DALLAS Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="Z" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="Z" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -27273,7 +27273,7 @@ DALLAS Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -27304,7 +27304,7 @@ DALLAS Semiconductor</description>
 <gate name="P" symbol="PWR+GND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="CSA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="CSA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-1" pin="COM" pad="2"/>
 <connect gate="-1" pin="IN" pad="7"/>
@@ -27344,7 +27344,7 @@ DALLAS Semiconductor</description>
 <gate name="P" symbol="PWR+GND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="CSA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="CSA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-1" pin="COM" pad="2"/>
 <connect gate="-1" pin="IN" pad="7"/>
@@ -27384,7 +27384,7 @@ DALLAS Semiconductor</description>
 <gate name="P" symbol="PWR+-" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="CSA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="CSA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-A" pin="COM" pad="2"/>
 <connect gate="-A" pin="IN" pad="7"/>
@@ -27490,7 +27490,7 @@ DALLAS Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="INTA" pad="3"/>
@@ -27643,7 +27643,7 @@ Half-Duplex Differential Transceiver for Battery-Powered Systems</description>
 <gate name="P" symbol="VCC-GND" x="27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -27666,7 +27666,7 @@ Half-Duplex Differential Transceiver for Battery-Powered Systems</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="DW" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -27935,7 +27935,7 @@ Regulated 5V Charge Pump</description>
 <gate name="G$1" symbol="MAX619" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!ON!/OFF" pad="7"/>
 <connect gate="G$1" pin="C1+" pad="1"/>
@@ -28104,7 +28104,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <technology name="E"/>
 </technologies>
 </device>
-<device name="PA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="PA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -28131,7 +28131,7 @@ Source: http://pdfserv.maxim-ic.com/en/ds/MAX985-MAX994.pdf</description>
 <gate name="P" symbol="PWR+-" x="17.78" y="0"/>
 </gates>
 <devices>
-<device name="ESA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="ESA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -28190,7 +28190,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <technology name="69E"/>
 </technologies>
 </device>
-<device name="SA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="6"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -28231,7 +28231,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="OUT" pad="5"/>
@@ -28298,7 +28298,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <gate name="G$1" symbol="DS32KHZS" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="32KHZ" pad="1"/>
 <connect gate="G$1" pin="GND@13" pad="13"/>
@@ -28400,7 +28400,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <gate name="P" symbol="PWR+GND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="CSA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="CSA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="COM" pad="2"/>
 <connect gate="A" pin="IN" pad="7"/>
@@ -28475,7 +28475,7 @@ Source: MAX3465-MAX3469.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="CS" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="CS" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="FB" pad="3"/>
 <connect gate="G$1" pin="GND" pad="6"/>
@@ -28805,7 +28805,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="P" symbol="PWR_VCCVEE" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -28872,7 +28872,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="G$1" symbol="MAX5035" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BST" pad="1"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -29000,7 +29000,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="P" symbol="V+-GND2" x="-27.94" y="0" addlevel="request" swaplevel="1"/>
 </gates>
 <devices>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="2"/>
 <connect gate="G$1" pin="IN-" pad="3"/>
@@ -29071,7 +29071,7 @@ Precision, Low-Power, High-Voltage</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="AA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="AA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="IN" pad="2"/>
@@ -29090,7 +29090,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="G$1" symbol="MAX682/3/4" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="2"/>
 <connect gate="G$1" pin="!SKIP!" pad="1"/>
@@ -29239,7 +29239,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="G$1" symbol="MAX889" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="6"/>
 <connect gate="G$1" pin="CAP+" pad="2"/>
@@ -29301,7 +29301,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="G$1" symbol="MAX1673" x="0" y="0"/>
 </gates>
 <devices>
-<device name="ESA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="ESA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!SHDN!" pad="4"/>
 <connect gate="G$1" pin="CAP+" pad="2"/>
@@ -29325,7 +29325,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="G$1" symbol="MAX3488" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -29435,7 +29435,7 @@ Micropower, Single-Supply, Rail-to-Rail</description>
 <gate name="G$1" symbol="MAX4194" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -29459,7 +29459,7 @@ Micropower, Single-Supply, Rail-to-Rail</description>
 <gate name="G$1" symbol="MAX4197" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -29482,7 +29482,7 @@ Micropower, Single-Supply, Rail-to-Rail</description>
 <gate name="G$1" symbol="MAX9051" x="0" y="0"/>
 </gates>
 <devices>
-<device name="ESA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="ESA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -29541,7 +29541,7 @@ with Alarm</description>
 <gate name="G$1" symbol="DS1682" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!ALARM!" pad="3"/>
 <connect gate="G$1" pin="EVENT" pad="1"/>
@@ -29563,7 +29563,7 @@ with Alarm</description>
 <gate name="G$1" symbol="MAX3490" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>

--- a/memory-atmel.lbr
+++ b/memory-atmel.lbr
@@ -269,9 +269,9 @@ body 11.8 x 8 mm&lt;p&gt;</description>
 <vertex x="-1" y="1.4"/>
 </polygon>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -294,20 +294,20 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-530W-530L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-8-127P-530W-530L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-1.75" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-2.105" y1="-3.9" x2="-1.705" y2="-2.65" layer="51"/>
 <rectangle x1="-2.105" y1="2.65" x2="-1.705" y2="3.9" layer="51"/>
@@ -389,9 +389,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm
 <wire x1="1.6" y1="-2" x2="1.6" y2="2" width="0.2032" layer="21"/>
 <wire x1="1.6" y1="2" x2="-1.6" y2="2" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-750W-530L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads.&lt;/p&gt;
+<package name="SOIC-8-127P-750W-530L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads.&lt;/p&gt;
 
 &lt;p&gt;Non-standard, based on JEDEC MS-013F, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-1.75" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -856,9 +856,9 @@ Rectangular plastic leaded chip carrier. 1.27mm pitch, 11.43mm body length, 13.9
 <text x="-20.955" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-17.145" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-32-127P-890W-2050L-265H-155F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 20.50mm length, 8.90mm width, 2.65mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body length,
+<package name="SOIC-32-127P-890W-2050L-265H-155F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.55mm lead length, 20.50mm length, 8.90mm width, 2.65mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body length,
 8.90mm body width, 2.65mm max height, 32 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-120B, variation AC.&lt;/p&gt;</description>
@@ -929,14 +929,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body 
 <smd name="32" x="-9.525" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-10.75" y="-4.45" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="11.25" y="-4.45" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-10.35" y1="-4.05" x2="10.35" y2="-4.05" width="0.2032" layer="21"/>
+<wire x1="-10.35" y1="4.05" x2="-10.35" y2="-4.05" width="0.2032" layer="21"/>
 <wire x1="-10.225" y1="4.425" x2="-10.225" y2="-4.425" width="0.0508" layer="51"/>
-<wire x1="-10.15" y1="-4.05" x2="10.15" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="-10.15" y1="4.05" x2="-10.15" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="10.15" y1="-4.05" x2="10.15" y2="4.05" width="0.2032" layer="21"/>
-<wire x1="10.15" y1="4.05" x2="-10.15" y2="4.05" width="0.2032" layer="21"/>
 <wire x1="10.225" y1="-4.425" x2="10.225" y2="4.425" width="0.0508" layer="51"/>
 <wire x1="10.225" y1="-4.425" x2="-10.225" y2="-4.425" width="0.0508" layer="51"/>
 <wire x1="10.225" y1="4.425" x2="-10.225" y2="4.425" width="0.0508" layer="51"/>
+<wire x1="10.35" y1="-4.05" x2="10.35" y2="4.05" width="0.2032" layer="21"/>
+<wire x1="10.35" y1="4.05" x2="-10.35" y2="4.05" width="0.2032" layer="21"/>
 </package>
 <package name="SOT23-5">
 <description>&lt;b&gt;TSSOP (SSOT, 0.95mm pitch, 1.6mm body, 5 leads)&lt;/b&gt;&lt;p&gt;
@@ -1605,7 +1605,7 @@ SPI bus serial</description>
 <gate name="G$1" symbol="AT45DB01X" x="0" y="0"/>
 </gates>
 <devices>
-<device name="A" package="SOP-8-127P-750W-530L-265H-140F">
+<device name="A" package="SOIC-8-127P-750W-530L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="4"/>
 <connect gate="G$1" pin="!RST!" pad="3"/>
@@ -1772,7 +1772,7 @@ SPI bus serial</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-SO" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="-SO" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
@@ -1796,7 +1796,7 @@ I2C serial bus</description>
 <gate name="G$1" symbol="AT24C" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-8S1" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="-8S1" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -1811,7 +1811,7 @@ I2C serial bus</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S2" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="-8S2" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -1835,7 +1835,7 @@ DataFlash, 16-megabit, 2.5-volt or 2.7-volt</description>
 <gate name="G$1" symbol="AT45DB161D-S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="4"/>
 <connect gate="G$1" pin="!RST!" pad="3"/>
@@ -1859,7 +1859,7 @@ RapidS Serial Interface, 66 MHZ</description>
 <gate name="G$1" symbol="AT45DB011D" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-SS" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="-SS" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="4"/>
 <connect gate="G$1" pin="!RST!" pad="3"/>
@@ -1874,7 +1874,7 @@ RapidS Serial Interface, 66 MHZ</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-S" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="-S" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="4"/>
 <connect gate="G$1" pin="!RST!" pad="3"/>
@@ -1928,7 +1928,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S1" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="-8S1" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -1943,7 +1943,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S2" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="-8S2" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A1" pad="2"/>
 <connect gate="G$1" pin="A2" pad="3"/>
@@ -1991,7 +1991,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <gate name="G$1" symbol="AT45" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-S" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="-S" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="4"/>
 <connect gate="G$1" pin="!RESET!" pad="3"/>
@@ -2338,7 +2338,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-32-127P-890W-2050L-265H-155F">
+<device name="R" package="SOIC-32-127P-890W-2050L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -2425,7 +2425,7 @@ I2C serial bus, 1M (131,072 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-32-127P-890W-2050L-265H-155F">
+<device name="R" package="SOIC-32-127P-890W-2050L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="22"/>
 <connect gate="G$1" pin="!OE!/VPP" pad="24"/>
@@ -2566,7 +2566,7 @@ I2C serial bus, 512K (65,536 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S1" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="-8S1" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -2581,7 +2581,7 @@ I2C serial bus, 512K (65,536 x 8)</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-8S2" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="-8S2" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>

--- a/memory-cypress.lbr
+++ b/memory-cypress.lbr
@@ -413,11 +413,11 @@ body 8 x 9.5 x 1 mm (51-85178)</description>
 <vertex x="-3.35" y="4.7"/>
 </polygon>
 </package>
-<package name="SOP-8-127P-530W-530L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-8-127P-530W-530L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-1.75" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-2.105" y1="-3.9" x2="-1.705" y2="-2.65" layer="51"/>
 <rectangle x1="-2.105" y1="2.65" x2="-1.705" y2="3.9" layer="51"/>
@@ -953,7 +953,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <gate name="G$1" symbol="FM25V20" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-G" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="-G" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>

--- a/memory-hitachi.lbr
+++ b/memory-hitachi.lbr
@@ -504,9 +504,9 @@
 <text x="-28.575" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-22.225" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2577,7 +2577,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="62256" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>

--- a/memory-idt.lbr
+++ b/memory-idt.lbr
@@ -191,9 +191,9 @@ rectangle</description>
 <rectangle x1="3.43" y1="3.68" x2="4.19" y2="4.13" layer="51"/>
 <rectangle x1="3.43" y1="-4.13" x2="4.19" y2="-3.68" layer="51"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -396,9 +396,9 @@ square</description>
 <rectangle x1="-6.22" y1="-2.92" x2="-5.75" y2="-2.16" layer="51"/>
 <rectangle x1="-6.22" y1="-4.19" x2="-5.75" y2="-3.43" layer="51"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -757,9 +757,9 @@ rectangle</description>
 <rectangle x1="-6.22" y1="-1.65" x2="-5.75" y2="-0.89" layer="51"/>
 <rectangle x1="-6.22" y1="-2.92" x2="-5.75" y2="-2.16" layer="51"/>
 </package>
-<package name="SOP-28-127P-840W-1790L-254H-180F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
+<package name="SOIC-28-127P-840W-1790L-254H-180F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
 8.40mm body width, 2.54mm max height, 28 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-059B, variation AC.&lt;/p&gt;</description>
@@ -822,10 +822,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body l
 <smd name="28" x="-8.255" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-9.45" y="-4.2" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="9.95" y="-4.2" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<wire x1="-8.85" y1="-4.1" x2="8.85" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="-8.85" y1="4.1" x2="-8.85" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="-4.1" x2="8.85" y2="4.1" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="4.1" x2="-8.85" y2="4.1" width="0.2032" layer="21"/>&gt;
+<wire x1="-9.05" y1="-4.1" x2="9.05" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-9.05" y1="4.1" x2="-9.05" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-8.925" y1="-4.175" x2="-8.925" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="-8.925" y1="4.175" x2="8.925" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="8.925" y1="-4.175" x2="-8.925" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="8.925" y1="4.175" x2="8.925" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="9.05" y1="-4.1" x2="9.05" y2="4.1" width="0.2032" layer="21"/>
+<wire x1="9.05" y1="4.1" x2="-9.05" y2="4.1" width="0.2032" layer="21"/>
 </package>
 <package name="C68-1">
 <description>&lt;b&gt;Dual In Line&lt;/b&gt;</description>
@@ -2273,9 +2277,9 @@ rectangle</description>
 <rectangle x1="3.43" y1="-4.95" x2="4.19" y2="-4.48" layer="51"/>
 <rectangle x1="4.7" y1="-4.95" x2="5.46" y2="-4.48" layer="51"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2322,9 +2326,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-18-127P-750W-1155L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
+<package name="SOIC-18-127P-750W-1155L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.875" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -13618,7 +13622,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="9"/>
@@ -13726,7 +13730,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="9"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -13846,7 +13850,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -13926,7 +13930,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="18"/>
 <connect gate="G$1" pin="!OE!" pad="20"/>
@@ -14134,7 +14138,7 @@ body 10 mm</description>
 <gate name="G$1" symbol="100490SO" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="22"/>
 <connect gate="G$1" pin="!WE!" pad="21"/>
@@ -14212,7 +14216,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="10"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -14416,7 +14420,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="10"/>
 <connect gate="G$1" pin="!CS2!" pad="18"/>
@@ -14720,7 +14724,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -14952,7 +14956,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="13"/>
 <connect gate="G$1" pin="!WE!" pad="11"/>
@@ -15032,7 +15036,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="11"/>
 <connect gate="G$1" pin="!WE!" pad="13"/>
@@ -15204,7 +15208,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15558,7 +15562,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15690,7 +15694,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -15870,7 +15874,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -16002,7 +16006,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="14"/>
 <connect gate="G$1" pin="!OE!" pad="13"/>
@@ -17944,7 +17948,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="11"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -17980,7 +17984,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="9"/>
 <connect gate="G$1" pin="D0" pad="4"/>
@@ -18012,7 +18016,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="9"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -18044,7 +18048,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="10"/>
 <connect gate="G$1" pin="D0" pad="4"/>
@@ -18078,7 +18082,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="10"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -20448,7 +20452,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="A#LO" pad="8"/>
 <connect gate="G$1" pin="A0" pad="24"/>
@@ -20580,7 +20584,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!WE!/BLE" pad="9"/>
 <connect gate="G$1" pin="A0" pad="24"/>
@@ -21972,7 +21976,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="13"/>
 <connect gate="G$1" pin="CLK" pad="11"/>
@@ -22228,7 +22232,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C/!D!" pad="23"/>
 <connect gate="G$1" pin="D0" pad="10"/>
@@ -22344,7 +22348,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0A" pad="2"/>
 <connect gate="G$1" pin="A0B" pad="14"/>
@@ -22444,7 +22448,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="1"/>
 <connect gate="G$1" pin="!PE!" pad="9"/>
@@ -22508,7 +22512,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!PE!" pad="9"/>
 <connect gate="G$1" pin="!SR!" pad="1"/>
@@ -22644,7 +22648,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!G!" pad="10"/>
 <connect gate="G$1" pin="!P!" pad="7"/>
@@ -22744,7 +22748,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!PL!" pad="11"/>
 <connect gate="G$1" pin="CPD" pad="4"/>
@@ -23136,7 +23140,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="19"/>
 <connect gate="G$1" pin="A0" pad="2"/>
@@ -23208,7 +23212,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -23316,7 +23320,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MR!" pad="9"/>
 <connect gate="G$1" pin="CP" pad="12"/>
@@ -23424,7 +23428,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="D0" pad="3"/>
@@ -23532,7 +23536,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -23640,7 +23644,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -23744,7 +23748,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CP" pad="9"/>
 <connect gate="G$1" pin="I0A" pad="3"/>
@@ -23848,7 +23852,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -23956,7 +23960,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-17.78" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="D0" pad="3"/>
@@ -24064,7 +24068,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -24172,7 +24176,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="D0" pad="2"/>
 <connect gate="G$1" pin="D1" pad="3"/>
@@ -24280,7 +24284,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="D0" pad="2"/>
 <connect gate="G$1" pin="D1" pad="3"/>
@@ -24392,7 +24396,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CEAB!" pad="11"/>
 <connect gate="G$1" pin="!CEBA!" pad="23"/>
@@ -24512,7 +24516,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="D0" pad="2"/>
@@ -24620,7 +24624,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="11"/>
@@ -24728,7 +24732,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="19"/>
 <connect gate="G$1" pin="A0" pad="2"/>
@@ -24836,7 +24840,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="19"/>
 <connect gate="G$1" pin="A0" pad="2"/>
@@ -24948,7 +24952,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="7.62" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!G!" pad="21"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -25072,7 +25076,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!GBA!" pad="21"/>
 <connect gate="G$1" pin="A1" pad="4"/>
@@ -25196,7 +25200,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="CP" pad="13"/>
@@ -25320,7 +25324,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!EN!" pad="14"/>
@@ -25444,7 +25448,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!EN!" pad="14"/>
@@ -25568,7 +25572,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="D0" pad="2"/>
 <connect gate="G$1" pin="D1" pad="3"/>
@@ -25692,7 +25696,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!ERR!" pad="10"/>
@@ -25772,7 +25776,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!EN!" pad="13"/>
@@ -25940,7 +25944,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OE!" pad="1"/>
 <connect gate="G$1" pin="D0" pad="2"/>
@@ -26020,7 +26024,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!OE!" pad="1"/>
@@ -26100,7 +26104,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="11"/>
 <connect gate="G$1" pin="!PRE!" pad="14"/>
@@ -26312,7 +26316,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!OER!" pad="1"/>
 <connect gate="G$1" pin="!OET!" pad="13"/>
@@ -26392,7 +26396,7 @@ body 10 mm</description>
 <gate name="P" symbol="VCCGND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="OER#1" pad="1"/>
 <connect gate="G$1" pin="OER#2" pad="11"/>

--- a/memory-issi.lbr
+++ b/memory-issi.lbr
@@ -75,11 +75,11 @@
 &lt;p&gt;THIS LIBRARY IS PROVIDED AS IS AND WITHOUT WARRANTY OF ANY KIND, EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2015, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SOP-8-127P-530W-530L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-8-127P-530W-530L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-1.75" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-2.105" y1="-3.9" x2="-1.705" y2="-2.65" layer="51"/>
 <rectangle x1="-2.105" y1="2.65" x2="-1.705" y2="3.9" layer="51"/>
@@ -108,9 +108,9 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="2.625" y1="-2.625" x2="-2.625" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="2.625" x2="-2.625" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -133,14 +133,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="WSON8-JK">
 <description>&lt;b&gt;8-WSON&lt;/b&gt;&lt;p&gt;
@@ -377,7 +377,7 @@ body 6.00 x 5.00 mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JB" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="JB" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!(IO3)" pad="7"/>
@@ -392,7 +392,7 @@ body 6.00 x 5.00 mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="JN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="JN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!(IO3)" pad="7"/>

--- a/memory-microchip.lbr
+++ b/memory-microchip.lbr
@@ -129,9 +129,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -154,14 +154,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
@@ -319,7 +319,7 @@ Small outline no-lead package. 0.50mm pitch, 0.40mm lead length 2mm length, 3mm 
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -357,7 +357,7 @@ Small outline no-lead package. 0.50mm pitch, 0.40mm lead length 2mm length, 3mm 
 <gate name="G$1" symbol="24XX1025" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SM" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SM" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>

--- a/memory-micron.lbr
+++ b/memory-micron.lbr
@@ -381,9 +381,9 @@ Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4m
 <vertex x="-4" y="3.5"/>
 </polygon>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -406,14 +406,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -972,7 +972,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <gate name="G$1" symbol="MP25P20" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
@@ -995,7 +995,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <gate name="G$1" symbol="M25P16" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
 <connect gate="G$1" pin="!S!" pad="1"/>

--- a/memory-nec.lbr
+++ b/memory-nec.lbr
@@ -410,9 +410,9 @@
 <text x="-15.24" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.795" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1789,7 +1789,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="4464" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -1996,7 +1996,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <gate name="G$1" symbol="43256" x="0" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>

--- a/memory-numonyx.lbr
+++ b/memory-numonyx.lbr
@@ -188,9 +188,9 @@ Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4m
 <wire x1="6.1" y1="-8.6" x2="6.1" y2="8.6" width="0.2032" layer="21"/>
 <wire x1="6.1" y1="8.6" x2="-6.1" y2="8.6" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -213,14 +213,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -369,7 +369,7 @@ with byte alterability, 75 MHz SPI bus, standard pinout</description>
 <gate name="G$1" symbol="M25PEXX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="MN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="MN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!RST!" pad="7"/>

--- a/memory-nxp.lbr
+++ b/memory-nxp.lbr
@@ -78,9 +78,9 @@ SDRAM, Flash, etc&lt;p&gt;
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2013, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -103,14 +103,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SSOP-8-65P-300W-300L-110H-95F">
 <description>&lt;b&gt;MSOP (0.65mm pitch, 0.95mm lead length, 3.0mm length, 3.0mm width, 1.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
@@ -170,7 +170,7 @@ Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0m
 <gate name="G$1" symbol="PCA24S08" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!PROT!" pad="3"/>
 <connect gate="G$1" pin="!WP!" pad="7"/>

--- a/memory-spansion.lbr
+++ b/memory-spansion.lbr
@@ -73,11 +73,11 @@
 <library>
 <description>Spansion Inc Memory Devices</description>
 <packages>
-<package name="SOP-8-127P-530W-530L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-8-127P-530W-530L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-1.75" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-2.105" y1="-3.9" x2="-1.705" y2="-2.65" layer="51"/>
 <rectangle x1="-2.105" y1="2.65" x2="-1.705" y2="3.9" layer="51"/>
@@ -321,7 +321,7 @@ Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4m
 <gate name="G$1" symbol="S25F" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!WP!/IO2" pad="3"/>

--- a/memory-sram.lbr
+++ b/memory-sram.lbr
@@ -581,9 +581,9 @@ Small outline package J-lead. Lead pitch 1.27mm, body width 400mil/10.15mm. 28 l
 <wire x1="9.3100" y1="4.9780" x2="9.3100" y2="-4.9780" width="0.2032" layer="21"/>
 <wire x1="9.3100" y1="4.9780" x2="8.8650" y2="4.9780" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-28-127P-840W-1790L-254H-180F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
+<package name="SOIC-28-127P-840W-1790L-254H-180F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
 8.40mm body width, 2.54mm max height, 28 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-059B, variation AC.&lt;/p&gt;</description>
@@ -646,10 +646,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body l
 <smd name="28" x="-8.255" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-9.45" y="-4.2" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="9.95" y="-4.2" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<wire x1="-8.85" y1="-4.1" x2="8.85" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="-8.85" y1="4.1" x2="-8.85" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="-4.1" x2="8.85" y2="4.1" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="4.1" x2="-8.85" y2="4.1" width="0.2032" layer="21"/>&gt;
+<wire x1="-9.05" y1="-4.1" x2="9.05" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-9.05" y1="4.1" x2="-9.05" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-8.925" y1="-4.175" x2="-8.925" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="-8.925" y1="4.175" x2="8.925" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="8.925" y1="-4.175" x2="-8.925" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="8.925" y1="4.175" x2="8.925" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="9.05" y1="-4.1" x2="9.05" y2="4.1" width="0.2032" layer="21"/>
+<wire x1="9.05" y1="4.1" x2="-9.05" y2="4.1" width="0.2032" layer="21"/>
 </package>
 <package name="TSOP28-450-T1">
 <description>TSOP28  Type-I&lt;p&gt;
@@ -2420,7 +2424,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body l
 <gate name="G$1" symbol="LH52256" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>

--- a/memory-sst.lbr
+++ b/memory-sst.lbr
@@ -73,9 +73,9 @@
 <library>
 <description>SST Memory Devices</description>
 <packages>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -98,18 +98,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -263,7 +263,7 @@ body 8.00 x 6.00 mm</description>
 <gate name="G$1" symbol="25XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-S2A" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="-S2A" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
@@ -287,7 +287,7 @@ body 8.00 x 6.00 mm</description>
 <gate name="G$1" symbol="25VF" x="0" y="0"/>
 </gates>
 <devices>
-<device name="-S3" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="-S3" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="1"/>
 <connect gate="G$1" pin="!RST!/!HOLD!" pad="7"/>
@@ -302,7 +302,7 @@ body 8.00 x 6.00 mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-S" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="-S" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="7"/>
 <connect gate="G$1" pin="!RST!/!HOLD!" pad="1"/>
@@ -356,7 +356,7 @@ Serial Quad I/O (SQI) Flash Memory</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S2" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S2" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="1"/>
 <connect gate="G$1" pin="SCK" pad="6"/>

--- a/memory-winbond.lbr
+++ b/memory-winbond.lbr
@@ -75,9 +75,9 @@
 &lt;p&gt;THIS LIBRARY IS PROVIDED AS IS AND WITHOUT WARRANTY OF ANY KIND, EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2010, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -100,14 +100,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="WSON8">
 <description>&lt;b&gt;8-WSON&lt;/b&gt;&lt;p&gt;
@@ -287,7 +287,7 @@ Small outline no-lead package. 0.50mm pitch, 0.40mm lead length 2mm length, 3mm 
 <gate name="G$1" symbol="25XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SS" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SS" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
@@ -302,7 +302,7 @@ Small outline no-lead package. 0.50mm pitch, 0.40mm lead length 2mm length, 3mm 
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!" pad="7"/>
@@ -434,7 +434,7 @@ SPI Serial Flash, 4KB Sectors</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!/IO3" pad="7"/>
@@ -449,7 +449,7 @@ SPI Serial Flash, 4KB Sectors</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SS" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SS" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="1"/>
 <connect gate="G$1" pin="!HOLD!/IO3" pad="7"/>

--- a/memory.lbr
+++ b/memory.lbr
@@ -701,9 +701,9 @@ Thin small outline package. 0.50mm pitch, 0.8mm lead length 12.0mm length, 18.4m
 <text x="-15.24" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-10.795" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-28-127P-890W-1790L-265H-155F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 17.90mm length, 8.90mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body length,
+<package name="SOIC-28-127P-890W-1790L-265H-155F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.55mm lead length, 17.90mm length, 8.90mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body length,
 8.90mm body width, 2.65mm max height, 28 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-120B, variation AB.&lt;/p&gt;</description>
@@ -766,14 +766,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <smd name="28" x="-8.255" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-9.45" y="-4.45" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="9.95" y="-4.45" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-9.05" y1="-4.05" x2="9.05" y2="-4.05" width="0.2032" layer="21"/>
+<wire x1="-9.05" y1="4.05" x2="-9.05" y2="-4.05" width="0.2032" layer="21"/>
 <wire x1="-8.925" y1="4.425" x2="-8.925" y2="-4.425" width="0.0508" layer="51"/>
-<wire x1="-8.85" y1="-4.05" x2="8.85" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="-8.85" y1="4.05" x2="-8.85" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="-4.05" x2="8.85" y2="4.05" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="4.05" x2="-8.85" y2="4.05" width="0.2032" layer="21"/>
 <wire x1="8.925" y1="-4.425" x2="8.925" y2="4.425" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="-4.425" x2="-8.925" y2="-4.425" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="4.425" x2="-8.925" y2="4.425" width="0.0508" layer="51"/>
+<wire x1="9.05" y1="-4.05" x2="9.05" y2="4.05" width="0.2032" layer="21"/>
+<wire x1="9.05" y1="4.05" x2="-9.05" y2="4.05" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -5201,7 +5201,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <gate name="G$1" symbol="257" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-890W-1790L-265H-155F">
+<device name="" package="SOIC-28-127P-890W-1790L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CE!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>

--- a/micrel.lbr
+++ b/micrel.lbr
@@ -582,9 +582,9 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm 
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -607,18 +607,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -665,9 +665,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -706,14 +706,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="QFN-32-50P-500W-500L-100H-40F-310EW-310EL">
 <description>&lt;b&gt;QFN (0.50mm pitch, 0.40mm lead length, 5mm length, 5mm width, 1.00mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
@@ -2523,7 +2523,7 @@ MIC2027/2077</description>
 <gate name="G$1" symbol="MIC2027/77" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="M" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="ENA" pad="2"/>
 <connect gate="G$1" pin="ENB" pad="15"/>
@@ -2546,7 +2546,7 @@ MIC2027/2077</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="WM" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="WM" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="ENA" pad="2"/>
 <connect gate="G$1" pin="ENB" pad="15"/>
@@ -2593,7 +2593,7 @@ MIC2026/2076</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="BM" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="BM" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="ENA" pad="1"/>
 <connect gate="G$1" pin="ENB" pad="4"/>
@@ -3086,7 +3086,7 @@ MOSFET, 6A-Peak</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND@4" pad="4"/>
 <connect gate="G$1" pin="GND@5" pad="5"/>
@@ -3533,7 +3533,7 @@ MOSFET, 6A-Peak</description>
 <gate name="G$1" symbol="MIC5209YM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BYP" pad="4"/>
 <connect gate="G$1" pin="EN" pad="1"/>
@@ -3785,7 +3785,7 @@ Adjustable 150mA Low-Noise</description>
 <gate name="G$1" symbol="MIC5201-X.XYM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EN" pad="5"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -3943,7 +3943,7 @@ Single Channel, High Current, Low Voltage</description>
 <gate name="G$1" symbol="MIC2042-2" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!EN!" pad="1"/>
 <connect gate="G$1" pin="!FAULT!" pad="2"/>
@@ -3966,7 +3966,7 @@ Single Channel, High Current, Low Voltage</description>
 <gate name="G$1" symbol="MIC5239-ADJ" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="2"/>
 <connect gate="G$1" pin="EN" pad="1"/>
@@ -3998,7 +3998,7 @@ Single Channel, High Current, Low Voltage</description>
 <gate name="G$1" symbol="MIC5239" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EN" pad="1"/>
 <connect gate="G$1" pin="FLG" pad="2"/>

--- a/micro-fujitsu.lbr
+++ b/micro-fujitsu.lbr
@@ -899,9 +899,9 @@ Small outline package J-lead. Lead pitch 1.27mm, body width 300mil/7.60mm. 28 le
 <wire x1="9.3100" y1="3.7080" x2="9.3100" y2="-3.7080" width="0.2032" layer="21"/>
 <wire x1="9.3100" y1="3.7080" x2="8.8650" y2="3.7080" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-28-127P-840W-1790L-254H-180F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
+<package name="SOIC-28-127P-840W-1790L-254H-180F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
 8.40mm body width, 2.54mm max height, 28 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-059B, variation AC.&lt;/p&gt;</description>
@@ -964,10 +964,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body l
 <smd name="28" x="-8.255" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-9.45" y="-4.2" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="9.95" y="-4.2" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<wire x1="-8.85" y1="-4.1" x2="8.85" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="-8.85" y1="4.1" x2="-8.85" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="-4.1" x2="8.85" y2="4.1" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="4.1" x2="-8.85" y2="4.1" width="0.2032" layer="21"/>&gt;
+<wire x1="-9.05" y1="-4.1" x2="9.05" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-9.05" y1="4.1" x2="-9.05" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-8.925" y1="-4.175" x2="-8.925" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="-8.925" y1="4.175" x2="8.925" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="8.925" y1="-4.175" x2="-8.925" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="8.925" y1="4.175" x2="8.925" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="9.05" y1="-4.1" x2="9.05" y2="4.1" width="0.2032" layer="21"/>
+<wire x1="9.05" y1="4.1" x2="-9.05" y2="4.1" width="0.2032" layer="21"/>
 </package>
 <package name="SOJ-127-760-32">
 <description>&lt;b&gt;SOJ (1.27mm pitch, 300mil/7.60mm width, 32 leads)&lt;/b&gt;&lt;p&gt;
@@ -1290,9 +1294,9 @@ Small outline package J-lead. Lead pitch 1.27mm, body width 400mil/10.15mm. 32 l
 <wire x1="10.5800" y1="4.9780" x2="10.5800" y2="-4.9780" width="0.2032" layer="21"/>
 <wire x1="10.5800" y1="4.9780" x2="10.1350" y2="4.9780" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-32-127P-890W-2050L-265H-155F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 20.50mm length, 8.90mm width, 2.65mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body length,
+<package name="SOIC-32-127P-890W-2050L-265H-155F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.55mm lead length, 20.50mm length, 8.90mm width, 2.65mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body length,
 8.90mm body width, 2.65mm max height, 32 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-120B, variation AC.&lt;/p&gt;</description>
@@ -1363,14 +1367,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body 
 <smd name="32" x="-9.525" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-10.75" y="-4.45" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="11.25" y="-4.45" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-10.35" y1="-4.05" x2="10.35" y2="-4.05" width="0.2032" layer="21"/>
+<wire x1="-10.35" y1="4.05" x2="-10.35" y2="-4.05" width="0.2032" layer="21"/>
 <wire x1="-10.225" y1="4.425" x2="-10.225" y2="-4.425" width="0.0508" layer="51"/>
-<wire x1="-10.15" y1="-4.05" x2="10.15" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="-10.15" y1="4.05" x2="-10.15" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="10.15" y1="-4.05" x2="10.15" y2="4.05" width="0.2032" layer="21"/>
-<wire x1="10.15" y1="4.05" x2="-10.15" y2="4.05" width="0.2032" layer="21"/>
 <wire x1="10.225" y1="-4.425" x2="10.225" y2="4.425" width="0.0508" layer="51"/>
 <wire x1="10.225" y1="-4.425" x2="-10.225" y2="-4.425" width="0.0508" layer="51"/>
 <wire x1="10.225" y1="4.425" x2="-10.225" y2="4.425" width="0.0508" layer="51"/>
+<wire x1="10.35" y1="-4.05" x2="10.35" y2="4.05" width="0.2032" layer="21"/>
+<wire x1="10.35" y1="4.05" x2="-10.35" y2="4.05" width="0.2032" layer="21"/>
 </package>
 <package name="SOP32-1120W">
 <description>&lt;b&gt;Small Outline Package&lt;/b&gt;</description>
@@ -5030,7 +5034,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -5118,7 +5122,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -5462,7 +5466,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GNDQ" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-32-127P-890W-2050L-265H-155F">
+<device name="" package="SOIC-32-127P-890W-2050L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="24"/>
 <connect gate="G$1" pin="!OE!" pad="10"/>
@@ -5554,7 +5558,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -5738,7 +5742,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-32-127P-890W-2050L-265H-155F">
+<device name="" package="SOIC-32-127P-890W-2050L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="22"/>
 <connect gate="G$1" pin="!OE!" pad="24"/>
@@ -5966,7 +5970,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -6142,7 +6146,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -6610,7 +6614,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -6790,7 +6794,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GND" x="-25.4" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-254H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-254H-180F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="20"/>
 <connect gate="G$1" pin="!OE!" pad="22"/>
@@ -7058,7 +7062,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GNDQ" x="-25.4" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-32-127P-890W-2050L-265H-155F">
+<device name="" package="SOIC-32-127P-890W-2050L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CLR!" pad="28"/>
 <connect gate="G$1" pin="!CS1!" pad="25"/>
@@ -7154,7 +7158,7 @@ Low profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 7mm length, 7mm w
 <gate name="P" symbol="VCC-GNDQ" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-32-127P-890W-2050L-265H-155F">
+<device name="" package="SOIC-32-127P-890W-2050L-265H-155F">
 <connects>
 <connect gate="G$1" pin="!CS1!" pad="24"/>
 <connect gate="G$1" pin="!OE!" pad="10"/>

--- a/micro-motorola.lbr
+++ b/micro-motorola.lbr
@@ -3042,11 +3042,11 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 52 leads.
 <wire x1="12.7" y1="-12.7" x2="12.7" y2="12.7" width="0.2032" layer="21"/>
 <wire x1="12.7" y1="12.7" x2="-11.43" y2="12.7" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-530W-530L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-8-127P-530W-530L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-1.75" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-2.105" y1="-3.9" x2="-1.705" y2="-2.65" layer="51"/>
 <rectangle x1="-2.105" y1="2.65" x2="-1.705" y2="3.9" layer="51"/>
@@ -3263,9 +3263,9 @@ EIAJ EDR-7320.&lt;/p&gt;
 <text x="-26.035" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-16.51" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -3312,9 +3312,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -3369,9 +3369,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -3410,14 +3410,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -11190,7 +11190,7 @@ source MC68HC11F1.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="DW" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="2"/>
@@ -11245,7 +11245,7 @@ source MC68HC11F1.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!TE" pad="14"/>
 <connect gate="G$1" pin="A1" pad="1"/>
@@ -11300,7 +11300,7 @@ source MC68HC11F1.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="DW" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A1" pad="1"/>
 <connect gate="G$1" pin="A2" pad="2"/>
@@ -12514,7 +12514,7 @@ Source: 9S12A128DGV1.pdf; 9S12A256DGV1.pdf</description>
 <gate name="P" symbol="VSSVDD" x="-30.48" y="2.54"/>
 </gates>
 <devices>
-<device name="1" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="1" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="OSC1" pad="3"/>
 <connect gate="A" pin="OSC2/PTA6" pad="4"/>
@@ -12629,7 +12629,7 @@ Source: 9S12A128DGV1.pdf; 9S12A256DGV1.pdf</description>
 <gate name="G$1" symbol="MCHC908QT2" x="12.7" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="PTA0/AD0/TCH0/KBI0" pad="7"/>
 <connect gate="G$1" pin="PTA1/AD1/TCH1/KBI1" pad="6"/>

--- a/micro-philips.lbr
+++ b/micro-philips.lbr
@@ -974,9 +974,9 @@ Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body wid
 <wire x1="2.553" y1="-4.225" x2="2.559" y2="-4.225" width="0.1016" layer="21"/>
 <circle x="1.8128" y="-3.0674" radius="1.6036" width="0.1016" layer="21"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1039,9 +1039,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2381,9 +2381,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -2406,18 +2406,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2464,9 +2464,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -4945,7 +4945,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="T" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="ADR" pad="1"/>
 <connect gate="G$1" pin="CEXT" pad="2"/>
@@ -5007,7 +5007,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="T" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -5061,7 +5061,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="T" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="5"/>
 <connect gate="G$1" pin="A1" pad="6"/>
@@ -5116,7 +5116,7 @@ with power fail detector</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="T" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -5148,7 +5148,7 @@ with digital and analog port functions</description>
 <gate name="G$1" symbol="P82C150" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AVDD" pad="18"/>
 <connect gate="G$1" pin="AVSS" pad="20"/>
@@ -5341,7 +5341,7 @@ with digital and analog port functions</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="T" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="17"/>
 <connect gate="G$1" pin="!IACK" pad="4"/>
@@ -6316,7 +6316,7 @@ with digital and analog port functions</description>
 <gate name="NC" symbol="NC2" x="40.64" y="0" addlevel="can"/>
 </gates>
 <devices>
-<device name="TD" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="TD" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G" pin="LX" pad="2"/>
 <connect gate="G" pin="LY" pad="7"/>
@@ -6346,7 +6346,7 @@ with digital and analog port functions</description>
 <gate name="VSS3" symbol="VSS" x="38.1" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="T" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="T" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="4"/>
 <connect gate="G$1" pin="!INT!" pad="16"/>
@@ -6405,7 +6405,7 @@ Dual bi-directional I2C bus buffer</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="TD" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="TD" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="RX(SDA)" pad="2"/>

--- a/micro-siemens.lbr
+++ b/micro-siemens.lbr
@@ -2197,9 +2197,9 @@ Plastic leaded chip carrier. 1.27mm pitch, 29.31mm body length, 29.31mm body wid
 <vertex x="2.5654" y="3.887"/>
 </polygon>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -10602,7 +10602,7 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 14mm length, 14m
 <gate name="P" symbol="+VBB" x="30.48" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="GND" pad="2"/>
 <connect gate="A" pin="IN1" pad="3"/>

--- a/microchip.lbr
+++ b/microchip.lbr
@@ -2637,9 +2637,9 @@ Micro small outline package. 0.65mm pitch, 0.95mm lead length 3.0mm length, 3.0m
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -2662,20 +2662,20 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-530W-530L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-8-127P-530W-530L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-1.75" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-2.105" y1="-3.9" x2="-1.705" y2="-2.65" layer="51"/>
 <rectangle x1="-2.105" y1="2.65" x2="-1.705" y2="3.9" layer="51"/>
@@ -2704,9 +2704,9 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="2.625" y1="-2.625" x2="-2.625" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="2.625" x2="-2.625" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-8-127P-750W-530L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads.&lt;/p&gt;
+<package name="SOIC-8-127P-750W-530L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads.&lt;/p&gt;
 
 &lt;p&gt;Non-standard, based on JEDEC MS-013F, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-1.75" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -2737,9 +2737,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 5.30mm length,
 <wire x1="2.625" y1="-3.725" x2="-2.625" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="3.725" x2="-2.625" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -2774,18 +2774,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-18-127P-750W-1155L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
+<package name="SOIC-18-127P-750W-1155L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.875" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -3383,9 +3383,9 @@ Metric quad flat package. 0.80mm pitch, 1.6mm lead length 10mm length, 10mm widt
 <wire x1="4.9" y1="-4.9" x2="4.9" y2="4.9" width="0.2032" layer="21"/>
 <wire x1="4.9" y1="4.9" x2="-4.9" y2="4.9" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -3432,9 +3432,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -3505,9 +3505,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -10986,7 +10986,7 @@ see also &lt;a href=PIC16F8*&gt;PIC16F8*&lt;/a&gt;</description>
 <technology name="R84"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="SO" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="16"/>
@@ -11096,7 +11096,7 @@ see also &lt;a href=PIC16F8*&gt;PIC16F8*&lt;/a&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="SO" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="16"/>
@@ -11242,7 +11242,7 @@ EPROM/ROM-based</description>
 <technology name="7A"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="28"/>
 <connect gate="G$1" pin="NC" pad="3"/>
@@ -12445,7 +12445,7 @@ EPROM/ROM-based</description>
 <gate name="G$1" symbol="13IO-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="SO" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="16"/>
@@ -12507,7 +12507,7 @@ see also &lt;a href=PIC16C*&gt;PIC16C*&lt;/a&gt;</description>
 <gate name="G$1" symbol="13IO-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="SO" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="4"/>
 <connect gate="G$1" pin="OSC1" pad="16"/>
@@ -12655,7 +12655,7 @@ PIC16C66, PIC16C72, PIC16C73A, PIC16C76</description>
 <technology name="R63"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="9"/>
@@ -12790,7 +12790,7 @@ EPROM/ROM-based</description>
 <gate name="G$1" symbol="22IO-1" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="9"/>
@@ -12903,7 +12903,7 @@ EPROM/ROM-based</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="1"/>
 <connect gate="G$1" pin="OSC1" pad="9"/>
@@ -13262,7 +13262,7 @@ PIC16F84A, PIC16CR84</description>
 <technology name="672"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="SM" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="GP0" pad="7"/>
 <connect gate="G$1" pin="GP1" pad="6"/>
@@ -13323,7 +13323,7 @@ PIC16F84A, PIC16CR84</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR" pad="14"/>
 <connect gate="G$1" pin="CDAC" pad="22"/>
@@ -13675,7 +13675,7 @@ with LCD driver</description>
 <gate name="G$1" symbol="24AA" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -13698,7 +13698,7 @@ with LCD driver</description>
 <technology name="04C"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="SM" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -13743,7 +13743,7 @@ with LCD driver</description>
 <technology name="04C"/>
 </technologies>
 </device>
-<device name="SL" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="SL" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="3"/>
@@ -13769,7 +13769,7 @@ with LCD driver</description>
 <gate name="G$1" symbol="SERIALEEPROM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-8-127P-750W-530L-265H-140F">
+<device name="SO" package="SOIC-8-127P-750W-530L-265H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -13841,7 +13841,7 @@ with LCD driver</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13856,7 +13856,7 @@ with LCD driver</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="SM" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13899,7 +13899,7 @@ with LCD driver</description>
 <technology name="92"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="SM" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="7" pin="NC" pad="7"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -13946,7 +13946,7 @@ with LCD driver</description>
 <technology name="LC56B"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -13982,7 +13982,7 @@ with LCD driver</description>
 <technology name="LC56B"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="SM" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -14024,7 +14024,7 @@ Microwire with software write protect</description>
 <technology name="66"/>
 </technologies>
 </device>
-<device name="SL" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="SL" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="3"/>
 <connect gate="G$1" pin="CS" pad="2"/>
@@ -14040,7 +14040,7 @@ Microwire with software write protect</description>
 <technology name="66"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="SM" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -14056,7 +14056,7 @@ Microwire with software write protect</description>
 <technology name="66"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -14081,7 +14081,7 @@ Microwire with software write protect</description>
 <gate name="G$1" symbol="93LC46" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -14121,7 +14121,7 @@ Microwire with software write protect</description>
 <technology name="LC66"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="SM" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -14167,7 +14167,7 @@ I2C</description>
 <gate name="G$1" symbol="24AA" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="SM" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -14200,7 +14200,7 @@ I2C</description>
 <technology name="LC64"/>
 </technologies>
 </device>
-<device name="SL" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="SL" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="3"/>
@@ -14267,7 +14267,7 @@ I2C</description>
 <technology name="LCS52"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -14681,7 +14681,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="C"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="2" pin="NC" pad="2"/>
 <connect gate="23" pin="NC" pad="23"/>
@@ -14795,7 +14795,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="LV"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE" pad="20"/>
 <connect gate="G$1" pin="!OE" pad="22"/>
@@ -15096,7 +15096,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="LV"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE" pad="20"/>
 <connect gate="G$1" pin="!OE" pad="22"/>
@@ -15247,7 +15247,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <technology name="C"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE" pad="20"/>
 <connect gate="G$1" pin="A0" pad="10"/>
@@ -15499,7 +15499,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/11125J.pdf</description>
 <gate name="G$1" symbol="27C64" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CE" pad="20"/>
 <connect gate="G$1" pin="!OE" pad="22"/>
@@ -15768,7 +15768,7 @@ code hopping encoder and transponder</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SO" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="P1" pin="GND" pad="5"/>
 <connect gate="P1" pin="LC0" pad="7"/>
@@ -15846,7 +15846,7 @@ code hopping encoder and transponder</description>
 <technology name="LC"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -15881,7 +15881,7 @@ code hopping encoder and transponder</description>
 <technology name="S21A"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!WP" pad="3"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -15916,7 +15916,7 @@ code hopping encoder and transponder</description>
 <technology name="C21A"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="SCL" pad="6"/>
@@ -15988,7 +15988,7 @@ code hopping encoder and transponder</description>
 <technology name="2"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!EDS" pad="3"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -16030,7 +16030,7 @@ code hopping encoder and transponder</description>
 <technology name="LC65"/>
 </technologies>
 </device>
-<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="SM" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -16076,7 +16076,7 @@ code hopping encoder and transponder</description>
 <technology name="65"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CE" pad="4"/>
 <connect gate="G$1" pin="!CEO" pad="6"/>
@@ -16156,7 +16156,7 @@ code hopping encoder and transponder</description>
 <technology name="LC040"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="1"/>
 <connect gate="G$1" pin="!HOLD" pad="7"/>
@@ -16182,7 +16182,7 @@ flash type</description>
 <gate name="G$1" symbol="PIC16F870" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -16452,7 +16452,7 @@ flash type</description>
 <gate name="G$1" symbol="PIC16F872" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -16816,7 +16816,7 @@ flash type</description>
 <gate name="G$1" symbol="PIC16F872" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -16895,7 +16895,7 @@ flash type</description>
 <gate name="G$1" symbol="PIC16F872" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR/THV" pad="1"/>
 <connect gate="G$1" pin="INT/RB0" pad="21"/>
@@ -17088,7 +17088,7 @@ Source: ww1.microchip.com/downloads/en/DeviceDoc/39605c.pdf</description>
 <technology name="2"/>
 </technologies>
 </device>
-<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="SO" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="BKI0/DT/RX/AN6/RB4" pad="10"/>
 <connect gate="G$1" pin="INT0/AN4/RB0" pad="8"/>
@@ -17205,7 +17205,7 @@ Source: http://www.microchip.com .. 41190c.pdf</description>
 <technology name="75"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GP0" pad="7"/>
 <connect gate="G$1" pin="GP1" pad="6"/>
@@ -17283,7 +17283,7 @@ Source: http://www.microchip.com .. 39637a.pdf</description>
 <technology name="5"/>
 </technologies>
 </device>
-<device name="-E/SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="-E/SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CANRX/RB3" pad="24"/>
 <connect gate="G$1" pin="INT0/AN10/RB0" pad="21"/>
@@ -17763,7 +17763,7 @@ Source: http://ww1.microchip.com/downloads/en/devicedoc/39632c.pdf</description>
 <technology name="550"/>
 </technologies>
 </device>
-<device name="W" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="W" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!MCLR!/VPP/RE3" pad="1"/>
 <connect gate="G$1" pin="OSC1/CLKI" pad="9"/>
@@ -17841,7 +17841,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21952a.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="18"/>
 <connect gate="G$1" pin="A0" pad="15"/>
@@ -18019,7 +18019,7 @@ SPI Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="11"/>
 <connect gate="G$1" pin="!RESET" pad="18"/>
@@ -18124,7 +18124,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <technology name="L"/>
 </technologies>
 </device>
-<device name="7SO" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="7SO" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="RA0/AN0" pad="17"/>
 <connect gate="G$1" pin="RA1/AN1" pad="18"/>
@@ -18292,7 +18292,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21796H.pdf</description>
 <technology name="LC"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLK" pad="2"/>
 <connect gate="G$1" pin="CS" pad="1"/>
@@ -18465,7 +18465,7 @@ Source: TC 4469-MOSFET-DRIVER.pdf</description>
 <gate name="P" symbol="VDD-GND-2" x="27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -18501,7 +18501,7 @@ Source: TC 4469-MOSFET-DRIVER.pdf</description>
 <gate name="P" symbol="VDD-GND-2" x="22.86" y="5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -18592,7 +18592,7 @@ Source: TC 4469-MOSFET-DRIVER.pdf</description>
 <gate name="P" symbol="VDD-GND-2" x="22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="B" pad="2"/>
@@ -18910,7 +18910,7 @@ Source: http://www.microchip.com .. 41190E.pdf</description>
 <gate name="G$1" symbol="PIC12F675" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="8"/>
 <connect gate="G$1" pin="GP0/AN0" pad="7"/>
@@ -19330,7 +19330,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40039E.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SL" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="SL" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CIN+/ICSPDAT/AN0/RA0" pad="13"/>
 <connect gate="G$1" pin="CIN-/VREF/ICSPCLK/AN1/RA1" pad="12"/>
@@ -20458,7 +20458,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/41211D_.pdf</description
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GP0/AN0/CIN+/ICSPDAT/ULPWU" pad="7"/>
 <connect gate="G$1" pin="GP1/AN1/CIN-/VREF/ICSPCLK" pad="6"/>
@@ -20515,7 +20515,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21950c.pdf</description>
 <technology name="3"/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-1" pin="!CS" pad="7"/>
 <connect gate="-1" pin="SCK" pad="5"/>
@@ -20601,7 +20601,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/21034D.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="P" pin="!CS!/SHDN" pad="1"/>
 <connect gate="P" pin="CH0" pad="2"/>
@@ -23225,7 +23225,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <gate name="G$1" symbol="PIC16F62*" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="SO" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="RA0/AN0" pad="17"/>
 <connect gate="G$1" pin="RA1/AN1" pad="18"/>
@@ -23322,7 +23322,7 @@ Source: http://ww1.microchip.com/downloads/en/DeviceDoc/40300C.pdf</description>
 <gate name="G$1" symbol="24XX512" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SM" package="SOP-8-127P-530W-530L-210H-125F">
+<device name="SM" package="SOIC-8-127P-530W-530L-210H-125F">
 <connects>
 <connect gate="G$1" pin="A0" pad="1"/>
 <connect gate="G$1" pin="A1" pad="2"/>
@@ -23398,7 +23398,7 @@ nanoWatt Technol</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="-I/SO" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="-I/SO" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!SS!/AN8/RC6" pad="8"/>
 <connect gate="G$1" pin="C12IN1-/AN5/RC1" pad="15"/>
@@ -23512,7 +23512,7 @@ Open-Drain Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -23557,7 +23557,7 @@ SPI Interface</description>
 <gate name="G$1" symbol="MCP23S18" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="12"/>
 <connect gate="G$1" pin="!RESET" pad="16"/>
@@ -23692,7 +23692,7 @@ I2C Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="SO" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="16"/>
 <connect gate="G$1" pin="ADDR" pad="15"/>
@@ -23746,7 +23746,7 @@ I2C Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="/SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CANH" pad="7"/>
 <connect gate="G$1" pin="CANL" pad="6"/>
@@ -23800,7 +23800,7 @@ Internal VREF and SPI Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!LDAC!" pad="5"/>
@@ -23846,7 +23846,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="G$1" symbol="MCP4821" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!LDAC!" pad="5"/>
@@ -23915,7 +23915,7 @@ Push-Pull Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!LDAC!" pad="5"/>
@@ -24183,7 +24183,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="G$1" symbol="TC647B" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!FAULT!" pad="6"/>
 <connect gate="G$1" pin="CF" pad="2"/>
@@ -24299,7 +24299,7 @@ Push-Pull Output Sub-Microamp</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="SO" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="6"/>
 <connect gate="G$1" pin="A0" pad="5"/>
@@ -24430,7 +24430,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="G$1" symbol="MCP23S08" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="SO" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS" pad="7"/>
 <connect gate="G$1" pin="!RESET" pad="6"/>
@@ -24488,7 +24488,7 @@ Push-Pull Output Sub-Microamp</description>
 <gate name="G$1" symbol="MCP2120" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SL" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="SL" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RESET!" pad="4"/>
 <connect gate="G$1" pin="BAUD0" pad="10"/>

--- a/motorola-sensor-driver.lbr
+++ b/motorola-sensor-driver.lbr
@@ -606,9 +606,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 11.0m
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -631,18 +631,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -697,9 +697,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1027,7 +1027,7 @@ http://onsemi.com; mc33039-d.pdf</description>
 <gate name="G$1" symbol="MC33039" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!A" pad="4"/>
 <connect gate="G$1" pin="A" pad="3"/>
@@ -1067,7 +1067,7 @@ http://onsemi.com; mc33035-d.pdf</description>
 <gate name="G$1" symbol="MC33035" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CSENSIN" pad="15"/>
 <connect gate="G$1" pin="!ERRAMP" pad="12"/>
@@ -1166,7 +1166,7 @@ http://onsemi.com; mc33033-d.pdf</description>
 <technology name="MC"/>
 </technologies>
 </device>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!ERRAMP" pad="10"/>
 <connect gate="G$1" pin="AB" pad="17"/>

--- a/national-semi.lbr
+++ b/national-semi.lbr
@@ -174,9 +174,9 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <wire x1="1" y1="-0.625" x2="-1" y2="-0.625" width="0.2032" layer="51"/>
 <wire x1="1" y1="0.625" x2="1" y2="-0.625" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -199,14 +199,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SOT23-5">
 <description>&lt;b&gt;TSSOP (SSOT, 0.95mm pitch, 1.6mm body, 5 leads)&lt;/b&gt;&lt;p&gt;
@@ -1430,7 +1430,7 @@ with over-current protection</description>
 <gate name="G$1" symbol="LM3526-H" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="ENA" pad="1"/>
 <connect gate="G$1" pin="ENB" pad="4"/>
@@ -1454,7 +1454,7 @@ with over-current protection</description>
 <gate name="G$1" symbol="LM3526-L" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!ENA!" pad="1"/>
 <connect gate="G$1" pin="!ENB!" pad="4"/>
@@ -1541,7 +1541,7 @@ Open Drain Output</description>
 <gate name="G$1" symbol="LM2675" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CB" pad="1"/>
 <connect gate="G$1" pin="EN" pad="5"/>
@@ -1799,7 +1799,7 @@ with Precision Enable</description>
 <gate name="G$1" symbol="LM5107" x="0" y="0"/>
 </gates>
 <devices>
-<device name="MA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="MA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="HB" pad="8"/>
 <connect gate="G$1" pin="HI" pad="2"/>
@@ -1990,7 +1990,7 @@ High Efficiency Switching Regulator</description>
 <gate name="G$1" symbol="LM2674" x="0" y="0"/>
 </gates>
 <devices>
-<device name="N" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="N" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CB" pad="1"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -2003,7 +2003,7 @@ High Efficiency Switching Regulator</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CB" pad="1"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -2202,7 +2202,7 @@ SIMPLE SWITCHERSynchronous 1MHz 0.75A</description>
 <gate name="G$1" symbol="LM34" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DM" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="DM" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="VOUT" pad="1"/>

--- a/nxp.lbr
+++ b/nxp.lbr
@@ -392,9 +392,9 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 24 leads. JED
 <wire x1="4.45" y1="-2.6" x2="4.45" y2="2.6" width="0.2032" layer="21"/>
 <wire x1="4.45" y1="2.6" x2="-4.4" y2="2.6" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -441,9 +441,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -692,9 +692,9 @@ Quad flat no-lead package. 0.50mm pitch, 0.40mm lead length 4mm length, 4mm widt
 <wire x1="2.2" y1="-2.2" x2="1.6" y2="-2.2" width="0.2032" layer="21"/>
 <wire x1="2.2" y1="1.6" x2="2.2" y2="2.2" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -717,14 +717,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="DIP-8-254P-762W">
 <description>&lt;b&gt;Dual In Line Package&lt;/b&gt;&lt;p/&gt;
@@ -1216,7 +1216,7 @@ Remote 8-bit I/O expander for I2C-bus</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="T" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1248,7 +1248,7 @@ Remote 8-bit I/O expander for I2C-bus</description>
 <gate name="G$1" symbol="PCA9500" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="D" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!WC" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1326,7 +1326,7 @@ Remote 8-bit I/O expander for I2C-bus</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="D" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1427,7 +1427,7 @@ Remote 8-bit I/O expander for Fm+ I2C-bus with interrupt and reset</description>
 <gate name="G$1" symbol="PCA9672" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="D" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="!RESET" pad="3"/>
@@ -1505,7 +1505,7 @@ with interrupt</description>
 <gate name="G$1" symbol="PCA9675" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="1"/>
 <connect gate="G$1" pin="AD0" pad="21"/>
@@ -1647,7 +1647,7 @@ with interrupt</description>
 <gate name="G$1" symbol="PCA9534" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="D" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="13"/>
 <connect gate="G$1" pin="A0" pad="1"/>
@@ -1762,7 +1762,7 @@ with interrupt</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="T" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="T" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CANH" pad="7"/>
 <connect gate="G$1" pin="CANL" pad="6"/>
@@ -1786,7 +1786,7 @@ with interrupt</description>
 <gate name="G$1" symbol="PCA9535" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="1"/>
 <connect gate="G$1" pin="A0" pad="21"/>
@@ -1888,7 +1888,7 @@ Hot swappable</description>
 <gate name="G$1" symbol="PCA9514" x="0" y="0"/>
 </gates>
 <devices>
-<device name="AD" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="AD" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EN" pad="1"/>
 <connect gate="G$1" pin="GND" pad="4"/>
@@ -1926,7 +1926,7 @@ Hot swappable</description>
 <gate name="G$1" symbol="PCA9517" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EN" pad="5"/>
 <connect gate="G$1" pin="GND" pad="4"/>

--- a/on-semi.lbr
+++ b/on-semi.lbr
@@ -202,9 +202,9 @@ Small outline no-lead package. 0.50mm pitch, 0.40mm lead length 2mm length, 3mm 
 <wire x1="1.1" y1="1.6" x2="1.15" y2="1.6" width="0.2032" layer="21"/>
 <wire x1="1.15" y1="-1.6" x2="1.1" y2="-1.6" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -315,9 +315,9 @@ CASE 485BN−01</description>
 <smd name="36" x="0.825" y="1.05" dx="1.12" dy="1.47" layer="1" rot="R270"/>
 <smd name="34" x="-0.825" y="-1" dx="1.12" dy="1.47" layer="1" rot="R270"/>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -352,14 +352,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SSOP-14-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
@@ -406,9 +406,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <wire x1="2.6" y1="-2" x2="2.6" y2="2" width="0.2032" layer="21"/>
 <wire x1="2.6" y1="2" x2="-2.6" y2="2" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -447,14 +447,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -913,7 +913,7 @@ with programmable delay</description>
 <gate name="G$1" symbol="AMIS-42770" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!EN1!" pad="10"/>
 <connect gate="G$1" pin="!EN2!" pad="2"/>
@@ -997,7 +997,7 @@ with programmable delay</description>
 <gate name="P" symbol="PWRN_VDDVSS" x="-22.86" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="I" pad="1"/>
 <connect gate="A" pin="O" pad="2"/>
@@ -1051,7 +1051,7 @@ with programmable delay</description>
 <gate name="P" symbol="PWRN_VDDVSS" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="IN1" pad="1"/>
 <connect gate="A" pin="IN2" pad="2"/>
@@ -1082,7 +1082,7 @@ with programmable delay</description>
 <gate name="P" symbol="PWRN_VDDVSS" x="-27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="!B!" pad="5"/>
 <connect gate="A" pin="!Q!" pad="7"/>

--- a/op-amp.lbr
+++ b/op-amp.lbr
@@ -355,9 +355,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 3.0mm
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -380,18 +380,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -426,14 +426,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SSOP-14-65P-440W-500L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 5.0mm length, 4.4mm width, 1.20mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
@@ -480,11 +480,11 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <wire x1="2.6" y1="-2" x2="2.6" y2="2" width="0.2032" layer="21"/>
 <wire x1="2.6" y1="2" x2="-2.6" y2="2" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-14-127P-530W-1030L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-14-127P-530W-1030L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-4.25" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.01" y1="-3.9" x2="-3.61" y2="-2.65" layer="51"/>
 <rectangle x1="-4.01" y1="2.65" x2="-3.61" y2="3.9" layer="51"/>
@@ -525,7 +525,7 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="5.125" y1="-2.625" x2="-5.125" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="2.625" x2="-5.125" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-8-127P-530W-620L">
+<package name="SOIC-8-127P-530W-620L">
 <description>&lt;b&gt;SOP (1.27mm pitch, 5.30mm width, 6.20mm length, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. Lead pitch 1.27mm, body width 5.3mm, body length 6.2mm, 8 leads. Non-standard.</description>
 <circle x="-2.5550" y="-1.3500" radius="0.3175" width="0" layer="21"/>
@@ -1338,7 +1338,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <gate name="P" symbol="PWRN_V+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1379,7 +1379,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <gate name="A" symbol="OPAMP_PV" x="0" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-BAL" pin="BAL" pad="1"/>
 <connect gate="-BALCOMP" pin="BAL/CMP" pad="8"/>
@@ -1409,7 +1409,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-8-127P-530W-620L">
+<device name="PS" package="SOIC-8-127P-530W-620L">
 <connects>
 <connect gate="-BAL" pin="BAL" pad="1"/>
 <connect gate="-BALCOMP" pin="BAL/CMP" pad="8"/>
@@ -1434,7 +1434,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <gate name="P" symbol="PWR_V+-" x="-15.24" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-NULL" pin="NULL1" pad="1"/>
 <connect gate="-NULL" pin="NULL2" pad="5"/>
@@ -1462,7 +1462,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-8-127P-530W-620L">
+<device name="PS" package="SOIC-8-127P-530W-620L">
 <connects>
 <connect gate="-NULL" pin="NULL1" pad="1"/>
 <connect gate="-NULL" pin="NULL2" pad="5"/>
@@ -1486,7 +1486,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <gate name="P" symbol="PWRN_V+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1531,7 +1531,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-8-127P-530W-620L">
+<device name="PS" package="SOIC-8-127P-530W-620L">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1573,7 +1573,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <gate name="P" symbol="PWRN_V+-" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1594,7 +1594,7 @@ ball pitch 0.5mm, body 2.3 x 1.3mm</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="SOP-14-127P-530W-1030L-210H-125F">
+<device name="NS" package="SOIC-14-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1669,7 +1669,7 @@ Single Supply, External Shutdown</description>
 <gate name="-SHDN" symbol="_SHDN" x="-2.54" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-NULL" pin="NULL1" pad="1"/>
 <connect gate="-NULL" pin="NULL2" pad="5"/>
@@ -1737,7 +1737,7 @@ Single Supply</description>
 <gate name="-NULL" symbol="_OFFNULL2" x="2.54" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-NULL" pin="NULL1" pad="1"/>
 <connect gate="-NULL" pin="NULL2" pad="5"/>
@@ -1801,7 +1801,7 @@ Single Supply</description>
 <gate name="P" symbol="PWRN_VDDGND" x="-17.78" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1898,7 +1898,7 @@ Single Supply</description>
 <gate name="P" symbol="PWRN_VDDGND" x="-15.24" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -1951,7 +1951,7 @@ Single Supply</description>
 <gate name="P" symbol="PWRN_VDDGND" x="-12.7" y="2.54" addlevel="always"/>
 </gates>
 <devices>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2031,7 +2031,7 @@ Single Supply</description>
 <gate name="P" symbol="PWR_V+-" x="-17.78" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2072,7 +2072,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2084,7 +2084,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-8-127P-530W-620L">
+<device name="PS" package="SOIC-8-127P-530W-620L">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2118,7 +2118,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2132,7 +2132,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-8-127P-530W-620L">
+<device name="PS" package="SOIC-8-127P-530W-620L">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2169,7 +2169,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2184,7 +2184,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-8-127P-530W-620L">
+<device name="PS" package="SOIC-8-127P-530W-620L">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2224,7 +2224,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2294,7 +2294,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="M" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2348,7 +2348,7 @@ Single Supply</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2471,7 +2471,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2495,7 +2495,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWRN_V+-" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2522,7 +2522,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWRN_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2553,7 +2553,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWR_VCCVEE" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2607,7 +2607,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <gate name="P" symbol="PWR_VCCVEE" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2676,7 +2676,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2743,7 +2743,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2798,7 +2798,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="N" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2828,7 +2828,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-8-127P-530W-620L">
+<device name="PS" package="SOIC-8-127P-530W-620L">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2867,7 +2867,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2881,7 +2881,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="PS" package="SOP-8-127P-530W-620L">
+<device name="PS" package="SOIC-8-127P-530W-620L">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -2928,7 +2928,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -2949,7 +2949,7 @@ microPower, Single-Supply, CMOS Instrumentation Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="SOP-14-127P-530W-1030L-210H-125F">
+<device name="NS" package="SOIC-14-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3026,7 +3026,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -3047,7 +3047,7 @@ with open collector; LM139/LM239/LM339/LM2901/LM3302&lt;br&gt;</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="NS" package="SOP-14-127P-530W-1030L-210H-125F">
+<device name="NS" package="SOIC-14-127P-530W-1030L-210H-125F">
 <connects>
 <connect gate="A" pin="+IN" pad="5"/>
 <connect gate="A" pin="-IN" pad="4"/>
@@ -3122,7 +3122,7 @@ Single Supply, Rail-to-Rail, 2.2V to 36V</description>
 <gate name="G$1" symbol="INA122" x="0" y="0"/>
 </gates>
 <devices>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -3174,7 +3174,7 @@ Low Voltage Rail-to-Rail</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3224,7 +3224,7 @@ Low Voltage Rail-to-Rail</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3267,7 +3267,7 @@ Low Voltage Rail-to-Rail</description>
 <gate name="D" symbol="OPAMP_NV" x="0" y="-45.72" swaplevel="1"/>
 </gates>
 <devices>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3311,7 +3311,7 @@ Single Operational Amplifier</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -3368,7 +3368,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <gate name="G$2" symbol="OPAMP_PV" x="0" y="0"/>
 </gates>
 <devices>
-<device name="/SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="/SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="REF" pad="5"/>
 <connect gate="G$2" pin="+IN" pad="3"/>
@@ -3455,7 +3455,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="/SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3509,7 +3509,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/SN" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="/SN" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="REF" pad="5"/>
 <connect gate="G$2" pin="+IN" pad="3"/>
@@ -3569,7 +3569,7 @@ High-Output-Drive, Low-Power, Single-Supply, Rail-to-Rail I/O</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="/SN" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="/SN" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3644,7 +3644,7 @@ Precision, Low-Power, High-Voltage</description>
 <gate name="P" symbol="PWR_VCCVEE" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3668,7 +3668,7 @@ Audio Grade, Fully-Differential</description>
 <gate name="G$1" symbol="OPA1632" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="8"/>
 <connect gate="G$1" pin="+OUT" pad="4"/>
@@ -3723,7 +3723,7 @@ Audio Grade, Fully-Differential</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3748,7 +3748,7 @@ Audio Grade, Fully-Differential</description>
 <gate name="P" symbol="PWR_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -3795,7 +3795,7 @@ Audio Grade, Fully-Differential</description>
 <gate name="P" symbol="PWR+-" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -3850,7 +3850,7 @@ Audio Grade, Fully-Differential</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="N" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="N" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -3898,7 +3898,7 @@ Audio Grade, Fully-Differential</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4009,7 +4009,7 @@ JFET, wide bandwidth</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4048,7 +4048,7 @@ JFET, wide bandwidth</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4087,7 +4087,7 @@ JFET, wide bandwidth</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4135,7 +4135,7 @@ JFET, wide bandwidth</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4178,7 +4178,7 @@ Rail-to-Rail, 3 MHz</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4271,7 +4271,7 @@ Output Current Drive and Shutdown Option</description>
 <gate name="P" symbol="PWR_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4322,7 +4322,7 @@ Output Current Drive and Shutdown Option</description>
 <gate name="A" symbol="OPAMP_NV" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4368,7 +4368,7 @@ Output Current Drive and Shutdown Option</description>
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4420,7 +4420,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4443,7 +4443,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <gate name="P" symbol="PWRN_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4486,7 +4486,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <gate name="P" symbol="PWRI_V+-" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4553,7 +4553,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4646,7 +4646,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4704,7 +4704,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <gate name="P" symbol="PWR+G" x="-17.78" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4761,7 +4761,7 @@ Single-Supply, 10MHz, Rail-to-Rail Output, Low-Noise, JFET Amplifier</descriptio
 <gate name="D" symbol="OPAMP_NV" x="0" y="-38.1"/>
 </gates>
 <devices>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4849,7 +4849,7 @@ Single-Supply, Low-Noise, Low-Distortion, Rail-to-Rail Op Amps</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4887,7 +4887,7 @@ Single-Supply, Low-Noise, Low-Distortion, Rail-to-Rail Op Amps</description>
 <gate name="G$1" symbol="OPAMP_PV" x="0" y="0" addlevel="must"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -4939,7 +4939,7 @@ Single-Supply, Low-Noise, Low-Distortion, Rail-to-Rail Op Amps</description>
 <gate name="P" symbol="PWRN_VCC+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -4980,7 +4980,7 @@ High Precision</description>
 <gate name="P" symbol="PWRN_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5036,7 +5036,7 @@ High Precision, Low Noise</description>
 <gate name="P" symbol="PWRI_V+-" x="-20.32" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -5075,7 +5075,7 @@ High Precision, Low Noise</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5136,7 +5136,7 @@ High Precision, Low Noise</description>
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5161,7 +5161,7 @@ High Precision, Low Noise</description>
 <gate name="A" symbol="ICL7650S" x="0" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="CBA" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="CBA" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5198,7 +5198,7 @@ Wideband, Low-Noise, Voltage-Feedback</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5220,7 +5220,7 @@ Wideband, Ultra-Low Noise, Voltage-Feedback with Shutdown</description>
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="3"/>
 <connect gate="G$1" pin="-IN" pad="2"/>
@@ -5256,7 +5256,7 @@ Wideband, Ultra-Low Noise, Voltage-Feedback with Shutdown</description>
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5319,7 +5319,7 @@ Wideband, Ultra-Low Noise, Voltage-Feedback with Shutdown</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5342,7 +5342,7 @@ Precision, Low-Noise, Rail-to-Rail Output,
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5491,7 +5491,7 @@ Dual-Supply</description>
 <gate name="P" symbol="PWR_VDDVSS" x="-20.32" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5582,7 +5582,7 @@ Precision Micropower, Low Noise CMOS, Rail-to-Rail</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="R" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5631,7 +5631,7 @@ Precision Micropower, Low Noise CMOS, Rail-to-Rail</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="R" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="R" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5709,7 +5709,7 @@ Very High Precision, 3V/5V Rail-to-Rail Op Amps</description>
 <gate name="B" symbol="OPAMP" x="0" y="-15.24"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5735,7 +5735,7 @@ Low Voltage Rail-to-Rail</description>
 <gate name="P" symbol="PWRN_V+-" x="-17.78" y="-2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5761,7 +5761,7 @@ Precision Low-Noise, Low Quiescent Current</description>
 <gate name="P" symbol="PWRI_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5865,7 +5865,7 @@ Precision Low-Noise, Low Quiescent Current</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5891,7 +5891,7 @@ Precision Low-Noise, Low Quiescent Current</description>
 <gate name="B" symbol="OPAMP" x="17.78" y="-15.24" swaplevel="1"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5931,7 +5931,7 @@ Precision Low-Noise, Low Quiescent Current</description>
 <gate name="P" symbol="PWR+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5956,7 +5956,7 @@ Precision Low-Noise, Low Quiescent Current</description>
 <gate name="B" symbol="OPAMP" x="0" y="-15.24" swaplevel="1"/>
 </gates>
 <devices>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>
@@ -5981,7 +5981,7 @@ SoundPlus High-Performance, Bipolar-Input Audio Operational Amplifiers</descript
 <gate name="P" symbol="PWRN_V+-" x="-17.78" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="+IN" pad="3"/>
 <connect gate="A" pin="-IN" pad="2"/>

--- a/opto-micro-linear.lbr
+++ b/opto-micro-linear.lbr
@@ -218,9 +218,9 @@ Plastic leaded chip carrier. 1.27mm pitch, 11.51mm body length, 11.51mm body wid
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -259,14 +259,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -362,7 +362,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="NC1" symbol="ML4622" x="0" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="NC1" pin="!CMPENABLE" pad="16"/>
 <connect gate="NC1" pin="!TTLMON" pad="1"/>

--- a/opto-vishay.lbr
+++ b/opto-vishay.lbr
@@ -238,9 +238,9 @@ Vishay Telefunken</description>
 <text x="-2.54" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 <text x="-4.445" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -263,14 +263,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="1206-PT">
 <description>1206 PHOTO-TRANSISTOR</description>
@@ -671,7 +671,7 @@ Vishay Telefunken</description>
 <gate name="B" symbol="OK" x="0" y="-17.78" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="1"/>
 <connect gate="A" pin="C" pad="2"/>

--- a/optocoupler.lbr
+++ b/optocoupler.lbr
@@ -717,9 +717,9 @@ HCPL-181</description>
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -742,14 +742,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="DIL05">
 <description>&lt;b&gt;Dual In Line&lt;/b&gt;</description>
@@ -5498,7 +5498,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="0600" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5519,7 +5519,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="0601" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5560,7 +5560,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="135" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5581,7 +5581,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="4502" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5601,7 +5601,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="4503" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5641,7 +5641,7 @@ Source: http://www.fairchildsemi.com/pf/4N/4N35-M.html</description>
 <gate name="A" symbol="138" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="A" pad="2"/>
 <connect gate="A" pin="C" pad="3"/>
@@ -5950,7 +5950,7 @@ PerkinElmer Optoelectronics</description>
 <gate name="G$1" symbol="0730" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="5"/>
 <connect gate="G$1" pin="V01" pad="7"/>
@@ -5994,7 +5994,7 @@ Fairchild</description>
 <gate name="G$1" symbol="MOCD223-M" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="C1" pad="8"/>
 <connect gate="G$1" pin="C2" pad="6"/>

--- a/philips-6.lbr
+++ b/philips-6.lbr
@@ -576,9 +576,9 @@ Plastic leaded chip carrier. 1.27mm pitch, 24.23mm body length, 24.23mm body wid
 <rectangle x1="-11.7201" y1="-5.4201" x2="-9.9499" y2="-4.9799" layer="51"/>
 <rectangle x1="-11.7201" y1="-6.22" x2="-9.9499" y2="-5.78" layer="51"/>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -951,9 +951,9 @@ Thin profile Quad Flat Package. 0.50mm pitch, 1.0mm lead length 20mm length, 20m
 <wire x1="9.9" y1="-9.9" x2="9.9" y2="9.9" width="0.2032" layer="21"/>
 <wire x1="9.9" y1="9.9" x2="-9.9" y2="9.9" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -976,14 +976,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="TQFP-64-50P-1000W-1000L-120H">
 <description>&lt;b&gt;TQFP (0.50mm pitch, 1.0mm lead length, 10mm length, 10mm width, 1.20mm max height, 64 leads)&lt;/b&gt;&lt;p&gt;
@@ -1941,9 +1941,9 @@ Plastic leaded chip carrier socket. 2.54mm lead pitch, 28 leads.
 <wire x1="8.89" y1="-8.89" x2="8.89" y2="8.89" width="0.2032" layer="21"/>
 <wire x1="8.89" y1="8.89" x2="-7.62" y2="8.89" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -3995,7 +3995,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <gate name="G$1" symbol="OP+-DIF" x="-2.54" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="+IN" pad="2"/>
 <connect gate="G$1" pin="-IN" pad="3"/>
@@ -4035,7 +4035,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <gate name="82C250" symbol="82C250" x="5.08" y="-20.32"/>
 </gates>
 <devices>
-<device name="SMD" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SMD" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="82C250" pin="CANH" pad="7"/>
 <connect gate="82C250" pin="CANL" pad="6"/>
@@ -4072,7 +4072,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <gate name="G$1" symbol="SJA1000" x="2.54" y="5.08"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AD0" pad="23"/>
 <connect gate="G$1" pin="AD1" pad="24"/>
@@ -4114,7 +4114,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <gate name="G$1" symbol="82C150" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AVDD" pad="18"/>
 <connect gate="G$1" pin="AVSS" pad="20"/>
@@ -4158,7 +4158,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <gate name="G$2" symbol="VCCVSS" x="2.54" y="27.94"/>
 </gates>
 <devices>
-<device name="SOT16W" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="SOT16W" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!IOUT!" pad="2"/>
 <connect gate="G$1" pin="B1" pad="5"/>
@@ -4193,7 +4193,7 @@ Vbat 5...27Volt
 <gate name="G$1" symbol="TJA1020" x="-2.54" y="2.54"/>
 </gates>
 <devices>
-<device name="SO8" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SO8" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BAT" pad="7"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -4215,7 +4215,7 @@ Vbat 5...27Volt
 <gate name="TDA5051" symbol="TDA5051" x="-15.24" y="10.16"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="TDA5051" pin="AGND" pad="12"/>
 <connect gate="TDA5051" pin="APGND" pad="9"/>
@@ -4523,7 +4523,7 @@ Vbat 5...27Volt
 <gate name="G$1" symbol="LPC904" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="FD" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="FD" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="AD11/PO.2/CIN2A/KBI2" pad="2"/>
 <connect gate="G$1" pin="P0.4/CIN1A/AD13/DAC1" pad="7"/>
@@ -4715,7 +4715,7 @@ Vbat 5...27Volt
 <gate name="G$1" symbol="PCF8563" x="0" y="0"/>
 </gates>
 <devices>
-<device name="T" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="T" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!INT!" pad="3"/>
 <connect gate="G$1" pin="CLKOUT" pad="7"/>
@@ -4737,7 +4737,7 @@ Vbat 5...27Volt
 <gate name="G$1" symbol="LM75A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="7"/>
 <connect gate="G$1" pin="A1" pad="6"/>

--- a/pot-xicor.lbr
+++ b/pot-xicor.lbr
@@ -94,9 +94,9 @@
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -119,14 +119,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -173,7 +173,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <gate name="1" symbol="X9C10X" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="1" pin="!CS" pad="7"/>
 <connect gate="1" pin="!INC" pad="1"/>

--- a/princeton-tech.lbr
+++ b/princeton-tech.lbr
@@ -106,9 +106,9 @@ USE AT YOUR OWN RISK!&lt;p&gt;
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -191,9 +191,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <text x="-15.875" y="-6.35" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-11.43" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -345,7 +345,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="S" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="3"/>
 <connect gate="G$1" pin="CC0" pad="8"/>
@@ -407,7 +407,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <technology name=""/>
 </technologies>
 </device>
-<device name="-S" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="-S" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="12"/>
 <connect gate="G$1" pin="CC1" pad="18"/>

--- a/ref-packages-soic.lbr
+++ b/ref-packages-soic.lbr
@@ -72,7 +72,7 @@
 </layers>
 <library>
 <packages>
-<package name="SOP-8-127P-530W-620L">
+<package name="SOIC-8-127P-530W-620L">
 <description>&lt;b&gt;SOP (1.27mm pitch, 5.30mm width, 6.20mm length, 8 leads)&lt;/b&gt;&lt;p&gt;
 Small outline package. Lead pitch 1.27mm, body width 5.3mm, body length 6.2mm, 8 leads. Non-standard.</description>
 <circle x="-2.5550" y="-1.3500" radius="0.3175" width="0" layer="21"/>
@@ -105,9 +105,9 @@ Small outline package. Lead pitch 1.27mm, body width 5.3mm, body length 6.2mm, 8
 <wire x1="3.2000" y1="1.9050" x2="-3.2000" y2="1.9050" width="0.2032" layer="21"/>
 <wire x1="3.2000" y1="1.9050" x2="3.2000" y2="2.5500" width="0.2032" layer="51"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -130,18 +130,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -176,18 +176,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -226,20 +226,20 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-14-127P-530W-1030L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-14-127P-530W-1030L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 14 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-4.25" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.01" y1="-3.9" x2="-3.61" y2="-2.65" layer="51"/>
 <rectangle x1="-4.01" y1="2.65" x2="-3.61" y2="3.9" layer="51"/>
@@ -280,11 +280,11 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="5.125" y1="-2.625" x2="-5.125" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="2.625" x2="-5.125" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-530W-1030L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-16-127P-530W-1030L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 10.30mm length, 5.30mm width, 2.10mm max height, 16 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-4.25" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-4.645" y1="-3.9" x2="-4.245" y2="-2.65" layer="51"/>
 <rectangle x1="-4.645" y1="2.65" x2="-4.245" y2="3.9" layer="51"/>
@@ -329,11 +329,11 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="5.125" y1="-2.625" x2="-5.125" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="2.625" x2="-5.125" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-18-127P-530W-1280L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 12.80mm length, 5.30mm width, 2.10mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 12.80mm length, 5.30mm width, 2.10mm max height, 18 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-18-127P-530W-1280L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 12.80mm length, 5.30mm width, 2.10mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 12.80mm length, 5.30mm width, 2.10mm max height, 18 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-5.5" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-5.28" y1="-3.9" x2="-4.88" y2="-2.65" layer="51"/>
 <rectangle x1="-5.28" y1="2.65" x2="-4.88" y2="3.9" layer="51"/>
@@ -382,11 +382,11 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="6.375" y1="-2.625" x2="-6.375" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="2.625" x2="-6.375" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-20-127P-530W-1280L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 12.80mm length, 5.30mm width, 2.10mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 12.80mm length, 5.30mm width, 2.10mm max height, 20 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-20-127P-530W-1280L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 12.80mm length, 5.30mm width, 2.10mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 12.80mm length, 5.30mm width, 2.10mm max height, 20 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-5.5" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-5.915" y1="-3.9" x2="-5.515" y2="-2.65" layer="51"/>
 <rectangle x1="-5.915" y1="2.65" x2="-5.515" y2="3.9" layer="51"/>
@@ -439,11 +439,11 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="6.375" y1="-2.625" x2="-6.375" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="2.625" x2="-6.375" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-22-127P-530W-1540L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 15.40mm length, 5.30mm width, 2.10mm max height, 22 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 15.40mm length, 5.30mm width, 2.10mm max height, 22 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-22-127P-530W-1540L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 15.40mm length, 5.30mm width, 2.10mm max height, 22 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 15.40mm length, 5.30mm width, 2.10mm max height, 22 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-6.8" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-6.55" y1="-3.9" x2="-6.15" y2="-2.65" layer="51"/>
 <rectangle x1="-6.55" y1="2.65" x2="-6.15" y2="3.9" layer="51"/>
@@ -500,11 +500,11 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="7.675" y1="-2.625" x2="-7.675" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="2.625" x2="-7.675" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-24-127P-530W-1540L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 15.40mm length, 5.30mm width, 2.10mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 15.40mm length, 5.30mm width, 2.10mm max height, 24 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-24-127P-530W-1540L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 15.40mm length, 5.30mm width, 2.10mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 15.40mm length, 5.30mm width, 2.10mm max height, 24 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-6.8" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-7.185" y1="-3.9" x2="-6.785" y2="-2.65" layer="51"/>
 <rectangle x1="-7.185" y1="2.65" x2="-6.785" y2="3.9" layer="51"/>
@@ -565,11 +565,11 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="7.675" y1="-2.625" x2="-7.675" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="2.625" x2="-7.675" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-8-127P-530W-530L-210H-125F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package. 1.27mm pitch, 1.25mm lead length 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.&lt;/p&gt;&lt;p&gt;
-EIAJ EDR-7320.&lt;/p&gt;
-</description>
+<package name="SOIC-8-127P-530W-530L-210H-125F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit. 1.27mm pitch, 1.25mm lead length, 5.30mm length, 5.30mm width, 2.10mm max height, 8 leads.
+&lt;/p&gt;
+&lt;p&gt;EIAJ EDR-7320.&lt;/p&gt;</description>
 <circle x="-1.75" y="-1.35" radius="0.3048" width="0" layer="21"/>
 <rectangle x1="-2.105" y1="-3.9" x2="-1.705" y2="-2.65" layer="51"/>
 <rectangle x1="-2.105" y1="2.65" x2="-1.705" y2="3.9" layer="51"/>
@@ -598,9 +598,9 @@ EIAJ EDR-7320.&lt;/p&gt;
 <wire x1="2.625" y1="-2.625" x2="-2.625" y2="-2.625" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="2.625" x2="-2.625" y2="2.625" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -647,9 +647,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-18-127P-750W-1155L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
+<package name="SOIC-18-127P-750W-1155L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.875" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -700,9 +700,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -757,9 +757,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -822,9 +822,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -895,9 +895,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-32-127P-750W-2050L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 20.50mm length, 7.50mm width, 2.65mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 20.50mm length, 7.50mm width, 2.65mm max height, 32 leads.&lt;/p&gt;
+<package name="SOIC-32-127P-750W-2050L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 20.50mm length, 7.50mm width, 2.65mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 20.50mm length, 7.50mm width, 2.65mm max height, 32 leads.&lt;/p&gt;
 
 &lt;p&gt;Non-standard, based on JEDEC MS-013F, B1R-PDSO.Very similar to JEDEC MO-119B, variation AC.&lt;/p&gt;</description>
 <circle x="-9.35" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -976,9 +976,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 20.50mm length
 <wire x1="10.225" y1="-3.725" x2="-10.225" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="10.225" y1="3.725" x2="-10.225" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-36-127P-750W-2300L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 23.00mm length, 7.50mm width, 2.65mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 23.00mm length, 7.50mm width, 2.65mm max height, 36 leads.&lt;/p&gt;
+<package name="SOIC-36-127P-750W-2300L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 23.00mm length, 7.50mm width, 2.65mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 23.00mm length, 7.50mm width, 2.65mm max height, 36 leads.&lt;/p&gt;
 
 &lt;p&gt;Non-standard, based on JEDEC MS-013F, B1R-PDSO.Very similar to JEDEC MO-119B, variation AD.&lt;/p&gt;</description>
 <circle x="-10.6" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1065,9 +1065,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 23.00mm length
 <wire x1="11.475" y1="-3.725" x2="-11.475" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="11.475" y1="3.725" x2="-11.475" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-8-127P-750W-530L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads.&lt;/p&gt;
+<package name="SOIC-8-127P-750W-530L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 5.30mm length, 7.50mm width, 2.65mm max height, 8 leads.&lt;/p&gt;
 
 &lt;p&gt;Non-standard, based on JEDEC MS-013F, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-1.75" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1098,9 +1098,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 5.30mm length,
 <wire x1="2.625" y1="-3.725" x2="-2.625" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="2.625" y1="3.725" x2="-2.625" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-14-127P-750W-900L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads.&lt;/p&gt;
+<package name="SOIC-14-127P-750W-900L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AF, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-3.6" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1143,9 +1143,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length,
 <wire x1="4.475" y1="-3.725" x2="-4.475" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="4.475" y1="3.725" x2="-4.475" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-20-127P-840W-1280L-254H-180F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 12.80mm length, 8.40mm width, 2.54mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body length,
+<package name="SOIC-20-127P-840W-1280L-254H-180F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.8mm lead length, 12.80mm length, 8.40mm width, 2.54mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body length,
 8.40mm body width, 2.54mm max height, 20 leads.
 &lt;/p&gt;
 &lt;p&gt;Non-standard, based on JEDEC MO-059B.&lt;/p&gt;</description>
@@ -1192,14 +1192,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 12.80mm body l
 <smd name="20" x="-5.715" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-6.9" y="-4.2" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="7.4" y="-4.2" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<wire x1="-6.3" y1="-4.1" x2="6.3" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="-6.3" y1="4.1" x2="-6.3" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="6.3" y1="-4.1" x2="6.3" y2="4.1" width="0.2032" layer="21"/>
-<wire x1="6.3" y1="4.1" x2="-6.3" y2="4.1" width="0.2032" layer="21"/>&gt;
+<wire x1="-6.5" y1="-4.1" x2="6.5" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-6.5" y1="4.1" x2="-6.5" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-6.375" y1="-4.175" x2="-6.375" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="-6.375" y1="4.175" x2="6.375" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="6.375" y1="-4.175" x2="-6.375" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="6.375" y1="4.175" x2="6.375" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="6.5" y1="-4.1" x2="6.5" y2="4.1" width="0.2032" layer="21"/>
+<wire x1="6.5" y1="4.1" x2="-6.5" y2="4.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-24-127P-840W-1540L-254H-180F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 15.40mm length, 8.40mm width, 2.54mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body length,
+<package name="SOIC-24-127P-840W-1540L-254H-180F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.8mm lead length, 15.40mm length, 8.40mm width, 2.54mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body length,
 8.40mm body width, 2.54mm max height, 24 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-059B, variation AA.&lt;/p&gt;</description>
@@ -1254,14 +1258,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body l
 <smd name="24" x="-6.985" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-8.2" y="-4.2" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="8.7" y="-4.2" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<wire x1="-7.6" y1="-4.1" x2="7.6" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="-7.6" y1="4.1" x2="-7.6" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="7.6" y1="-4.1" x2="7.6" y2="4.1" width="0.2032" layer="21"/>
-<wire x1="7.6" y1="4.1" x2="-7.6" y2="4.1" width="0.2032" layer="21"/>&gt;
+<wire x1="-7.8" y1="-4.1" x2="7.8" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-7.8" y1="4.1" x2="-7.8" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-7.675" y1="-4.175" x2="-7.675" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="-7.675" y1="4.175" x2="7.675" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="7.675" y1="-4.175" x2="-7.675" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="7.675" y1="4.175" x2="7.675" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="7.8" y1="-4.1" x2="7.8" y2="4.1" width="0.2032" layer="21"/>
+<wire x1="7.8" y1="4.1" x2="-7.8" y2="4.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-24-127P-840W-1540L-305H-180F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 15.40mm length, 8.40mm width, 3.05mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body length,
+<package name="SOIC-24-127P-840W-1540L-305H-180F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.8mm lead length, 15.40mm length, 8.40mm width, 3.05mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body length,
 8.40mm body width, 3.05mm max height, 24 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-059B, variation AB.&lt;/p&gt;</description>
@@ -1316,14 +1324,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 15.40mm body l
 <smd name="24" x="-6.985" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-8.2" y="-4.2" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="8.7" y="-4.2" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<wire x1="-7.6" y1="-4.1" x2="7.6" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="-7.6" y1="4.1" x2="-7.6" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="7.6" y1="-4.1" x2="7.6" y2="4.1" width="0.2032" layer="21"/>
-<wire x1="7.6" y1="4.1" x2="-7.6" y2="4.1" width="0.2032" layer="21"/>&gt;
+<wire x1="-7.8" y1="-4.1" x2="7.8" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-7.8" y1="4.1" x2="-7.8" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-7.675" y1="-4.175" x2="-7.675" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="-7.675" y1="4.175" x2="7.675" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="7.675" y1="-4.175" x2="-7.675" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="7.675" y1="4.175" x2="7.675" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="7.8" y1="-4.1" x2="7.8" y2="4.1" width="0.2032" layer="21"/>
+<wire x1="7.8" y1="4.1" x2="-7.8" y2="4.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-28-127P-840W-1790L-254H-180F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
+<package name="SOIC-28-127P-840W-1790L-254H-180F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 2.54mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
 8.40mm body width, 2.54mm max height, 28 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-059B, variation AC.&lt;/p&gt;</description>
@@ -1386,14 +1398,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body l
 <smd name="28" x="-8.255" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-9.45" y="-4.2" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="9.95" y="-4.2" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<wire x1="-8.85" y1="-4.1" x2="8.85" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="-8.85" y1="4.1" x2="-8.85" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="-4.1" x2="8.85" y2="4.1" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="4.1" x2="-8.85" y2="4.1" width="0.2032" layer="21"/>&gt;
+<wire x1="-9.05" y1="-4.1" x2="9.05" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-9.05" y1="4.1" x2="-9.05" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-8.925" y1="-4.175" x2="-8.925" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="-8.925" y1="4.175" x2="8.925" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="8.925" y1="-4.175" x2="-8.925" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="8.925" y1="4.175" x2="8.925" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="9.05" y1="-4.1" x2="9.05" y2="4.1" width="0.2032" layer="21"/>
+<wire x1="9.05" y1="4.1" x2="-9.05" y2="4.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-28-127P-840W-1790L-305H-180F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 3.05mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
+<package name="SOIC-28-127P-840W-1790L-305H-180F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 3.05mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
 8.40mm body width, 3.05mm max height, 28 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-059B, variation AD.&lt;/p&gt;</description>
@@ -1456,14 +1472,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body l
 <smd name="28" x="-8.255" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-9.45" y="-4.2" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="9.95" y="-4.2" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<wire x1="-8.85" y1="-4.1" x2="8.85" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="-8.85" y1="4.1" x2="-8.85" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="-4.1" x2="8.85" y2="4.1" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="4.1" x2="-8.85" y2="4.1" width="0.2032" layer="21"/>&gt;
+<wire x1="-9.05" y1="-4.1" x2="9.05" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-9.05" y1="4.1" x2="-9.05" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-8.925" y1="-4.175" x2="-8.925" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="-8.925" y1="4.175" x2="8.925" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="8.925" y1="-4.175" x2="-8.925" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="8.925" y1="4.175" x2="8.925" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="9.05" y1="-4.1" x2="9.05" y2="4.1" width="0.2032" layer="21"/>
+<wire x1="9.05" y1="4.1" x2="-9.05" y2="4.1" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-24-127P-890W-1540L-265H-155F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 15.40mm length, 8.90mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 15.40mm body length,
+<package name="SOIC-24-127P-890W-1540L-265H-155F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.55mm lead length, 15.40mm length, 8.90mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 15.40mm body length,
 8.90mm body width, 2.65mm max height, 24 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-120B, variation AA.&lt;/p&gt;</description>
@@ -1518,18 +1538,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 15.40mm body 
 <smd name="24" x="-6.985" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-8.2" y="-4.45" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="8.7" y="-4.45" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-7.8" y1="-4.05" x2="7.8" y2="-4.05" width="0.2032" layer="21"/>
+<wire x1="-7.8" y1="4.05" x2="-7.8" y2="-4.05" width="0.2032" layer="21"/>
 <wire x1="-7.675" y1="4.425" x2="-7.675" y2="-4.425" width="0.0508" layer="51"/>
-<wire x1="-7.6" y1="-4.05" x2="7.6" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="-7.6" y1="4.05" x2="-7.6" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="7.6" y1="-4.05" x2="7.6" y2="4.05" width="0.2032" layer="21"/>
-<wire x1="7.6" y1="4.05" x2="-7.6" y2="4.05" width="0.2032" layer="21"/>
 <wire x1="7.675" y1="-4.425" x2="7.675" y2="4.425" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="-4.425" x2="-7.675" y2="-4.425" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="4.425" x2="-7.675" y2="4.425" width="0.0508" layer="51"/>
+<wire x1="7.8" y1="-4.05" x2="7.8" y2="4.05" width="0.2032" layer="21"/>
+<wire x1="7.8" y1="4.05" x2="-7.8" y2="4.05" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-28-127P-890W-1790L-265H-155F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 17.90mm length, 8.90mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body length,
+<package name="SOIC-28-127P-890W-1790L-265H-155F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.55mm lead length, 17.90mm length, 8.90mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body length,
 8.90mm body width, 2.65mm max height, 28 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-120B, variation AB.&lt;/p&gt;</description>
@@ -1592,18 +1612,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 17.90mm body 
 <smd name="28" x="-8.255" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-9.45" y="-4.45" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="9.95" y="-4.45" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-9.05" y1="-4.05" x2="9.05" y2="-4.05" width="0.2032" layer="21"/>
+<wire x1="-9.05" y1="4.05" x2="-9.05" y2="-4.05" width="0.2032" layer="21"/>
 <wire x1="-8.925" y1="4.425" x2="-8.925" y2="-4.425" width="0.0508" layer="51"/>
-<wire x1="-8.85" y1="-4.05" x2="8.85" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="-8.85" y1="4.05" x2="-8.85" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="-4.05" x2="8.85" y2="4.05" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="4.05" x2="-8.85" y2="4.05" width="0.2032" layer="21"/>
 <wire x1="8.925" y1="-4.425" x2="8.925" y2="4.425" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="-4.425" x2="-8.925" y2="-4.425" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="4.425" x2="-8.925" y2="4.425" width="0.0508" layer="51"/>
+<wire x1="9.05" y1="-4.05" x2="9.05" y2="4.05" width="0.2032" layer="21"/>
+<wire x1="9.05" y1="4.05" x2="-9.05" y2="4.05" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-32-127P-890W-2050L-265H-155F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 20.50mm length, 8.90mm width, 2.65mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body length,
+<package name="SOIC-32-127P-890W-2050L-265H-155F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.55mm lead length, 20.50mm length, 8.90mm width, 2.65mm max height, 32 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body length,
 8.90mm body width, 2.65mm max height, 32 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-120B, variation AC.&lt;/p&gt;</description>
@@ -1674,18 +1694,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 20.50mm body 
 <smd name="32" x="-9.525" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-10.75" y="-4.45" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="11.25" y="-4.45" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-10.35" y1="-4.05" x2="10.35" y2="-4.05" width="0.2032" layer="21"/>
+<wire x1="-10.35" y1="4.05" x2="-10.35" y2="-4.05" width="0.2032" layer="21"/>
 <wire x1="-10.225" y1="4.425" x2="-10.225" y2="-4.425" width="0.0508" layer="51"/>
-<wire x1="-10.15" y1="-4.05" x2="10.15" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="-10.15" y1="4.05" x2="-10.15" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="10.15" y1="-4.05" x2="10.15" y2="4.05" width="0.2032" layer="21"/>
-<wire x1="10.15" y1="4.05" x2="-10.15" y2="4.05" width="0.2032" layer="21"/>
 <wire x1="10.225" y1="-4.425" x2="10.225" y2="4.425" width="0.0508" layer="51"/>
 <wire x1="10.225" y1="-4.425" x2="-10.225" y2="-4.425" width="0.0508" layer="51"/>
 <wire x1="10.225" y1="4.425" x2="-10.225" y2="4.425" width="0.0508" layer="51"/>
+<wire x1="10.35" y1="-4.05" x2="10.35" y2="4.05" width="0.2032" layer="21"/>
+<wire x1="10.35" y1="4.05" x2="-10.35" y2="4.05" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-36-127P-890W-2300L-265H-155F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.55mm lead length, 23.00mm length, 8.90mm width, 2.65mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 23.00mm body length,
+<package name="SOIC-36-127P-890W-2300L-265H-155F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.55mm lead length, 23.00mm length, 8.90mm width, 2.65mm max height, 36 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 23.00mm body length,
 8.90mm body width, 2.65mm max height, 36 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-120B, variation AD.&lt;/p&gt;</description>
@@ -1764,14 +1784,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.55mm lead length, 23.00mm body 
 <smd name="36" x="-10.795" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-12" y="-4.45" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="12.5" y="-4.45" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-11.6" y1="-4.05" x2="11.6" y2="-4.05" width="0.2032" layer="21"/>
+<wire x1="-11.6" y1="4.05" x2="-11.6" y2="-4.05" width="0.2032" layer="21"/>
 <wire x1="-11.475" y1="4.425" x2="-11.475" y2="-4.425" width="0.0508" layer="51"/>
-<wire x1="-11.4" y1="-4.05" x2="11.4" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="-11.4" y1="4.05" x2="-11.4" y2="-4.05" width="0.2032" layer="21"/>
-<wire x1="11.4" y1="-4.05" x2="11.4" y2="4.05" width="0.2032" layer="21"/>
-<wire x1="11.4" y1="4.05" x2="-11.4" y2="4.05" width="0.2032" layer="21"/>
 <wire x1="11.475" y1="-4.425" x2="11.475" y2="4.425" width="0.0508" layer="51"/>
 <wire x1="11.475" y1="-4.425" x2="-11.475" y2="-4.425" width="0.0508" layer="51"/>
 <wire x1="11.475" y1="4.425" x2="-11.475" y2="4.425" width="0.0508" layer="51"/>
+<wire x1="11.6" y1="-4.05" x2="11.6" y2="4.05" width="0.2032" layer="21"/>
+<wire x1="11.6" y1="4.05" x2="-11.6" y2="4.05" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>

--- a/relay.lbr
+++ b/relay.lbr
@@ -6046,7 +6046,7 @@ American Zettler, Inc.</description>
 <rectangle x1="11.43" y1="3.175" x2="12.7" y2="9.525" layer="51"/>
 <rectangle x1="8.255" y1="13.335" x2="9.525" y2="19.685" layer="51" rot="R90"/>
 </package>
-<package name="SOP-4">
+<package name="SOIC-4">
 <description>&lt;b&gt;SOP-4&lt;/b&gt;&lt;p&gt;
 body 3.8 x 4.1 mm&lt;p&gt;
 IXYS Corporation</description>
@@ -11982,7 +11982,7 @@ Single-Pole, Normally Open, 4-Lead SOP</description>
 <gate name="G$1" symbol="PHOTOMOS_2D_NO" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-4">
+<device name="" package="SOIC-4">
 <connects>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="DS1" pad="4"/>

--- a/resistor-bourns.lbr
+++ b/resistor-bourns.lbr
@@ -74,9 +74,9 @@
 <description>&lt;b&gt;Bourns Resistor Networks&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
 <packages>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -99,14 +99,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="2QSP14">
 <description>&lt;b&gt;BOURNS RESISTOR NETWORK&lt;/b&gt;</description>
@@ -321,9 +321,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <rectangle x1="-2.765" y1="2.8361" x2="-2.315" y2="3.8111" layer="51"/>
 <rectangle x1="-4.035" y1="2.8361" x2="-3.585" y2="3.8111" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -362,14 +362,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -1525,7 +1525,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="08R" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="2" pad="2"/>
@@ -1554,7 +1554,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G" symbol="R1NVXX" x="0" y="-17.78" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="1" pad="1"/>
 <connect gate="A" pin="2" pad="8"/>
@@ -1577,7 +1577,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="G$1" symbol="15R" x="0" y="0" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1" pad="1"/>
 <connect gate="G$1" pin="10" pad="10"/>
@@ -1622,7 +1622,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="O" symbol="R1NVXX" x="0" y="-55.88" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1" pad="1"/>
 <connect gate="A" pin="2" pad="16"/>
@@ -1653,7 +1653,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="B" symbol="RX08" x="0" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="B" pin="1" pad="1"/>
 <connect gate="B" pin="10" pad="10"/>
@@ -1691,7 +1691,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="H" symbol="R1NV" x="0" y="-20.32" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="1" pad="1"/>
 <connect gate="A" pin="2" pad="16"/>

--- a/st-microelectronics.lbr
+++ b/st-microelectronics.lbr
@@ -1676,9 +1676,9 @@ Thin shrink small outline transistor package (also known as SOT-353). 0.65mm pit
 <text x="-15.875" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-13.335" y="-0.9525" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -1701,18 +1701,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1767,9 +1767,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1832,9 +1832,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length
 <wire x1="7.675" y1="-3.725" x2="-7.675" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="7.675" y1="3.725" x2="-7.675" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-28-127P-750W-1790L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
+<package name="SOIC-28-127P-750W-1790L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length, 7.50mm width, 2.65mm max height, 28 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AE, B1R-PDSO.Very similar to JEDEC MO-119B, variation AB.&lt;/p&gt;</description>
 <circle x="-8.05" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1905,9 +1905,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 17.90mm length
 <wire x1="8.925" y1="-3.725" x2="-8.925" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="8.925" y1="3.725" x2="-8.925" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-28-127P-840W-1790L-305H-180F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 3.05mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
+<package name="SOIC-28-127P-840W-1790L-305H-180F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.8mm lead length, 17.90mm length, 8.40mm width, 3.05mm max height, 28 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body length,
 8.40mm body width, 3.05mm max height, 28 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MO-059B, variation AD.&lt;/p&gt;</description>
@@ -1970,10 +1970,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.8mm lead length, 17.90mm body l
 <smd name="28" x="-8.255" y="5.5" dx="0.6" dy="2.0" layer="1"/>
 <text x="-9.45" y="-4.2" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="9.95" y="-4.2" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
-<wire x1="-8.85" y1="-4.1" x2="8.85" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="-8.85" y1="4.1" x2="-8.85" y2="-4.1" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="-4.1" x2="8.85" y2="4.1" width="0.2032" layer="21"/>
-<wire x1="8.85" y1="4.1" x2="-8.85" y2="4.1" width="0.2032" layer="21"/>&gt;
+<wire x1="-9.05" y1="-4.1" x2="9.05" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-9.05" y1="4.1" x2="-9.05" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-8.925" y1="-4.175" x2="-8.925" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="-8.925" y1="4.175" x2="8.925" y2="4.175" width="0.0508" layer="51"/>
+<wire x1="8.925" y1="-4.175" x2="-8.925" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="8.925" y1="4.175" x2="8.925" y2="-4.175" width="0.0508" layer="51"/>
+<wire x1="9.05" y1="-4.1" x2="9.05" y2="4.1" width="0.2032" layer="21"/>
+<wire x1="9.05" y1="4.1" x2="-9.05" y2="4.1" width="0.2032" layer="21"/>
 </package>
 <package name="SSOP-8-65P-440W-300L-120H-100F">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 3.0mm length, 4.4mm width, 1.20mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
@@ -3714,7 +3718,7 @@ body 2x2x1mm</description>
 <gate name="-4" symbol="D-2-1" x="10.16" y="-10.16" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-1" pin="K" pad="1"/>
 <connect gate="-2" pin="K" pad="2"/>
@@ -3743,7 +3747,7 @@ body 2x2x1mm</description>
 <gate name="-6" symbol="D-2-1" x="7.62" y="-15.24" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="-1" pin="K" pad="5"/>
 <connect gate="-2" pin="K" pad="4"/>
@@ -4601,7 +4605,7 @@ SPI bus, 1 K x 8</description>
 <gate name="P" symbol="PWRN" x="12.7" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!HOLD" pad="7"/>
 <connect gate="G$1" pin="!S" pad="1"/>
@@ -4650,7 +4654,7 @@ SPI bus, 1 K x 8</description>
 <gate name="B" symbol="STA013PW" x="-2.54" y="-25.4" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="!RESET" pad="26"/>
 <connect gate="A" pin="!SRC_INT" pad="8"/>
@@ -4771,7 +4775,7 @@ with ADPCM capability</description>
 <gate name="B" symbol="STA015PW" x="48.26" y="2.54" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="A" pin="!RESET" pad="26"/>
 <connect gate="A" pin="!TESTEN" pad="24"/>
@@ -4880,7 +4884,7 @@ Satellite receiver</description>
 <gate name="G$1" symbol="STV5730A" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="21"/>
 <connect gate="G$1" pin="AVDD" pad="5"/>
@@ -4947,7 +4951,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="G$1" symbol="L620X" x="0" y="0"/>
 </gates>
 <devices>
-<device name="1" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="1" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CBOOT1" pad="12"/>
 <connect gate="G$1" pin="CBOOT2" pad="19"/>
@@ -5083,7 +5087,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DD" package="SOP-28-127P-750W-1790L-265H-140F">
+<device name="DD" package="SOIC-28-127P-750W-1790L-265H-140F">
 <connects>
 <connect gate="G$1" pin="BOOTSTRAP" pad="15"/>
 <connect gate="G$1" pin="ENABLE1" pad="3"/>
@@ -5306,7 +5310,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="P1" pin="EN_A" pad="20"/>
 <connect gate="P1" pin="EN_B" pad="11"/>
@@ -5372,7 +5376,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="D" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="EN_A" pad="23"/>
 <connect gate="G$1" pin="EN_B" pad="14"/>
@@ -5509,7 +5513,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="G3" symbol="GND" x="5.08" y="-22.86" addlevel="request"/>
 </gates>
 <devices>
-<device name="P" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="P" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="." pin="ALARM" pad="14"/>
 <connect gate="." pin="COMP-IN" pad="12"/>
@@ -5641,7 +5645,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="G$1" symbol="M41ST95W" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-305H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-305H-180F">
 <connects>
 <connect gate="G$1" pin="!E!" pad="27"/>
 <connect gate="G$1" pin="!ECON!" pad="15"/>
@@ -5674,7 +5678,7 @@ http://eu.st.com/stonline/ 3732.pdf and 5691.pdf</description>
 <gate name="G$1" symbol="M41S94" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-28-127P-840W-1790L-305H-180F">
+<device name="" package="SOIC-28-127P-840W-1790L-305H-180F">
 <connects>
 <connect gate="G$1" pin="!E!" pad="27"/>
 <connect gate="G$1" pin="!IRQ!/FT/OUT" pad="26"/>
@@ -5723,7 +5727,7 @@ FOR USB DOWNSTREAM PORTS</description>
 <gate name="G$1" symbol="M25PE20" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!S!" pad="1"/>
 <connect gate="G$1" pin="C" pad="6"/>

--- a/texas.lbr
+++ b/texas.lbr
@@ -827,9 +827,9 @@ Plastic thin shrink small outline package. 0.50mm pitch, 1.0mm lead length 7.8mm
 <wire x1="4" y1="-2" x2="4" y2="2" width="0.2032" layer="21"/>
 <wire x1="4" y1="2" x2="-4" y2="2" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -852,18 +852,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-14-127P-750W-900L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads.&lt;/p&gt;
+<package name="SOIC-14-127P-750W-900L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length, 7.50mm width, 2.65mm max height, 14 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AF, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-3.6" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -906,9 +906,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 9.00mm length,
 <wire x1="4.475" y1="-3.725" x2="-4.475" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="4.475" y1="3.725" x2="-4.475" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -955,9 +955,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length
 <wire x1="5.125" y1="-3.725" x2="-5.125" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.125" y1="3.725" x2="-5.125" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1012,9 +1012,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-18-127P-750W-1155L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
+<package name="SOIC-18-127P-750W-1155L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.875" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1065,9 +1065,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -1106,14 +1106,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SSOP-16-65P-530W">
 <description>&lt;b&gt;SSOP (0.65mm pitch, 5.3mm body, 16 leads)&lt;/b&gt;&lt;p&gt;
@@ -1223,9 +1223,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 7.8mm
 <wire x1="4" y1="-2" x2="4" y2="2" width="0.2032" layer="21"/>
 <wire x1="4" y1="2" x2="-4" y2="2" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-24-127P-750W-1540L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
+<package name="SOIC-24-127P-750W-1540L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 15.40mm length, 7.50mm width, 2.65mm max height, 24 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AD, B1R-PDSO.Very similar to JEDEC MO-119B, variation AA.&lt;/p&gt;</description>
 <circle x="-6.8" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -3428,9 +3428,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <wire x1="2.6" y1="-2" x2="2.6" y2="2" width="0.2032" layer="21"/>
 <wire x1="2.6" y1="2" x2="-2.6" y2="2" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -3465,14 +3465,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SSOP-24-65P-440W-780L-120H-100F-320EW-500EL">
 <description>&lt;b&gt;TSSOP (0.65mm pitch, 1.0mm lead length, 7.8mm length, 4.4mm width, 1.20mm max height, 24 leads)&lt;/b&gt;&lt;p&gt;
@@ -7960,7 +7960,7 @@ Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0m
 <gate name="G$1" symbol="BQ2054" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BAT" pad="3"/>
 <connect gate="G$1" pin="ICOMP" pad="5"/>
@@ -7991,7 +7991,7 @@ Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0m
 <gate name="G$1" symbol="BQ2058" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="B1N" pad="8"/>
 <connect gate="G$1" pin="B1P" pad="9"/>
@@ -8022,7 +8022,7 @@ Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0m
 <gate name="G$1" symbol="BQ2002" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BAT" pad="3"/>
 <connect gate="G$1" pin="CC" pad="8"/>
@@ -8105,7 +8105,7 @@ Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0m
 <gate name="P" symbol="VCCGND" x="30.48" y="-2.54" addlevel="always"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="DW" pin="!EARMUTE" pad="10"/>
 <connect gate="DW" pin="!LINSEL" pad="15"/>
@@ -8285,7 +8285,7 @@ Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0m
 <gate name="G$1" symbol="BQ2000" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!LED" pad="3"/>
 <connect gate="G$1" pin="BAT" pad="4"/>
@@ -8368,7 +8368,7 @@ Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0m
 <gate name="G$1" symbol="UC1526" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!RESET" pad="5"/>
 <connect gate="G$1" pin="!SHDOWN" pad="8"/>
@@ -8405,7 +8405,7 @@ Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0m
 <gate name="NC4" symbol="NC" x="27.94" y="-5.08" addlevel="request"/>
 </gates>
 <devices>
-<device name="" package="SOP-14-127P-750W-900L-265H-140F">
+<device name="" package="SOIC-14-127P-750W-900L-265H-140F">
 <connects>
 <connect gate="G$1" pin="COMP" pad="1"/>
 <connect gate="G$1" pin="GND" pad="9"/>
@@ -8434,7 +8434,7 @@ Micro small outline package. 0.50mm pitch, 0.95mm lead length 3.0mm length, 3.0m
 <gate name="G$1" symbol="UC1843-8" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COMP" pad="1"/>
 <connect gate="G$1" pin="GND" pad="5"/>
@@ -8806,7 +8806,7 @@ www.ti.com; tas3002.pdf</description>
 <gate name="G$1" symbol="TPS5420" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BOOT" pad="1"/>
 <connect gate="G$1" pin="ENA" pad="5"/>
@@ -8848,7 +8848,7 @@ www.ti.com; tas3002.pdf</description>
 <gate name="G$1" symbol="MC33063" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COMP" pad="5"/>
 <connect gate="G$1" pin="DRIVE" pad="8"/>
@@ -8992,7 +8992,7 @@ BUTTERWORTH FOURTH-ORDER LOW-PASS</description>
 <gate name="G$1" symbol="TLC04/MF4A-50" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="6"/>
 <connect gate="G$1" pin="CLKIN" pad="1"/>
@@ -9108,7 +9108,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <gate name="P" symbol="VCC-GND" x="27.94" y="0" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -9131,7 +9131,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="DW" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="C1+" pad="1"/>
 <connect gate="G$1" pin="C1-" pad="3"/>
@@ -9239,7 +9239,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="DW" package="SOP-24-127P-750W-1540L-265H-140F">
+<device name="DW" package="SOIC-24-127P-750W-1540L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!INT" pad="1"/>
 <connect gate="G$1" pin="!RESET" pad="3"/>
@@ -9324,7 +9324,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="RX" pad="2"/>
@@ -9382,7 +9382,7 @@ LOW-POWER, 16-Bit, 26-KSPS MONO CODEC</description>
 <gate name="G$1" symbol="SN65HVD1050" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CANH" pad="7"/>
 <connect gate="G$1" pin="CANL" pad="6"/>
@@ -9406,7 +9406,7 @@ use TLV5626 for internal ref</description>
 <gate name="G$1" symbol="TLV5625" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="3"/>
 <connect gate="G$1" pin="AGND" pad="5"/>
@@ -9429,7 +9429,7 @@ use TLV5626 for internal ref</description>
 <gate name="G$1" symbol="UC2909" x="0" y="0"/>
 </gates>
 <devices>
-<device name="DW" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="DW" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CA-" pad="13"/>
 <connect gate="G$1" pin="CAO" pad="14"/>
@@ -9491,7 +9491,7 @@ use TLV5626 for internal ref</description>
 <gate name="G$1" symbol="TPS2375/77" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CLASS" pad="2"/>
 <connect gate="G$1" pin="DET" pad="3"/>
@@ -10129,7 +10129,7 @@ with I2C Interface</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="2"/>
 <connect gate="G$1" pin="!MUTE!" pad="8"/>
@@ -10934,7 +10934,7 @@ with Battery Management for Energy Harvester Applications</description>
 <gate name="G$1" symbol="TLV5637" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!CS!" pad="3"/>
 <connect gate="G$1" pin="AGND" pad="5"/>
@@ -10976,7 +10976,7 @@ with Battery Management for Energy Harvester Applications</description>
 <gate name="G$1" symbol="LM56" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="OUT1" pad="7"/>
@@ -11179,7 +11179,7 @@ High Performance 24-Bit, 216kHz Sampling</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="/G" pad="12"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -11332,7 +11332,7 @@ Low-Noise, Very Low Drift, Precision</description>
 </technology>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="DNC@1" pad="1"/>
 <connect gate="G$1" pin="DNC@8" pad="8"/>
@@ -11378,7 +11378,7 @@ Low-Noise, Very Low Drift, Precision</description>
 <gate name="G$1" symbol="LM35" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="OUT" pad="1"/>
@@ -11476,7 +11476,7 @@ Low-Noise, Very Low Drift, Precision</description>
 <gate name="G$1" symbol="TPS54233" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="BOOT" pad="1"/>
 <connect gate="G$1" pin="COMP" pad="6"/>
@@ -11856,7 +11856,7 @@ LOW-VOLTAGE WITH ±15-kV IEC ESD PROTECTION</description>
 <gate name="G$1" symbol="AM26LV31E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!G!" pad="12"/>
 <connect gate="G$1" pin="1A" pad="1"/>
@@ -11910,7 +11910,7 @@ LOW-VOLTAGE WITH ±15-kV IEC ESD PROTECTION</description>
 <gate name="G$1" symbol="AM26LV32E" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!G!" pad="12"/>
 <connect gate="G$1" pin="1A" pad="2"/>
@@ -11965,7 +11965,7 @@ SIMPLE SWITCHER Power Converter 150 kHz 0.5A</description>
 <gate name="G$1" symbol="LM2594" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!ON!/OFF" pad="5"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -12088,7 +12088,7 @@ RS-422/485</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="2"/>
 <connect gate="G$1" pin="A" pad="6"/>
@@ -12111,7 +12111,7 @@ RS-422/485</description>
 <gate name="G$1" symbol="SN65HVD232" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CANH" pad="7"/>
 <connect gate="G$1" pin="CANL" pad="6"/>
@@ -12132,7 +12132,7 @@ RS-422/485</description>
 <gate name="G$1" symbol="SN65HVD230" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CANH" pad="7"/>
 <connect gate="G$1" pin="CANL" pad="6"/>
@@ -12177,7 +12177,7 @@ RS-422/485</description>
 <gate name="G$1" symbol="SN65HVD71" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A" pad="8"/>
 <connect gate="G$1" pin="B" pad="7"/>
@@ -12216,7 +12216,7 @@ RS-422/485</description>
 <gate name="G$1" symbol="SN65HVD76" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="3"/>
 <connect gate="G$1" pin="A" pad="12"/>
@@ -12283,7 +12283,7 @@ RS-422/485</description>
 <gate name="G$1" symbol="LM2907" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="-VIN" pad="11"/>
 <connect gate="G$1" pin="C1" pad="2"/>
@@ -12956,7 +12956,7 @@ Ultra Low-Noise, 250-mA Linear Regulator for RF and Analog Circuits</description
 <gate name="G$1" symbol="SN65HVD1473" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!RE!" pad="3"/>
 <connect gate="G$1" pin="A" pad="12"/>
@@ -13078,7 +13078,7 @@ Low-Noise, Very Low Drift, Precision</description>
 <gate name="G$1" symbol="TPS40200" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="COMP" pad="3"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -13133,7 +13133,7 @@ Low-Noise, Very Low Drift, Precision</description>
 <gate name="G$1" symbol="INA219" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="A0" pad="2"/>
 <connect gate="G$1" pin="A1" pad="1"/>
@@ -13265,7 +13265,7 @@ Boost, Flyback, Step-Up, Step-Up/Step-Down DC-DC Controller</description>
 <gate name="G$1" symbol="LM3478" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="AGND" pad="4"/>
 <connect gate="G$1" pin="COMP" pad="2"/>

--- a/that-corp.lbr
+++ b/that-corp.lbr
@@ -335,9 +335,9 @@ wide body 7.5 mm x 15.4 mm, 1MM pitch leads</description>
 <text x="-13.335" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.8425" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -360,18 +360,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -406,18 +406,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-16-127P-750W-1030L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
+<package name="SOIC-16-127P-750W-1030L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 10.30mm length, 7.50mm width, 2.65mm max height, 16 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.25" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -1017,7 +1017,7 @@ Low Noise, High Performance</description>
 <gate name="G$1" symbol="THAT1512" x="-2.54" y="2.54"/>
 </gates>
 <devices>
-<device name="SO8-U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SO8-U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="3"/>
 <connect gate="G$1" pin="IN-" pad="2"/>
@@ -1047,7 +1047,7 @@ Low Noise, High Performance</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="W16-U" package="SOP-16-127P-750W-1030L-265H-140F">
+<device name="W16-U" package="SOIC-16-127P-750W-1030L-265H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="5"/>
 <connect gate="G$1" pin="IN-" pad="4"/>
@@ -1062,7 +1062,7 @@ Low Noise, High Performance</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="S14-U" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="S14-U" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="5"/>
 <connect gate="G$1" pin="IN-" pad="4"/>
@@ -1085,7 +1085,7 @@ Low Noise, High Performance</description>
 <gate name="G$1" symbol="THAT2181" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EC+" pad="2"/>
 <connect gate="G$1" pin="EC-" pad="3"/>
@@ -1334,7 +1334,7 @@ Pre-trimmed Low-voltage Low-power</description>
 <gate name="D" symbol="NPN" x="7.62" y="-20.32"/>
 </gates>
 <devices>
-<device name="S" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="S" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -1383,7 +1383,7 @@ Pre-trimmed Low-voltage Low-power</description>
 <gate name="D" symbol="PNP" x="7.62" y="-20.32"/>
 </gates>
 <devices>
-<device name="S" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="S" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -1433,7 +1433,7 @@ Pre-trimmed Low-voltage Low-power</description>
 <gate name="-SUB" symbol="SUBPINS" x="22.86" y="-17.78" addlevel="request"/>
 </gates>
 <devices>
-<device name="S" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="S" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="-SUB" pin="GND@11" pad="11"/>
 <connect gate="-SUB" pin="GND@4" pad="4"/>
@@ -1484,7 +1484,7 @@ InGenius High-CMRR</description>
 <gate name="G$1" symbol="THAT1200" x="0" y="0"/>
 </gates>
 <devices>
-<device name="S" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="S" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CM_IN" pad="5"/>
 <connect gate="G$1" pin="CM_OUT" pad="8"/>
@@ -1523,7 +1523,7 @@ THAT1240, THAT1243, THAT1246</description>
 <gate name="G$1" symbol="THAT1240" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO8-U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SO8-U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="3"/>
 <connect gate="G$1" pin="IN-" pad="2"/>
@@ -1560,7 +1560,7 @@ THAT1250, THAT1253, THAT1256</description>
 <gate name="G$1" symbol="THAT1250" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO8-U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SO8-U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="IN+" pad="3"/>
 <connect gate="G$1" pin="IN-" pad="2"/>
@@ -1596,7 +1596,7 @@ THAT1250, THAT1253, THAT1256</description>
 <gate name="G$1" symbol="THAT1646" x="0" y="0"/>
 </gates>
 <devices>
-<device name="SO8-U" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SO8-U" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="3"/>
 <connect gate="G$1" pin="IN" pad="4"/>

--- a/transistor-fet.lbr
+++ b/transistor-fet.lbr
@@ -939,9 +939,9 @@ PLD-1.5</description>
 <rectangle x1="-0.6" y1="2.7" x2="0.6" y2="3.2" layer="51"/>
 <rectangle x1="-0.6" y1="-3.2" x2="0.6" y2="-2.7" layer="51"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -964,14 +964,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SC70-6">
 <description>&lt;b&gt;SC70-5 (TSSOT, 0.65mm pitch, 1.25mm body, 6 leads)&lt;/b&gt;&lt;p&gt;
@@ -4276,7 +4276,7 @@ Panasonic SMini3-F2-B</description>
 <gate name="G$1" symbol="IGFET-EN-G4D3S" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="D1" pad="5"/>
 <connect gate="G$1" pin="D2" pad="6"/>
@@ -4583,7 +4583,7 @@ Vgs=12V</description>
 <gate name="G$1" symbol="MFNS-D4S3" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="D1" pad="5"/>
 <connect gate="G$1" pin="D2" pad="6"/>
@@ -5108,7 +5108,7 @@ Monolithic Dual, Ultra Low Noise</description>
 <gate name="B" symbol="JFET-N" x="12.7" y="0"/>
 </gates>
 <devices>
-<device name="SOIC-8" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="SOIC-8" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="2"/>
 <connect gate="A" pin="G" pad="4"/>
@@ -5674,7 +5674,7 @@ Dual N &amp; P Channel Power HEXFET</description>
 <gate name="B" symbol="MFPS-D2" x="0" y="-20.32"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D1" pad="8"/>
 <connect gate="A" pin="D2" pad="7"/>
@@ -6703,7 +6703,7 @@ Logic Level PowerTrench</description>
 <gate name="B" symbol="EMOS_ND2" x="10.16" y="0" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="5"/>
 <connect gate="A" pin="D2" pad="6"/>
@@ -7745,7 +7745,7 @@ MOSFET P-CH 55V 18A DPAK</description>
 <gate name="B" symbol="EMOS-PD" x="20.32" y="0" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="7 8"/>
 <connect gate="A" pin="G" pad="2"/>
@@ -7804,7 +7804,7 @@ Logic Level, PowerTrench</description>
 <gate name="B" symbol="EMOS-PD" x="17.78" y="0" addlevel="always" swaplevel="1"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D" pad="7 8"/>
 <connect gate="A" pin="G" pad="2"/>

--- a/transistor-npn.lbr
+++ b/transistor-npn.lbr
@@ -850,9 +850,9 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -891,14 +891,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="TO78">
 <description>&lt;b&gt;TO-78 (6 leads)&lt;/b&gt;&lt;p&gt;
@@ -945,9 +945,9 @@ JEDEC TO-78.
 <text x="-8.89" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-6.6675" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-14-127P-390W-865L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
+<package name="SOIC-14-127P-390W-865L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 8.65mm length, 3.90mm width, 1.75mm max height, 14 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body length,
 3.90mm body width, 1.75mm max height, 14 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
@@ -982,14 +982,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 8.65mm body l
 <smd name="14" x="-3.81" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-4.825" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.325" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-4.425" y1="-1.45" x2="4.425" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-4.425" y1="1.45" x2="-4.425" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.3" y1="1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.225" y1="-1.45" x2="4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.225" y1="1.45" x2="-4.225" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="-1.45" x2="4.225" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.225" y1="1.45" x2="-4.225" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.3" y1="-1.925" x2="4.3" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="-1.925" x2="-4.3" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.3" y1="1.925" x2="-4.3" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="4.425" y1="-1.45" x2="4.425" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="4.425" y1="1.45" x2="-4.425" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="SC70-3">
 <description>&lt;b&gt;SC70-3 (TSSOT, 0.65mm pitch, 1.25mm body, 3 leads)&lt;/b&gt;&lt;p&gt;
@@ -3595,7 +3595,7 @@ common collector</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="M" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="16"/>
 <connect gate="A" pin="C" pad="15"/>
@@ -3655,7 +3655,7 @@ common emitter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="M" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="16"/>
 <connect gate="A" pin="C" pad="1"/>
@@ -5314,7 +5314,7 @@ complimentary to CMPTA56</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-14-127P-390W-865L-175H-140F">
+<device name="D" package="SOIC-14-127P-390W-865L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="1"/>

--- a/transistor-power.lbr
+++ b/transistor-power.lbr
@@ -1200,9 +1200,9 @@ JEDEC TO-252E, variation AA, R-PSFM-G. Also known as DPAK.
 <wire x1="3.302" y1="-3" x2="3.302" y2="3.2" width="0.2032" layer="21"/>
 <wire x1="3.302" y1="-3" x2="-3.302" y2="-3" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -1225,14 +1225,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="HVMDIP">
 <description>HVM DIP</description>
@@ -2866,7 +2866,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <gate name="B" symbol="PNP2" x="7.62" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="2"/>
 <connect gate="A" pin="C" pad="7"/>

--- a/transistor.lbr
+++ b/transistor.lbr
@@ -1040,9 +1040,9 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-10.795" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-7.62" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -1081,14 +1081,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -3643,7 +3643,7 @@ common collector</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="M" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="16"/>
 <connect gate="A" pin="C" pad="15"/>
@@ -3703,7 +3703,7 @@ common emitter</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="M" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="B" pad="16"/>
 <connect gate="A" pin="C" pad="1"/>

--- a/uln-udn.lbr
+++ b/uln-udn.lbr
@@ -182,9 +182,9 @@ Plastic thin shrink small outline package. 0.65mm pitch, 1.0mm lead length 5.0mm
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -239,9 +239,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-18-127P-750W-1155L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
+<package name="SOIC-18-127P-750W-1155L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.875" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -292,9 +292,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length
 <wire x1="5.75" y1="-3.725" x2="-5.75" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="5.75" y1="3.725" x2="-5.75" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -333,14 +333,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -680,7 +680,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -734,7 +734,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -811,7 +811,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -888,7 +888,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="CD+" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -963,7 +963,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1013,7 +1013,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1063,7 +1063,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1113,7 +1113,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1164,7 +1164,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1216,7 +1216,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1268,7 +1268,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1320,7 +1320,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="GND@1" pad="4"/>
 <connect gate="A" pin="GND@2" pad="5"/>
@@ -1373,7 +1373,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="C1" pad="1"/>
 <connect gate="A" pin="C2" pad="8"/>
@@ -1427,7 +1427,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="C1" pad="1"/>
 <connect gate="A" pin="C2" pad="8"/>
@@ -1481,7 +1481,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="C1" pad="1"/>
 <connect gate="A" pin="C2" pad="8"/>
@@ -1535,7 +1535,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="C1" pad="1"/>
 <connect gate="A" pin="C2" pad="8"/>
@@ -1620,7 +1620,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="1" pin="GND" pad="8"/>
 <connect gate="1" pin="I1" pad="1"/>
@@ -1674,7 +1674,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="D" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="D" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="1" pin="GND" pad="10"/>
 <connect gate="1" pin="I1" pad="1"/>
@@ -1765,7 +1765,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="FW" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="FW" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CD+" pad="10"/>
 <connect gate="G$1" pin="GND" pad="9"/>
@@ -1823,7 +1823,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <technology name=""/>
 </technologies>
 </device>
-<device name="FW" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="FW" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="G$1" pin="CD+" pad="10"/>
 <connect gate="G$1" pin="GND" pad="9"/>
@@ -1936,7 +1936,7 @@ DS2003 National Semiconductor</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="M" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="COM" pad="9"/>
 <connect gate="A" pin="GND" pad="8"/>
@@ -1968,7 +1968,7 @@ Darlington, High Voltage, High Current</description>
 <gate name="G$1" symbol="MC1413" x="0" y="0"/>
 </gates>
 <devices>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="8"/>
 <connect gate="G$1" pin="I1" pad="1"/>
@@ -2000,7 +2000,7 @@ Darlington, High Voltage, High Current</description>
 <gate name="G$1" symbol="SN75468" x="5.08" y="2.54"/>
 </gates>
 <devices>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="G$1" pin="1B" pad="1"/>
 <connect gate="G$1" pin="1C" pad="16"/>

--- a/v-reg.lbr
+++ b/v-reg.lbr
@@ -983,9 +983,9 @@ Small outline transistor (SOT). 2.3mm pitch, 3.5mm body width, 4 leads. JEDEC TO
 <text x="-5.715" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-3.4925" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -1008,14 +1008,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="P2PAK">
 <description>&lt;b&gt;SMD P2PAK&lt;/b&gt;</description>
@@ -3163,7 +3163,7 @@ horizontal, no mount hole.</description>
 <gate name="G$1" symbol="L78XX" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="2 3 6 7"/>
 <connect gate="G$1" pin="IN" pad="8"/>
@@ -3276,7 +3276,7 @@ National Semiconductor</description>
 <gate name="A" symbol="LM2674" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="CB" pad="1"/>
 <connect gate="A" pin="FB" pad="4"/>
@@ -3424,7 +3424,7 @@ Sharp PQ20WZ51 / PQ20WZ11</description>
 <gate name="G$1" symbol="LM2936BM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND@1" pad="2"/>
 <connect gate="G$1" pin="GND@2" pad="3"/>
@@ -3484,7 +3484,7 @@ Texas Instruments</description>
 <gate name="G$1" symbol="LM2671" x="0" y="0"/>
 </gates>
 <devices>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="CB" pad="1"/>
 <connect gate="G$1" pin="FB" pad="4"/>
@@ -3583,7 +3583,7 @@ Texas Instruments</description>
 <gate name="G$1" symbol="78LXXACM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="GND1" pad="3"/>
@@ -3704,7 +3704,7 @@ National Semiconductor</description>
 <gate name="G$1" symbol="78XX" x="0" y="2.54"/>
 </gates>
 <devices>
-<device name="XXS8-5" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="XXS8-5" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="4"/>
 <connect gate="G$1" pin="IN" pad="2"/>
@@ -3864,7 +3864,7 @@ SO-8, fixed voltage</description>
 <gate name="G$1" symbol="LM2931D" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND@2" pad="2"/>
 <connect gate="G$1" pin="GND@3" pad="3"/>
@@ -3888,7 +3888,7 @@ SO-8, adjustable voltage</description>
 <gate name="G$1" symbol="LM2931D-ADJ" x="0" y="-2.54"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="ADJ" pad="4"/>
 <connect gate="G$1" pin="GND@2" pad="2"/>
@@ -3930,7 +3930,7 @@ Burr-Brown</description>
 <gate name="G$1" symbol="TDA3673" x="0" y="0"/>
 </gates>
 <devices>
-<device name="AT" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="AT" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EN" pad="5"/>
 <connect gate="G$1" pin="GND" pad="2"/>
@@ -4231,7 +4231,7 @@ Adjustable</description>
 <gate name="G$1" symbol="MIC5201-X.XYM" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="EN" pad="5"/>
 <connect gate="G$1" pin="GND" pad="3"/>
@@ -4623,7 +4623,7 @@ Adjustable Micropower, 100mA</description>
 <technology name=""/>
 </technologies>
 </device>
-<device name="M" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="M" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="!ERR" pad="5"/>
 <connect gate="G$1" pin="FB" pad="7"/>
@@ -5404,7 +5404,7 @@ Fixed 150mA Low-Noise</description>
 <technology name="AC"/>
 </technologies>
 </device>
-<device name="D13TR" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="D13TR" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="G$1" pin="GND" pad="5"/>
 <connect gate="G$1" pin="IN" pad="2 3 6 7" route="any"/>

--- a/vishay.lbr
+++ b/vishay.lbr
@@ -79,9 +79,9 @@
 USE AT YOUR OWN RISK!&lt;p&gt;
 &lt;author&gt;Copyright (C) 2014, Bob Starr&lt;br&gt; http://www.bobstarr.net&lt;br&gt;&lt;/author&gt;</description>
 <packages>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -120,14 +120,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 <package name="TFBS4711">
 <smd name="1" x="0" y="2.375" dx="1.27" dy="0.64" layer="1"/>
@@ -269,7 +269,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="-PWR" symbol="DG41XL-PWR" x="-2.54" y="27.94" addlevel="request"/>
 </gates>
 <devices>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="-PWR" pin="GND" pad="5"/>
 <connect gate="-PWR" pin="V+" pad="13"/>
@@ -304,7 +304,7 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <gate name="D" symbol="DG41XL-NC-GATE" x="38.1" y="-25.4" swaplevel="1"/>
 </gates>
 <devices>
-<device name="D" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="D" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="-PWR" pin="GND" pad="5"/>
 <connect gate="-PWR" pin="V+" pad="13"/>

--- a/zarlink.lbr
+++ b/zarlink.lbr
@@ -102,9 +102,9 @@
 <text x="-12.065" y="-2.54" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="-9.525" y="-0.635" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
 </package>
-<package name="SOP-18-127P-750W-1155L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
+<package name="SOIC-18-127P-750W-1155L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 11.55mm length, 7.50mm width, 2.65mm max height, 18 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AB, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-4.875" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -274,7 +274,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="S" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="A" pin="EST" pad="16"/>
 <connect gate="A" pin="GS" pad="3"/>
@@ -359,7 +359,7 @@ Shrink small outline package. Lead pitch 0.65mm, body width 5.3mm, 20 leads. JED
 <technology name=""/>
 </technologies>
 </device>
-<device name="S" package="SOP-18-127P-750W-1155L-265H-140F">
+<device name="S" package="SOIC-18-127P-750W-1155L-265H-140F">
 <connects>
 <connect gate="A" pin="EST" pad="16"/>
 <connect gate="A" pin="GS" pad="3"/>

--- a/zetex.lbr
+++ b/zetex.lbr
@@ -404,9 +404,9 @@ Thin shrink small outline transistor package (also known as SOT323). 0.65mm pitc
 <rectangle x1="0.9" y1="-0.2" x2="1.35" y2="0.2" layer="51"/>
 <rectangle x1="-0.45" y1="-0.575" x2="-0.075" y2="0.575" layer="21"/>
 </package>
-<package name="SOP-8-127P-390W-490L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
+<package name="SOIC-8-127P-390W-490L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 4.90mm length, 3.90mm width, 1.75mm max height, 8 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body length,
 3.90mm body width, 1.75mm max height, 8 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AA, B1R-PDSO.&lt;/p&gt;</description>
@@ -429,18 +429,18 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 4.90mm body l
 <smd name="8" x="-1.905" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-2.95" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="3.45" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-2.55" y1="-1.45" x2="2.55" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-2.55" y1="1.45" x2="-2.55" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-2.425" y1="1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-2.35" y1="-1.45" x2="2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-2.35" y1="1.45" x2="-2.35" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="-1.45" x2="2.35" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="2.35" y1="1.45" x2="-2.35" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="2.425" y1="-1.925" x2="2.425" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="-1.925" x2="-2.425" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="2.425" y1="1.925" x2="-2.425" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="2.55" y1="-1.45" x2="2.55" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="2.55" y1="1.45" x2="-2.55" y2="1.45" width="0.2032" layer="21"/>
 </package>
-<package name="SOP-20-127P-750W-1280L-265H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
+<package name="SOIC-20-127P-750W-1280L-265H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length, 7.50mm width, 2.65mm max height, 20 leads.&lt;/p&gt;
 
 &lt;p&gt;JEDEC MS-013F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
 <circle x="-5.5" y="-2.45" radius="0.3048" width="0" layer="21"/>
@@ -495,9 +495,9 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.4mm lead length, 12.80mm length
 <wire x1="6.375" y1="-3.725" x2="-6.375" y2="-3.725" width="0.0508" layer="51"/>
 <wire x1="6.375" y1="3.725" x2="-6.375" y2="3.725" width="0.0508" layer="51"/>
 </package>
-<package name="SOP-16-127P-390W-990L-175H-140F">
-<description>&lt;b&gt;SOP (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
-Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
+<package name="SOIC-16-127P-390W-990L-175H-140F">
+<description>&lt;b&gt;SOIC (1.27mm pitch, 1.05mm lead length, 9.90mm length, 3.90mm width, 1.75mm max height, 16 leads)&lt;/b&gt;&lt;p&gt;
+Small outline integrated circuit, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body length,
 3.90mm body width, 1.75mm max height, 16 leads.
 &lt;/p&gt;
 &lt;p&gt;JEDEC MS-012F, variation AC, B1R-PDSO.&lt;/p&gt;</description>
@@ -536,14 +536,14 @@ Small outline package, SO, SOIC. 1.27mm pitch, 1.05mm lead length, 9.90mm body l
 <smd name="16" x="-4.445" y="2.85" dx="0.6" dy="2.0" layer="1"/>
 <text x="-5.45" y="-1.95" size="1.016" layer="25" ratio="18" rot="R90">&gt;NAME</text>
 <text x="5.95" y="-1.95" size="0.8128" layer="27" ratio="10" rot="R90">&gt;VALUE</text>
+<wire x1="-5.05" y1="-1.45" x2="5.05" y2="-1.45" width="0.2032" layer="21"/>
+<wire x1="-5.05" y1="1.45" x2="-5.05" y2="-1.45" width="0.2032" layer="21"/>
 <wire x1="-4.925" y1="1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
-<wire x1="-4.85" y1="-1.45" x2="4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="-4.85" y1="1.45" x2="-4.85" y2="-1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="-1.45" x2="4.85" y2="1.45" width="0.2032" layer="21"/>
-<wire x1="4.85" y1="1.45" x2="-4.85" y2="1.45" width="0.2032" layer="21"/>
 <wire x1="4.925" y1="-1.925" x2="4.925" y2="1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="-1.925" x2="-4.925" y2="-1.925" width="0.0508" layer="51"/>
 <wire x1="4.925" y1="1.925" x2="-4.925" y2="1.925" width="0.0508" layer="51"/>
+<wire x1="5.05" y1="-1.45" x2="5.05" y2="1.45" width="0.2032" layer="21"/>
+<wire x1="5.05" y1="1.45" x2="-5.05" y2="1.45" width="0.2032" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -2976,7 +2976,7 @@ source ZXMD63C02.pdf from http://www.zetex.com/</description>
 <gate name="A" symbol="SDA12" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-8-127P-390W-490L-175H-140F">
+<device name="" package="SOIC-8-127P-390W-490L-175H-140F">
 <connects>
 <connect gate="A" pin="D01" pad="2"/>
 <connect gate="A" pin="D02" pad="3"/>
@@ -2999,7 +2999,7 @@ source ZXMD63C02.pdf from http://www.zetex.com/</description>
 <gate name="A" symbol="SDA24" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-16-127P-390W-990L-175H-140F">
+<device name="" package="SOIC-16-127P-390W-990L-175H-140F">
 <connects>
 <connect gate="A" pin="D01" pad="2"/>
 <connect gate="A" pin="D02" pad="3"/>
@@ -3030,7 +3030,7 @@ source ZXMD63C02.pdf from http://www.zetex.com/</description>
 <gate name="A" symbol="SDA32" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="SOP-20-127P-750W-1280L-265H-140F">
+<device name="" package="SOIC-20-127P-750W-1280L-265H-140F">
 <connects>
 <connect gate="A" pin="D01" pad="2"/>
 <connect gate="A" pin="D02" pad="3"/>


### PR DESCRIPTION
- Renamed SOP packages to SOIC
- Slightly enlarged the silk screen markings under the chips to be just outside the chip body instead of completely under it. The same approach is used in all other packages.